### PR TITLE
fix: include phone number in opportunity contact comment

### DIFF
--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -82,7 +82,7 @@ export default async function opportunityLegacyRoutes(
       const commentRepository = fastify.db.commentRepository;
       await commentRepository.save(
         new Comment({
-          text: `${request.body.rac_email}<|>${request.body.rac_full_name}<|>${request.body.rac_address}<|>${request.body.rac_plz}`,
+          text: `${request.body.rac_email}<|>${request.body.rac_full_name}<|>${request.body.rac_address}<|>${request.body.rac_plz}<|>${request.body.rac_phone}`,
           entityId: id,
           entityType: EntityTableName.OPPORTUNITY,
           userId: 1,


### PR DESCRIPTION
## Summary

- Adds `rac_phone` to the `<|>`-delimited contact comment saved when a new opportunity is submitted via the public form
- The phone number was already present in the form payload (`OpportunityLegacyFormData.rac_phone`) but was silently dropped when the comment was constructed

## Root cause

`legacy.routes.ts:85` built the comment text from `rac_email`, `rac_full_name`, `rac_address`, and `rac_plz` but omitted `rac_phone`.

## Closes

https://github.com/need4deed-org/be/issues/444

## Note for FE

Once this is deployed, the FE comment parser should be verified to render the `rac_phone` field correctly (the `<|>` delimiter count increases by one). Check https://github.com/need4deed-org/fe/issues/444 if tracking exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)