### PR TITLE
feat: Notion → BE data migration (status, matching, appreciation, comments)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "test:coverage": "yarn test --coverage",
     "test:ui": "yarn test --ui",
     "prepare": "husky",
-    "what": "./get-json-field-value.sh package.json"
+    "what": "./get-json-field-value.sh package.json",
+    "migrate:notion": "ts-node -r tsconfig-paths/register src/data/seeds/migrate-notion.ts"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/csv-to-json.py
+++ b/scripts/csv-to-json.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Convert Notion volunteer CSV export to JSON for the BE migration script.
+
+Usage:
+  python3 scripts/csv-to-json.py <csv_file> <output_json>
+
+Example:
+  python3 scripts/csv-to-json.py "volunteers.csv" volunteers-migration.json
+"""
+
+import csv
+import json
+import sys
+
+# Column indices (from header row — top row in the revised Notion export)
+COL = {
+    "email": 0,
+    "appreciation": 9,
+    "cgc": 10,
+    "volunteer_comments": 11,
+    "coordinator_comments": 13,
+    "status": 16,
+    "notion_id": 20,
+    "matching_status": 23,
+    "name": 25,
+    "active_opp_ids": 41,      # VO active ID   — comma-separated VOL-xxx
+    "contacted_opp_ids": 43,   # VO contacted ID — comma-separated VOL-xxx
+    "matched_opp_ids": 45,     # VO matched ID   — comma-separated VOL-xxx
+}
+
+
+def get_col(row: list[str], key: str) -> str:
+    idx = COL[key]
+    return row[idx].strip() if len(row) > idx else ""
+
+
+def split_ids(raw: str) -> list[str]:
+    """Split a comma-separated VOL-xxx string into a clean list."""
+    return [v.strip() for v in raw.split(",") if v.strip().startswith("VOL-")]
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python3 csv-to-json.py <csv_file> <output_json>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+
+    with open(input_file, "r", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    # Detect header position: if row 0 col[20] is a label it's at the top,
+    # otherwise (legacy Notion export) the header is the last row.
+    if rows and rows[0][COL["notion_id"]].strip() not in ("", ) and \
+            not rows[0][COL["notion_id"]].strip().startswith("VOLVO-"):
+        data_rows = rows[1:]   # header at top
+    else:
+        data_rows = rows[:-1]  # header at bottom (legacy)
+
+    volunteers = []
+    skipped = 0
+
+    for row in data_rows:
+        notion_id = get_col(row, "notion_id")
+        if not notion_id or not notion_id.startswith("VOLVO-"):
+            skipped += 1
+            continue
+
+        volunteers.append(
+            {
+                "notionId": notion_id,
+                "status": get_col(row, "status"),
+                "appreciation": get_col(row, "appreciation"),
+                "cgc": get_col(row, "cgc"),
+                "coordinatorComments": get_col(row, "coordinator_comments"),
+                "volunteerComments": get_col(row, "volunteer_comments"),
+                "activeOpportunityIds": split_ids(get_col(row, "active_opp_ids")),
+                "contactedOpportunityIds": split_ids(get_col(row, "contacted_opp_ids")),
+                "matchedOpportunityIds": split_ids(get_col(row, "matched_opp_ids")),
+            }
+        )
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(volunteers, f, ensure_ascii=False, indent=2)
+
+    print(f"Done: {len(volunteers)} volunteers written to {output_file}")
+    if skipped:
+        print(f"Skipped {skipped} rows without a valid VOLVO-xxx ID")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/entity/volunteer/volunteer.entity.ts
+++ b/src/data/entity/volunteer/volunteer.entity.ts
@@ -40,6 +40,11 @@ export default class Volunteer {
   @Column({ nullable: true })
   @IsOptional()
   @IsString()
+  notionId: string;
+
+  @Column({ nullable: true })
+  @IsOptional()
+  @IsString()
   infoAbout: string;
 
   @Column({ nullable: true })

--- a/src/data/migrations/1776335627281-add-volunteer-notion-id.ts
+++ b/src/data/migrations/1776335627281-add-volunteer-notion-id.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddVolunteerNotionId1776335627281 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE volunteer ADD COLUMN IF NOT EXISTS notion_id VARCHAR(50)`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_volunteer_notion_id ON volunteer (notion_id)`,
+    );
+
+    // Partial backfill: volunteers that have at least one opportunity link in
+    // notion_relation can be resolved immediately without any external call.
+    // Volunteers with no opportunity links are backfilled by the
+    // migrate-notion script, which uses the seed JSON (nid + email).
+    await queryRunner.query(`
+      UPDATE volunteer v
+      SET notion_id = sub.tenant_nid
+      FROM (
+        SELECT DISTINCT ON (ov.volunteer_id)
+          ov.volunteer_id,
+          nr.tenant_nid
+        FROM notion_relation nr
+        JOIN opportunity_volunteer ov ON ov.opportunity_id = nr.host_id
+        WHERE nr.tenant_type = 'volunteer'
+          AND nr.host_type = 'opportunity'
+        ORDER BY ov.volunteer_id
+      ) sub
+      WHERE v.id = sub.volunteer_id
+        AND v.notion_id IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_volunteer_notion_id`);
+    await queryRunner.query(
+      `ALTER TABLE volunteer DROP COLUMN IF EXISTS notion_id`,
+    );
+  }
+}

--- a/src/data/seeds/migrate-notion.ts
+++ b/src/data/seeds/migrate-notion.ts
@@ -1,0 +1,358 @@
+/**
+ * Notion → BE data migration script.
+ *
+ * Migrates four fields for every volunteer found in a Notion CSV export:
+ *   1. Engagement status  (Active, Available, Inactive, Unresponsive, …)
+ *   2. Opportunity matching  (PENDING → MATCHED / ACTIVE on OpportunityVolunteer)
+ *   3. Appreciation records  (T-shirt, Certificate, …)
+ *   4. Comments  (coordinator notes + volunteer personal notes)
+ *
+ * The script is idempotent — safe to run multiple times and for different
+ * engagement-status slices (active, inactive, unresponsive, etc.).
+ *
+ * Usage:
+ *   1. Convert the Notion CSV:
+ *        python3 scripts/csv-to-json.py <notion-export.csv> migration.json
+ *   2. Run this script:
+ *        yarn migrate:notion migration.json
+ */
+
+import * as fs from "fs";
+import "reflect-metadata";
+import {
+  EntityTableName,
+  OpportunityVolunteerStatusType,
+  VolunteerStateAppreciationType,
+  VolunteerStateEngagementType,
+} from "need4deed-sdk";
+import { DataSource } from "typeorm";
+import { seedVolunteersFile } from "../../config/constants";
+import logger from "../../logger";
+import { tryCatch } from "../../services/utils";
+import { dataSource } from "../data-source";
+import Comment from "../entity/comment.entity";
+import OpportunityVolunteer from "../entity/m2m/opportunity-volunteer";
+import NotionRelation from "../entity/notion-relation.entity";
+import Person from "../entity/person.entity";
+import Language from "../entity/profile/language.entity";
+import User from "../entity/user.entity";
+import Appreciation from "../entity/volunteer/appreciation.entity";
+import Volunteer from "../entity/volunteer/volunteer.entity";
+import { fetchJsonFromUrl, getRepository } from "../utils";
+import { updateVolunteerMatching } from "../utils/update-volunteer-matching";
+import { VolunteerJSON } from "./types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface MigrationEntry {
+  notionId: string;
+  status: string;
+  appreciation: string;
+  cgc: string;
+  coordinatorComments: string;
+  volunteerComments: string;
+  activeOpportunityIds: string[];
+  contactedOpportunityIds: string[];
+  matchedOpportunityIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Status mapping — covers all Notion engagement status values
+// ---------------------------------------------------------------------------
+
+const ENGAGEMENT_MAP: Record<string, VolunteerStateEngagementType> = {
+  Active: VolunteerStateEngagementType.ACTIVE,
+  Available: VolunteerStateEngagementType.AVAILABLE,
+  Inactive: VolunteerStateEngagementType.INACTIVE,
+  New: VolunteerStateEngagementType.NEW,
+  "Temp Unavailable": VolunteerStateEngagementType.TEMP_UNAVAILABLE,
+  Unresponsive: VolunteerStateEngagementType.UNRESPONSIVE,
+};
+
+// ---------------------------------------------------------------------------
+// Appreciation mapping
+// ---------------------------------------------------------------------------
+
+function parseAppreciation(
+  raw: string,
+): { title: VolunteerStateAppreciationType; delivered: boolean }[] {
+  const result: { title: VolunteerStateAppreciationType; delivered: boolean }[] =
+    [];
+  for (const part of raw.split(",").map((p) => p.trim())) {
+    if (part === "T-shirt") {
+      result.push({
+        title: VolunteerStateAppreciationType.T_SHIRT,
+        delivered: true,
+      });
+    } else if (part === "T-shirt offered") {
+      result.push({
+        title: VolunteerStateAppreciationType.T_SHIRT,
+        delivered: false,
+      });
+    } else if (part === "Certificate") {
+      result.push({
+        title: VolunteerStateAppreciationType.BENEFIT_CARD,
+        delivered: true,
+      });
+    }
+    // MTV Video, EA - Recommended, FWP - Recommended: no enum equivalent, skip
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — backfill notionId for volunteers not covered by the schema migration
+// ---------------------------------------------------------------------------
+
+async function backfillNotionIds(ds: DataSource): Promise<number> {
+  const volunteersJson = (await fetchJsonFromUrl(
+    seedVolunteersFile,
+  )) as VolunteerJSON[];
+
+  const personRepo = getRepository(ds, Person);
+  const volunteerRepo = getRepository(ds, Volunteer);
+  let count = 0;
+
+  for (const v of volunteersJson ?? []) {
+    if (!v.nid || !v.person?.email) continue;
+
+    const person = await personRepo.findOne({
+      where: { email: v.person.email },
+    });
+    if (!person) continue;
+
+    const volunteer = await volunteerRepo.findOne({
+      where: { personId: person.id },
+    });
+    if (!volunteer || volunteer.notionId) continue;
+
+    volunteer.notionId = v.nid;
+    await volunteerRepo.save(volunteer);
+    count++;
+  }
+
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — process each CSV entry
+// ---------------------------------------------------------------------------
+
+async function procesEntries(
+  ds: DataSource,
+  entries: MigrationEntry[],
+): Promise<void> {
+  const volunteerRepo = getRepository(ds, Volunteer);
+  const commentRepo = getRepository(ds, Comment);
+  const appreciationRepo = getRepository(ds, Appreciation);
+  const oppVolRepo = getRepository(ds, OpportunityVolunteer);
+  const notionRelRepo = getRepository(ds, NotionRelation);
+  const userRepo = getRepository(ds, User);
+  const langRepo = getRepository(ds, Language);
+
+  // Use admin user as author for migrated comments / appreciation records
+  const systemUser = await userRepo.findOne({
+    where: { email: "john.doe@need4deed.org" },
+  });
+  const englishLang = await langRepo.findOne({ where: { title: "English" } });
+
+  let updated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const entry of entries) {
+    const [, err] = await tryCatch(processOne(entry));
+    if (err) {
+      logger.error(
+        `Error processing ${entry.notionId}: ${(err as Error).message}`,
+      );
+      errors++;
+    }
+  }
+
+  logger.info(
+    `Migration complete — updated: ${updated}, skipped: ${skipped}, errors: ${errors}`,
+  );
+
+  // -------------------------------------------------------------------------
+  async function processOne(entry: MigrationEntry): Promise<void> {
+    if (!entry.notionId) {
+      skipped++;
+      return;
+    }
+
+    const volunteer = await volunteerRepo.findOne({
+      where: { notionId: entry.notionId },
+    });
+    if (!volunteer) {
+      logger.warn(`Volunteer not found: ${entry.notionId} — skipping`);
+      skipped++;
+      return;
+    }
+
+    // 1. Engagement status — always write the CSV value so re-runs stay fresh
+    const engStatus = ENGAGEMENT_MAP[entry.status];
+    if (engStatus) {
+      volunteer.statusEngagement = engStatus;
+      await volunteerRepo.save(volunteer);
+    }
+
+    // 2. Coordinator comments (idempotent — skip if text already exists)
+    if (entry.coordinatorComments) {
+      const exists = await commentRepo.findOne({
+        where: {
+          entityType: EntityTableName.VOLUNTEER,
+          entityId: volunteer.id,
+          text: entry.coordinatorComments,
+        },
+      });
+      if (!exists) {
+        await commentRepo.save(
+          new Comment({
+            text: entry.coordinatorComments,
+            entityType: EntityTableName.VOLUNTEER,
+            entityId: volunteer.id,
+            userId: systemUser?.id,
+            languageId: englishLang?.id,
+          }),
+        );
+      }
+    }
+
+    // 3. Volunteer personal comments (idempotent)
+    if (entry.volunteerComments) {
+      const exists = await commentRepo.findOne({
+        where: {
+          entityType: EntityTableName.VOLUNTEER,
+          entityId: volunteer.id,
+          text: entry.volunteerComments,
+        },
+      });
+      if (!exists) {
+        await commentRepo.save(
+          new Comment({
+            text: entry.volunteerComments,
+            entityType: EntityTableName.VOLUNTEER,
+            entityId: volunteer.id,
+            userId: systemUser?.id,
+            languageId: englishLang?.id,
+          }),
+        );
+      }
+    }
+
+    // 4. Appreciation records (idempotent — one record per title per volunteer)
+    for (const { title, delivered } of parseAppreciation(entry.appreciation)) {
+      const exists = await appreciationRepo.findOne({
+        where: { volunteerId: volunteer.id, title },
+      });
+      if (!exists) {
+        await appreciationRepo.save(
+          new Appreciation({
+            title,
+            volunteerId: volunteer.id,
+            userId: systemUser?.id,
+            dateDelivery: delivered ? new Date() : null,
+          }),
+        );
+      }
+    }
+
+    // 5. OpportunityVolunteer statuses
+    //    Notion "active" opportunities  → ACTIVE  (only upgrade from PENDING)
+    //    Notion "matched" opportunities → MATCHED (only upgrade from PENDING)
+    //    volunteer.statusMatch is then recomputed automatically by
+    //    updateVolunteerMatching, keeping it opportunity-driven as the BE expects.
+
+    let oppStatusChanged = false;
+
+    for (const oppNid of entry.activeOpportunityIds) {
+      if (await upgradeOppVolStatus(oppNid, volunteer.id, OpportunityVolunteerStatusType.ACTIVE)) {
+        oppStatusChanged = true;
+      }
+    }
+
+    for (const oppNid of entry.matchedOpportunityIds) {
+      if (await upgradeOppVolStatus(oppNid, volunteer.id, OpportunityVolunteerStatusType.MATCHED)) {
+        oppStatusChanged = true;
+      }
+    }
+
+    if (oppStatusChanged) {
+      await updateVolunteerMatching(volunteer.id);
+    }
+
+    updated++;
+  }
+
+  // -------------------------------------------------------------------------
+  // Helper: look up the opportunity by its Notion ID, then upgrade the
+  // OpportunityVolunteer row only if it is currently PENDING.
+  // Returns true when a change was made.
+  // -------------------------------------------------------------------------
+  async function upgradeOppVolStatus(
+    oppNotionId: string,
+    volunteerId: number,
+    targetStatus: OpportunityVolunteerStatusType,
+  ): Promise<boolean> {
+    const notionRel = await notionRelRepo.findOne({
+      where: {
+        hostNid: oppNotionId,
+        hostType: EntityTableName.OPPORTUNITY,
+      },
+    });
+    if (!notionRel) return false;
+
+    const ov = await oppVolRepo.findOne({
+      where: { volunteerId, opportunityId: notionRel.hostId },
+    });
+    if (!ov || ov.status !== OpportunityVolunteerStatusType.PENDING) return false;
+
+    ov.status = targetStatus;
+    await oppVolRepo.save(ov);
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const jsonPath = process.argv[2];
+  if (!jsonPath) {
+    console.error(
+      "Usage: yarn migrate:notion <path-to-migration-json>\n" +
+        "  Generate the JSON first with: python3 scripts/csv-to-json.py <csv> <json>",
+    );
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(jsonPath)) {
+    console.error(`File not found: ${jsonPath}`);
+    process.exit(1);
+  }
+
+  await dataSource.initialize();
+
+  // Step 1: ensure every volunteer has a notionId
+  logger.info("Step 1: backfilling notionId from seed JSON…");
+  const backfilled = await backfillNotionIds(dataSource);
+  logger.info(`  → ${backfilled} volunteer(s) backfilled`);
+
+  // Step 2: apply CSV data
+  const entries: MigrationEntry[] = JSON.parse(
+    fs.readFileSync(jsonPath, "utf-8"),
+  );
+  logger.info(`Step 2: processing ${entries.length} entries from ${jsonPath}…`);
+  await procesEntries(dataSource, entries);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  logger.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/src/data/seeds/volunteer.seed.ts
+++ b/src/data/seeds/volunteer.seed.ts
@@ -45,6 +45,7 @@ export async function seedVolunteers(dataSource: DataSource): Promise<void> {
         statusVaccination: getDocumentStatus(volunteer.statusVaccination),
         infoAbout: volunteer.infoAbout || "",
         infoExperience: volunteer.infoExperience || "",
+        notionId: volunteer.nid || null,
         createdAt: new Date(volunteer.timestamp),
         updatedAt: new Date(volunteer.timestamp),
         person,


### PR DESCRIPTION
## Overview

Closes #375 #376 #377 #378 (sub-tasks of #379 database migration from Notion)

## What this PR does

### Schema
- Adds `notion_id` (VARCHAR 50, nullable, indexed) to the `volunteer` table
- Partial backfill in the migration: volunteers with any opportunity link in `notion_relation` are resolved immediately via a JOIN
- Full backfill is completed by the migration script (uses the seed JSON from S3)

### Files changed
| File | Change |
|------|--------|
| `src/data/migrations/1776335627281-add-volunteer-notion-id.ts` | New TypeORM migration — adds column + partial backfill |
| `src/data/entity/volunteer/volunteer.entity.ts` | Add `notionId` field |
| `src/data/seeds/volunteer.seed.ts` | Persist `volunteer.nid` as `notionId` on seed |
| `src/data/seeds/migrate-notion.ts` | New — reusable data migration runner |
| `scripts/csv-to-json.py` | New — convert any Notion volunteer CSV → JSON |

## How to run

```bash
# 1. Export any volunteer slice from Notion as CSV (active, inactive, unresponsive…)
# 2. Convert to JSON
python3 scripts/csv-to-json.py notion-export.csv migration.json

# 3. Run — fully idempotent, safe to re-run
yarn migrate:notion migration.json
```

## What the script does per volunteer

1. **Backfills `notionId`** — fetches `volunteers.json` from S3, maps `nid → email → DB volunteer` so every volunteer is resolvable by VOLVO-xxx
2. **Engagement status** — always overwrites with the Notion value (`Active → active`, `Inactive → inactive`, `Unresponsive → unresponsive`, …)
3. **Comments** — inserts coordinator notes + volunteer personal notes; skips if exact text already exists
4. **Appreciation** — creates T-shirt / Certificate records; skips if title already exists for that volunteer
5. **Opportunity matching** — upgrades `PENDING → MATCHED` or `PENDING → ACTIVE` on `OpportunityVolunteer` based on Notion columns, then calls `updateVolunteerMatching` so `volunteer.statusMatch` is always opportunity-driven, never set directly

## Idempotency
- Re-running produces the same result
- Comments: deduped on exact text
- Appreciation: deduped on `(volunteerId, title)`
- Opportunity status: only upgrades from PENDING — never downgrades an already-MATCHED record

🤖 Generated with [Claude Code](https://claude.ai/claude-code)