### PR TITLE
fix: use setUTCHours/setUTCMinutes in getDateObj to prevent 2h drift on UTC servers

### DIFF
--- a/src/services/utils/index.ts
+++ b/src/services/utils/index.ts
@@ -141,8 +141,8 @@ export function isProbablyFileSystemPath(str: string): boolean {
 export function getDateObj(date: string, time: string): Date {
   const [hours, minutes] = time?.split(":") || "";
   const dateObj = new Date(date);
-  dateObj.setHours(Number(hours));
-  dateObj.setMinutes(Number(minutes));
+  dateObj.setUTCHours(Number(hours));
+  dateObj.setUTCMinutes(Number(minutes));
 
   if (isNaN(dateObj.getTime())) {
     throw new BadRequestError("Date and/or time is invalid.");

--- a/src/test/services/utils/index.test.ts
+++ b/src/test/services/utils/index.test.ts
@@ -268,15 +268,15 @@ describe("getDateObj()", () => {
     expect(result.getFullYear()).toBe(2026);
     expect(result.getMonth()).toBe(2); // March is 0-indexed
     expect(result.getDate()).toBe(11);
-    expect(result.getHours()).toBe(14);
-    expect(result.getMinutes()).toBe(30);
+    expect(result.getUTCHours()).toBe(14);
+    expect(result.getUTCMinutes()).toBe(30);
   });
 
   it("should handle single digit hours and minutes correctly", () => {
     const result = getDateObj("2026-05-20", "09:05");
 
-    expect(result.getHours()).toBe(9);
-    expect(result.getMinutes()).toBe(5);
+    expect(result.getUTCHours()).toBe(9);
+    expect(result.getUTCMinutes()).toBe(5);
   });
 
   it("should throw BadRequestError if the date string is invalid", () => {


### PR DESCRIPTION
## Summary
- Changes `setHours`/`setMinutes` → `setUTCHours`/`setUTCMinutes` in `getDateObj`
- Updates unit tests to assert `getUTCHours`/`getUTCMinutes`

## Why
The server runs in UTC (no `TZ` set in Dockerfile). `setHours(9)` on a UTC server stores 09:00 UTC. When a coordinator enters 09:00 CEST, the correct stored value is 07:00 UTC — so the setter must be UTC-aware. The paired FE fix (https://github.com/need4deed-org/fe/issues/527) converts local time to UTC before the API call, so `getDateObj` will receive UTC HH:mm and must store it with `setUTCHours`.

Closes https://github.com/need4deed-org/be/issues/498
Paired FE fix: https://github.com/need4deed-org/fe/issues/527

🤖 Generated with [Claude Code](https://claude.com/claude-code)