### PR TITLE
fix: replace non-existent OpportunityType.BREAD_DELIVERY with REGULAR in test

### DIFF
--- a/src/test/server/utils/data/add-district-to-opp.test.ts
+++ b/src/test/server/utils/data/add-district-to-opp.test.ts
@@ -73,7 +73,7 @@ describe("getDistrictToOpportunityHandler", () => {
         const handler = getDistrictToOpportunityHandler();
         const district = makeDistrict({ id: 5 });
         const opportunity = makeOpportunity({
-          type: OpportunityType.BREAD_DELIVERY, // Non-accompanying type
+          type: OpportunityType.REGULAR, // Non-accompanying type
           deal: {
             location: {
               locationDistrict: [{ district }],


### PR DESCRIPTION
## Summary
- `OpportunityType.BREAD_DELIVERY` doesn't exist in the SDK enum (only `ACCOMPANYING`, `REGULAR`, `EVENTS`)
- Test written in PR #473 used it to represent a "non-accompanying type" — `REGULAR` is the correct substitute
- This is breaking the `build-be` CI job

## Test plan
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)