### PR TITLE
fix: remove hardcoded city="Berlin" from volunteer address DTO

### DIFF
--- a/src/services/dto/dto-volunteer.ts
+++ b/src/services/dto/dto-volunteer.ts
@@ -16,7 +16,6 @@ import {
   getTitles,
 } from "./utils";
 
-const city = "Berlin";
 
 export function volunteerListSerializer(
   volunteer: Volunteer,
@@ -65,7 +64,6 @@ export function volunteerSerializer(
     ? {
         ...volunteer.person.address,
         id: volunteer.person.address.id,
-        city,
         postcode: {
           ...volunteer.person.address.postcode,
           id: volunteer.person.address.postcode.id,


### PR DESCRIPTION
## Summary

- `dto-volunteer.ts` had `const city = "Berlin"` at module scope
- This constant was used inside `volunteerSerializer` to override `volunteer.person.address.city` in the address object
- Every `GET /volunteer/:id` response returned `city: "Berlin"` regardless of what was actually stored in the DB
- Editing the city in the volunteer contact form appeared to save (PATCH succeeded) but the next GET always returned "Berlin", making it look like the change didn't persist

## Fix

Removed `const city = "Berlin"` and the `city,` override in the address serializer. The spread `...volunteer.person.address` now correctly provides the real city value.

## Closes

https://github.com/need4deed-org/be/issues/448

🤖 Generated with [Claude Code](https://claude.com/claude-code)