### PR TITLE
feat: include statusMatch and statusCommunication in volunteer list response

### DIFF
--- a/src/services/dto/dto-volunteer.ts
+++ b/src/services/dto/dto-volunteer.ts
@@ -42,6 +42,8 @@ export function volunteerListSerializer(
       id,
       statusEngagement,
       statusType,
+      statusMatch: volunteer.statusMatch,
+      statusCommunication: volunteer.statusCommunication,
       name,
       avatarUrl,
       languages,


### PR DESCRIPTION
## Summary
Adds `statusMatch` and `statusCommunication` to `volunteerListSerializer` so they appear in `GET /volunteers` responses. The matching-status column in the volunteer table and the match tag on volunteer cards were showing `—` because these fields were missing from the list serializer.

## Related
- FE issue: https://github.com/need4deed-org/fe/issues/423
- SDK PR: https://github.com/need4deed-org/sdk/pull/99
- FE PR: https://github.com/need4deed-org/fe/pull/523

## Test plan
- [ ] `GET /volunteers` includes `statusMatch` per volunteer
- [ ] Volunteer table "Matching-Status" column shows real values instead of dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)