### PR TITLE
fix: return explicit UTC time in dtoOpportunityAccompanying

### DIFF
--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -8,7 +8,7 @@ export function dtoOpportunityAccompanying(
     ? {
         appointmentAddress: accompanying.address,
         appointmentDate: accompanying.date.toDateString(),
-        appointmentTime: accompanying.date.toTimeString().slice(0, 5),
+        appointmentTime: `${String(accompanying.date.getUTCHours()).padStart(2, "0")}:${String(accompanying.date.getUTCMinutes()).padStart(2, "0")}`,
         refugeeNumber: accompanying.phone,
         refugeeName: accompanying.name,
         languageToTranslate: accompanying.langCode,


### PR DESCRIPTION
## Summary
- Replaces `accompanying.date.toTimeString().slice(0, 5)` with explicit `getUTCHours/getUTCMinutes` in `dtoOpportunityAccompanying`
- `toTimeString()` returns server-local time, which caused the frontend's UTC→local conversion to add an extra 2h on CEST servers
- `getUTCHours/getUTCMinutes` is timezone-independent and always returns UTC

## Test plan
- [ ] Create an accompanying opportunity with appointment time 09:00 (CEST)
- [ ] Verify the dashboard shows 09:00, not 11:00
- [ ] Edit and re-save the time — verify it stays stable (no drift)

Closes https://github.com/need4deed-org/be/issues/491
Paired FE fix: need4deed-org/fe (fix/519-appointment-time-double-utc-conversion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)