### PR TITLE
fix: add opp-inactive to schema and activity filter to opportunity WHERE

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -622,7 +622,7 @@
     "OpportunityStatusType": {
       "$id": "OpportunityStatusType",
       "type": "string",
-      "enum": ["opp-new", "opp-searching", "opp-active", "opp-past"]
+      "enum": ["opp-new", "opp-searching", "opp-active", "opp-inactive", "opp-past"]
     },
     "ApiOpportunityGetList": {
       "$id": "ApiOpportunityGetList",

--- a/src/server/utils/data/get-opportunity-where.ts
+++ b/src/server/utils/data/get-opportunity-where.ts
@@ -48,5 +48,18 @@ export function getOpportunityWhere(
           },
         }
       : {}),
+    ...(filter?.activity
+      ? {
+          deal: {
+            profile: {
+              profileActivity: {
+                activity: {
+                  id: normalizeStringArrayInput(filter.activity),
+                },
+              },
+            },
+          },
+        }
+      : {}),
   } as FindOptionsWhere<Opportunity>;
 }


### PR DESCRIPTION
## Summary
- Adds `"opp-inactive"` to `OpportunityStatusType` enum in `sdk-types.json` — AJV was rejecting PATCH requests to set opportunity status to inactive because the value was missing from the validation schema
- Adds `activity` filter clause to `getOpportunityWhere` — mirrors the existing pattern used by language/district/type filters; the activity param was being sent by the FE correctly but silently ignored by the BE

## Test plan
- [ ] Set a regular opportunity status to "inactive" — should succeed without validation error
- [ ] Filter opportunities by activity type on the dashboard — list should filter correctly
- [ ] Existing type/status/language/district filters still work

Closes https://github.com/need4deed-org/fe/issues/459
Closes https://github.com/need4deed-org/fe/issues/484

🤖 Generated with [Claude Code](https://claude.com/claude-code)