### PR TITLE
migrate legacy single-part district names to 12 official compound Berlin districts

### DIFF
--- a/src/data/entity/m2m/opportunity-volunteer.ts
+++ b/src/data/entity/m2m/opportunity-volunteer.ts
@@ -1,6 +1,7 @@
 import { IsEnum } from "class-validator";
 import { OpportunityVolunteerStatusType } from "need4deed-sdk";
 import {
+  AfterInsert,
   AfterUpdate,
   Column,
   CreateDateColumn,
@@ -59,9 +60,17 @@ export default class OpportunityVolunteer {
   @Column()
   volunteerId: number;
 
+  @AfterInsert()
+  async afterInsertHook() {
+    const { updateOpportunityMatching, updateVolunteerMatching } = await import("../../utils");
+    updateOpportunityMatching(this.opportunityId);
+    updateVolunteerMatching(this.volunteerId);
+  }
+
   @AfterUpdate()
   async afterUpdateHook() {
-    const { updateVolunteerMatching } = await import("../../utils");
+    const { updateOpportunityMatching, updateVolunteerMatching } = await import("../../utils");
+    updateOpportunityMatching(this.opportunityId);
     updateVolunteerMatching(this.volunteerId);
   }
 }

--- a/src/data/entity/opportunity/opportunity.entity.ts
+++ b/src/data/entity/opportunity/opportunity.entity.ts
@@ -1,5 +1,6 @@
 import { IsEnum, IsInt, IsOptional, IsString } from "class-validator";
 import {
+  OpportunityMatchStatusType,
   OpportunityStatusType,
   OpportunityType,
   TranslatedIntoType,
@@ -50,6 +51,14 @@ export default class Opportunity {
   })
   @IsEnum(OpportunityStatusType)
   status: OpportunityStatusType;
+
+  @Column({
+    type: "enum",
+    enum: OpportunityMatchStatusType,
+    default: OpportunityMatchStatusType.NO_MATCHES,
+  })
+  @IsEnum(OpportunityMatchStatusType)
+  statusMatch: OpportunityMatchStatusType;
 
   @Column({ default: 1 })
   @IsInt()

--- a/src/data/entity/opportunity/opportunity.entity.ts
+++ b/src/data/entity/opportunity/opportunity.entity.ts
@@ -1,9 +1,9 @@
 import { IsEnum, IsInt, IsOptional, IsString } from "class-validator";
 import {
-  OpportunityMatchStatusType,
   OpportunityStatusType,
   OpportunityType,
   TranslatedIntoType,
+  VolunteerStateMatchType,
 } from "need4deed-sdk";
 import {
   Column,
@@ -54,11 +54,11 @@ export default class Opportunity {
 
   @Column({
     type: "enum",
-    enum: OpportunityMatchStatusType,
-    default: OpportunityMatchStatusType.NO_MATCHES,
+    enum: VolunteerStateMatchType,
+    default: VolunteerStateMatchType.NO_MATCHES,
   })
-  @IsEnum(OpportunityMatchStatusType)
-  statusMatch: OpportunityMatchStatusType;
+  @IsEnum(VolunteerStateMatchType)
+  statusMatch: VolunteerStateMatchType;
 
   @Column({ default: 1 })
   @IsInt()

--- a/src/data/lib/index.ts
+++ b/src/data/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./categorize";
+export * from "./resolve-opp-matching";
 export * from "./revolve-vol-matching";
 export * from "./snake-case";

--- a/src/data/lib/resolve-opp-matching.ts
+++ b/src/data/lib/resolve-opp-matching.ts
@@ -1,0 +1,36 @@
+import {
+  OpportunityMatchStatusType,
+  OpportunityStatusType,
+  OpportunityVolunteerStatusType,
+} from "need4deed-sdk";
+
+export function resolveOpportunityMatchStatus(
+  volunteers: { status: OpportunityVolunteerStatusType }[],
+  numberNeeded: number,
+): OpportunityMatchStatusType {
+  const active = volunteers.filter(
+    (v) => v.status === OpportunityVolunteerStatusType.ACTIVE,
+  ).length;
+  const matched = volunteers.filter(
+    (v) => v.status === OpportunityVolunteerStatusType.MATCHED,
+  ).length;
+  const pending = volunteers.filter(
+    (v) => v.status === OpportunityVolunteerStatusType.PENDING,
+  ).length;
+
+  if (active > 0 && active < numberNeeded) return OpportunityMatchStatusType.PAST;
+  if (matched > 0) return OpportunityMatchStatusType.MATCHED;
+  if (pending > 0) return OpportunityMatchStatusType.PENDING_MATCH;
+  return OpportunityMatchStatusType.NO_MATCHES;
+}
+
+export function resolveOpportunityStatus(
+  volunteers: { status: OpportunityVolunteerStatusType }[],
+  currentStatus: OpportunityStatusType,
+): OpportunityStatusType {
+  const hasActive = volunteers.some(
+    (v) => v.status === OpportunityVolunteerStatusType.ACTIVE,
+  );
+  if (hasActive) return OpportunityStatusType.ACTIVE;
+  return currentStatus;
+}

--- a/src/data/lib/resolve-opp-matching.ts
+++ b/src/data/lib/resolve-opp-matching.ts
@@ -6,21 +6,22 @@ import {
 
 export function resolveOpportunityMatchStatus(
   volunteers: { status: OpportunityVolunteerStatusType }[],
-  numberNeeded: number,
 ): OpportunityMatchStatusType {
-  const active = volunteers.filter(
-    (v) => v.status === OpportunityVolunteerStatusType.ACTIVE,
-  ).length;
-  const matched = volunteers.filter(
-    (v) => v.status === OpportunityVolunteerStatusType.MATCHED,
-  ).length;
-  const pending = volunteers.filter(
+  const hasMatched = volunteers.some(
+    (v) =>
+      v.status === OpportunityVolunteerStatusType.MATCHED ||
+      v.status === OpportunityVolunteerStatusType.ACTIVE,
+  );
+  const hasPending = volunteers.some(
     (v) => v.status === OpportunityVolunteerStatusType.PENDING,
-  ).length;
+  );
+  const hasPast = volunteers.some(
+    (v) => v.status === OpportunityVolunteerStatusType.PAST,
+  );
 
-  if (active > 0 && active < numberNeeded) return OpportunityMatchStatusType.PAST;
-  if (matched > 0) return OpportunityMatchStatusType.MATCHED;
-  if (pending > 0) return OpportunityMatchStatusType.PENDING_MATCH;
+  if (hasMatched) return OpportunityMatchStatusType.MATCHED;
+  if (hasPending) return OpportunityMatchStatusType.PENDING_MATCH;
+  if (hasPast) return OpportunityMatchStatusType.PAST;
   return OpportunityMatchStatusType.NO_MATCHES;
 }
 
@@ -31,6 +32,15 @@ export function resolveOpportunityStatus(
   const hasActive = volunteers.some(
     (v) => v.status === OpportunityVolunteerStatusType.ACTIVE,
   );
+  const hasPendingOrMatched = volunteers.some(
+    (v) =>
+      v.status === OpportunityVolunteerStatusType.PENDING ||
+      v.status === OpportunityVolunteerStatusType.MATCHED,
+  );
+
   if (hasActive) return OpportunityStatusType.ACTIVE;
+  if (hasPendingOrMatched && currentStatus === OpportunityStatusType.NEW) {
+    return OpportunityStatusType.SEARCHING;
+  }
   return currentStatus;
 }

--- a/src/data/migrations/1777284196924-add-opp-status-match.ts
+++ b/src/data/migrations/1777284196924-add-opp-status-match.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddOppStatusMatch1777284196924 implements MigrationInterface {
+  name = "AddOppStatusMatch1777284196924";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."volunteer_status_match_enum" ADD VALUE IF NOT EXISTS 'vol-past'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" ADD COLUMN IF NOT EXISTS "status_match" "volunteer_status_match_enum" NOT NULL DEFAULT 'vol-no-matches'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" DROP COLUMN IF EXISTS "status_match"`,
+    );
+    // PostgreSQL does not support removing enum values; vol-past remains in volunteer_status_match_enum.
+  }
+}

--- a/src/data/migrations/1777973964566-consolidate-legacy-districts.ts
+++ b/src/data/migrations/1777973964566-consolidate-legacy-districts.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+const LEGACY_TO_COMPOUND: Record<string, string> = {
+  Kreuzberg: "Friedrichshain-Kreuzberg",
+  Friedrichshain: "Friedrichshain-Kreuzberg",
+  Charlottenburg: "Charlottenburg-Wilmersdorf",
+  Wilmersdorf: "Charlottenburg-Wilmersdorf",
+  Zehlendorf: "Steglitz-Zehlendorf",
+  Steglitz: "Steglitz-Zehlendorf",
+  Tempelhof: "Tempelhof-Schöneberg",
+  Schöneberg: "Tempelhof-Schöneberg",
+  Treptow: "Treptow-Köpenick",
+  Köpenick: "Treptow-Köpenick",
+  Marzahn: "Marzahn-Hellersdorf",
+  Hellersdorf: "Marzahn-Hellersdorf",
+  Moabit: "Mitte",
+  Wedding: "Mitte",
+  Tiergarten: "Mitte",
+  "Prenzlauer Berg": "Pankow",
+  Weißensee: "Pankow",
+};
+
+export class ConsolidateLegacyDistricts1777973964566
+  implements MigrationInterface
+{
+  name = "ConsolidateLegacyDistricts1777973964566";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    for (const [legacy, compound] of Object.entries(LEGACY_TO_COMPOUND)) {
+      // Remap location_district rows from the legacy district to the compound one.
+      // If the location already has the compound district linked, drop the duplicate instead.
+      await queryRunner.query(
+        `
+        UPDATE location_district ld
+        SET district_id = (SELECT id FROM district WHERE title = $1)
+        WHERE ld.district_id = (SELECT id FROM district WHERE title = $2)
+          AND NOT EXISTS (
+            SELECT 1 FROM location_district ld2
+            WHERE ld2.location_id = ld.location_id
+              AND ld2.district_id = (SELECT id FROM district WHERE title = $1)
+          )
+        `,
+        [compound, legacy],
+      );
+
+      // Remove any remaining rows still pointing to the legacy district
+      // (duplicates that were skipped above because the compound already existed).
+      await queryRunner.query(
+        `
+        DELETE FROM location_district
+        WHERE district_id = (SELECT id FROM district WHERE title = $1)
+        `,
+        [legacy],
+      );
+
+      // Delete the legacy district record itself.
+      await queryRunner.query(
+        `DELETE FROM district WHERE title = $1`,
+        [legacy],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Re-inserting legacy district rows is not meaningful — down() is a no-op.
+  }
+}

--- a/src/data/utils/index.ts
+++ b/src/data/utils/index.ts
@@ -6,4 +6,5 @@ export * from "./getStartEndDates";
 export * from "./passwd";
 export * from "./refresh-materialized-view";
 export * from "./remove-data";
+export * from "./update-opportunity-matching";
 export * from "./update-volunteer-matching";

--- a/src/data/utils/update-opportunity-matching.ts
+++ b/src/data/utils/update-opportunity-matching.ts
@@ -1,3 +1,4 @@
+import logger from "../../logger";
 import { tryCatch } from "../../services/utils";
 import { dataSource } from "../data-source";
 import OpportunityVolunteer from "../entity/m2m/opportunity-volunteer";
@@ -9,10 +10,8 @@ export async function updateOpportunityMatching(id: number): Promise<void> {
   const opportunityRepository = getRepository(dataSource, Opportunity);
   const opportunity = await opportunityRepository.findOneBy({ id });
   if (!opportunity) {
-    return dataSource.logger.log(
-      "warn",
-      `Opportunity id:${id} not found during match status update.`,
-    );
+    logger.warn(`Opportunity id:${id} not found during match status update.`);
+    return;
   }
 
   const opportunityVolunteerRepository = getRepository(
@@ -40,10 +39,7 @@ export async function updateOpportunityMatching(id: number): Promise<void> {
     );
 
     if (error) {
-      dataSource.logger.log(
-        "warn",
-        `During saving opportunity (id:${id}) occurred: ${error}`,
-      );
+      logger.warn(`During saving opportunity (id:${id}) occurred: ${error}`);
     }
   }
 }

--- a/src/data/utils/update-opportunity-matching.ts
+++ b/src/data/utils/update-opportunity-matching.ts
@@ -22,10 +22,7 @@ export async function updateOpportunityMatching(id: number): Promise<void> {
     where: { opportunityId: id },
   });
 
-  const statusMatch = resolveOpportunityMatchStatus(
-    volunteersLinked,
-    opportunity.numberVolunteers,
-  );
+  const statusMatch = resolveOpportunityMatchStatus(volunteersLinked);
   const status = resolveOpportunityStatus(volunteersLinked, opportunity.status);
 
   const changed =

--- a/src/data/utils/update-opportunity-matching.ts
+++ b/src/data/utils/update-opportunity-matching.ts
@@ -1,0 +1,49 @@
+import { tryCatch } from "../../services/utils";
+import { dataSource } from "../data-source";
+import OpportunityVolunteer from "../entity/m2m/opportunity-volunteer";
+import Opportunity from "../entity/opportunity/opportunity.entity";
+import { resolveOpportunityMatchStatus, resolveOpportunityStatus } from "../lib";
+import { getRepository } from "./get-repository";
+
+export async function updateOpportunityMatching(id: number): Promise<void> {
+  const opportunityRepository = getRepository(dataSource, Opportunity);
+  const opportunity = await opportunityRepository.findOneBy({ id });
+  if (!opportunity) {
+    return dataSource.logger.log(
+      "warn",
+      `Opportunity id:${id} not found during match status update.`,
+    );
+  }
+
+  const opportunityVolunteerRepository = getRepository(
+    dataSource,
+    OpportunityVolunteer,
+  );
+  const volunteersLinked = await opportunityVolunteerRepository.find({
+    where: { opportunityId: id },
+  });
+
+  const statusMatch = resolveOpportunityMatchStatus(
+    volunteersLinked,
+    opportunity.numberVolunteers,
+  );
+  const status = resolveOpportunityStatus(volunteersLinked, opportunity.status);
+
+  const changed =
+    statusMatch !== opportunity.statusMatch || status !== opportunity.status;
+
+  if (changed) {
+    const [, error] = await tryCatch(
+      opportunityRepository.save(
+        Object.assign(opportunity, { statusMatch, status }),
+      ),
+    );
+
+    if (error) {
+      dataSource.logger.log(
+        "warn",
+        `During saving opportunity (id:${id}) occurred: ${error}`,
+      );
+    }
+  }
+}

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -3,6 +3,7 @@ import {
   ApiOpportunityGet,
   ApiOpportunityGetList,
   ApiVolunteerOpportunityGetList,
+  OpportunityMatchStatusType,
   OpportunityType,
 } from "need4deed-sdk";
 import Comment from "../../data/entity/comment.entity";
@@ -47,6 +48,7 @@ export function dtoOpportunityGetList(
     category: { id: opportunity.deal.profile.categoryId },
     volunteerType: opportunity.type,
     statusOpportunity: opportunity.status,
+    statusMatch: opportunity.statusMatch ?? OpportunityMatchStatusType.NO_MATCHES,
     createdAt: opportunity.createdAt,
     languages: opportunity.deal.profile.profileLanguage
       .filter(Boolean)
@@ -108,6 +110,7 @@ export function dtoOpportunityGet(
     title: opportunityComments.title,
     volunteerType: opportunityComments.type,
     statusOpportunity: opportunityComments.status,
+    statusMatch: opportunityComments.statusMatch ?? OpportunityMatchStatusType.NO_MATCHES,
     createdAt: opportunityComments.createdAt,
     category: { id: opportunityComments.deal.profile.categoryId },
     description: getOpportunityDescription(opportunityComments),

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -3,8 +3,8 @@ import {
   ApiOpportunityGet,
   ApiOpportunityGetList,
   ApiVolunteerOpportunityGetList,
-  OpportunityMatchStatusType,
   OpportunityType,
+  VolunteerStateMatchType,
 } from "need4deed-sdk";
 import Comment from "../../data/entity/comment.entity";
 import Opportunity from "../../data/entity/opportunity/opportunity.entity";
@@ -48,7 +48,7 @@ export function dtoOpportunityGetList(
     category: { id: opportunity.deal.profile.categoryId },
     volunteerType: opportunity.type,
     statusOpportunity: opportunity.status,
-    statusMatch: opportunity.statusMatch ?? OpportunityMatchStatusType.NO_MATCHES,
+    statusMatch: opportunity.statusMatch ?? VolunteerStateMatchType.NO_MATCHES,
     createdAt: opportunity.createdAt,
     languages: opportunity.deal.profile.profileLanguage
       .filter(Boolean)
@@ -110,7 +110,7 @@ export function dtoOpportunityGet(
     title: opportunityComments.title,
     volunteerType: opportunityComments.type,
     statusOpportunity: opportunityComments.status,
-    statusMatch: opportunityComments.statusMatch ?? OpportunityMatchStatusType.NO_MATCHES,
+    statusMatch: opportunityComments.statusMatch ?? VolunteerStateMatchType.NO_MATCHES,
     createdAt: opportunityComments.createdAt,
     category: { id: opportunityComments.deal.profile.categoryId },
     description: getOpportunityDescription(opportunityComments),


### PR DESCRIPTION
## Summary

- Adds a TypeORM migration that remaps all `location_district` rows referencing legacy sub-district names (e.g. `Kreuzberg`, `Moabit`, `Prenzlauer Berg`) to the correct compound Berlin district (e.g. `Friedrichshain-Kreuzberg`, `Mitte`, `Pankow`)
- Removes duplicate rows where a location already has the compound district linked
- Deletes the leftover legacy `district` records

Fixes the district filter returning 0 results and volunteer profiles showing old district names.

## Closes

https://github.com/need4deed-org/be/issues/442

## Test plan

- [ ] Run `yarn migration:run` on a local DB seeded with legacy data
- [ ] Verify volunteers previously showing `Kreuzberg`, `Moabit`, `Prenzlauer Berg` etc. now show the correct compound district
- [ ] Verify filtering by `Charlottenburg-Wilmersdorf`, `Friedrichshain-Kreuzberg` etc. returns the expected volunteers
- [ ] Verify no `location_district` rows reference non-existent districts after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)