### PR TITLE
fix: cast volunteerSerializer return to unblock build (SDK 0.0.82 pending)

### DIFF
--- a/src/services/dto/dto-volunteer.ts
+++ b/src/services/dto/dto-volunteer.ts
@@ -130,6 +130,7 @@ export function volunteerSerializer(
   const languages = getLanguages(volunteer.deal.profile.profileLanguage);
   const availability = getAvailability(volunteer.deal.time.timeTimeslot);
 
+  // TODO: remove cast once need4deed-sdk >= 0.0.82 is published (adds statusVaccinationDate etc.)
   return {
     id: volunteer.id,
     person,
@@ -160,5 +161,5 @@ export function volunteerSerializer(
     activities,
     skills,
     locations,
-  };
+  } as unknown as ApiVolunteerGet;
 }


### PR DESCRIPTION
## Summary

The 3 new status date fields added in PR #482 (`statusVaccinationDate`, `statusCGCApplicationDate`, `statusCGCDate`) are in the entity and DTO but not yet in the installed SDK type — npm publish of `0.0.82` is pending.

TypeScript was rejecting the object literal in `volunteerSerializer` with `TS2353: Object literal may only specify known properties`.

Added `as unknown as ApiVolunteerGet` cast with a TODO comment to remove it once SDK >= 0.0.82 is published to npm.

## TODO

Remove the cast once `need4deed-sdk` 0.0.82 is published and the BE dependency is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)