### PR TITLE
feat(#488): expose agent id in opportunity agent DTO

### DIFF
--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -44,6 +44,7 @@ export function dtoAgentGet(
 
 export function dtoOpportunityAgent(agent: Agent): ApiOpportunityAgent {
   return {
+    id: agent.id,
     type: agent.type,
     name: agent.title,
     address: serializeAddress(agent.representative?.person?.address),


### PR DESCRIPTION
## Summary
- Adds `id` to `dtoOpportunityAgent` so the FE can link directly to an agent's profile from the opportunity page

Closes https://github.com/need4deed-org/fe/issues/488

🤖 Generated with [Claude Code](https://claude.com/claude-code)