### PR TITLE
fix: parse accomp_datetime as Europe/Berlin; use toISOString() for appointmentDate

### DIFF
--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -7,7 +7,7 @@ export function dtoOpportunityAccompanying(
   return accompanying
     ? {
         appointmentAddress: accompanying.address,
-        appointmentDate: accompanying.date.toDateString(),
+        appointmentDate: accompanying.date.toISOString(),
         appointmentTime: `${String(accompanying.date.getUTCHours()).padStart(2, "0")}:${String(accompanying.date.getUTCMinutes()).padStart(2, "0")}`,
         refugeeNumber: accompanying.phone,
         refugeeName: accompanying.name,

--- a/src/services/dto/parser-accompanying-legacy.ts
+++ b/src/services/dto/parser-accompanying-legacy.ts
@@ -1,6 +1,38 @@
 import { OpportunityLegacyFormData, TranslatedIntoType } from "need4deed-sdk";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
 
+// Parses a datetime string as Europe/Berlin time when no timezone is specified.
+// Uses the Intl API so DST transitions (CET⇔CEST) are handled automatically.
+function parseAccompDatetime(value: string | undefined): Date {
+  if (!value) return new Date(NaN);
+  if (/Z|[+-]\d{2}:?\d{2}$/.test(value)) return new Date(value);
+
+  const asIfUtc = new Date(value + "Z");
+  if (isNaN(asIfUtc.getTime())) return asIfUtc;
+
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Europe/Berlin",
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    hour12: false,
+  }).formatToParts(asIfUtc);
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value ?? 0);
+  const berlinAsUtcMs = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour") % 24,
+    get("minute"),
+    get("second"),
+  );
+  return new Date(asIfUtc.getTime() - (berlinAsUtcMs - asIfUtc.getTime()));
+}
+
 export function accompanyingParserOpportunity(
   body: OpportunityLegacyFormData,
 ): Accompanying {
@@ -8,7 +40,7 @@ export function accompanyingParserOpportunity(
     address: body.accomp_address,
     name: body.accomp_name,
     phone: body.accomp_phone,
-    date: new Date(body.accomp_datetime),
+    date: parseAccompDatetime(body.accomp_datetime),
     languageToTranslate: body.accomp_translation as TranslatedIntoType,
   });
 


### PR DESCRIPTION
## Summary
- `parser-accompanying-legacy.ts`: replaces `new Date(body.accomp_datetime)` with a DST-safe Berlin parser — if the string has no timezone info, it is treated as Europe/Berlin time via the Intl API
- `dto-accompanying.ts`: changes `appointmentDate: accompanying.date.toDateString()` → `toISOString()` to avoid CEST browsers parsing the date string as midnight local (one day behind)

## Why these two bugs were missed before
The previous fix (https://github.com/need4deed-org/be/pull/492) only addressed the read path (`toTimeString` → `getUTCHours`). The write path for the initial form submission (`new Date(accomp_datetime)`) was still storing 2h ahead on a UTC server when the form sends local CEST time without timezone info.

`toDateString()` was a separate silent bug: the date appears correct on a UTC server, but CEST browsers parse it as the previous day at 22:00 UTC, causing the date to drift on every edit.

### parseAccompDatetime logic
1. If string has TZ info (`Z` or `+HH:MM`) → `new Date()` handles it directly
2. Otherwise: append `Z` to parse as UTC, ask Intl what Berlin thinks that UTC moment is, compute the offset, subtract it → correct UTC

Example: `"2026-05-15T09:00"` (CEST) → offset = +2h → stored as 07:00 UTC ✓

Closes https://github.com/need4deed-org/be/issues/500

🤖 Generated with [Claude Code](https://claude.com/claude-code)