### PR TITLE
feat: add video-call to ContactMethodType in sdk-types.json

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -383,7 +383,8 @@
         "whatsapp",
         "signal",
         "sms",
-        "voicenote"
+        "voicenote",
+        "video-call"
       ]
     },
     "CommunicationType": {


### PR DESCRIPTION
## Summary
- Adds `"video-call"` to the `ContactMethodType` enum in `sdk-types.json` so the BE validation schema accepts it

## Related
- Closes (part of) https://github.com/need4deed-org/fe/issues/521
- SDK PR: https://github.com/need4deed-org/sdk/pull/97
- FE PR: https://github.com/need4deed-org/fe/pull/522

## Test plan
- [ ] PATCH a communication entry with `contactMethod: "video-call"` — returns 200 (not 400 validation error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)