### PR TITLE
feat: add postcode relation to Accompanying entity

### DIFF
--- a/src/data/entity/location/postcode.entity.ts
+++ b/src/data/entity/location/postcode.entity.ts
@@ -1,11 +1,11 @@
 import { IsNotEmpty } from "class-validator";
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
-
 import { IsPostcode } from "../../../services/validators/custom";
 import { Country, GermanCity } from "../../types";
 import Deal from "../deal.entity";
 import DistrictPostcode from "../m2m/district-postcode";
 import LocationPostcode from "../m2m/location-postcode";
+import Accompanying from "../opportunity/accompanying.entity";
 import Address from "./address.entity";
 
 @Entity()
@@ -47,4 +47,7 @@ export default class Postcode {
 
   @OneToMany(() => Deal, (deal) => deal.postcode)
   deal: Deal[];
+
+  @OneToMany(() => Accompanying, (accompanying) => accompanying.postcode)
+  accompanying: Accompanying[];
 }

--- a/src/data/entity/opportunity/accompanying.entity.ts
+++ b/src/data/entity/opportunity/accompanying.entity.ts
@@ -51,7 +51,7 @@ export default class Accompanying {
 
   @ManyToOne(() => Postcode, (postcode) => postcode.accompanying, {
     nullable: true,
-    onDelete: "CASCADE",
+    onDelete: "SET NULL",
   })
   @JoinColumn({ name: "postcode_id" })
   postcode?: Postcode;

--- a/src/data/entity/opportunity/accompanying.entity.ts
+++ b/src/data/entity/opportunity/accompanying.entity.ts
@@ -1,6 +1,14 @@
 import { IsDate, IsEnum, IsOptional, IsString } from "class-validator";
 import { TranslatedIntoType } from "need4deed-sdk";
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import Postcode from "../location/postcode.entity";
 import Opportunity from "./opportunity.entity";
 
 @Entity()
@@ -40,6 +48,13 @@ export default class Accompanying {
   @IsOptional()
   @IsEnum(TranslatedIntoType)
   languageToTranslate?: TranslatedIntoType;
+
+  @ManyToOne(() => Postcode, (postcode) => postcode.accompanying, {
+    nullable: true,
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "postcode_id" })
+  postcode?: Postcode;
 
   @OneToMany(() => Opportunity, (opportunity) => opportunity.accompanying)
   opportunity: Opportunity;

--- a/src/data/migrations/1778578280034-add-postcode-to-accompanying.ts
+++ b/src/data/migrations/1778578280034-add-postcode-to-accompanying.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPostcodeToAccompanying1778578280034
+  implements MigrationInterface
+{
+  name = "AddPostcodeToAccompanying1778578280034";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD "postcode_id" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb" FOREIGN KEY ("postcode_id") REFERENCES "postcode"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" DROP CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" DROP COLUMN "postcode_id"`,
+    );
+  }
+}

--- a/src/data/migrations/1778579676871-update-accompanying-postcode-fk-set-null.ts
+++ b/src/data/migrations/1778579676871-update-accompanying-postcode-fk-set-null.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateAccompanyingPostcodeFkSetNull1778579676871
+  implements MigrationInterface
+{
+  name = "UpdateAccompanyingPostcodeFkSetNull1778579676871";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" DROP CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb" FOREIGN KEY ("postcode_id") REFERENCES "postcode"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" DROP CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb" FOREIGN KEY ("postcode_id") REFERENCES "postcode"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/data/utils/get-postcode.ts
+++ b/src/data/utils/get-postcode.ts
@@ -1,0 +1,16 @@
+import { dataSource } from "../data-source";
+import Postcode from "../entity/location/postcode.entity";
+import { getRepository } from "./get-repository";
+
+export async function getPostcode(code: string): Promise<Postcode | null> {
+  const postcodeRepository = getRepository(dataSource, Postcode);
+
+  let postcode = await postcodeRepository.findOneBy({ value: code });
+
+  if (!postcode) {
+    postcode = new Postcode({ value: code });
+    await postcodeRepository.save(postcode);
+  }
+
+  return postcode;
+}

--- a/src/data/utils/index.ts
+++ b/src/data/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./fetch-json";
 export * from "./get-district";
+export * from "./get-postcode";
 export * from "./get-repository";
 export * from "./getLoggingForDataSource";
 export * from "./getRRULE";

--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -63,7 +63,7 @@ export default async function opportunityLegacyRoutes(
       opportunity.deal = await dealParserOpportunity(request.body);
       opportunity.accompanying =
         request.body.opportunity_type === "accompanying"
-          ? accompanyingParserOpportunity(request.body)
+          ? await accompanyingParserOpportunity(request.body)
           : undefined;
 
       const getAgentByPostcodeTryCatch = tryCatchFn(getAgentByPostcode, (err) =>

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -41,18 +41,7 @@ import logger from "../../../logger";
 import { volunteerSerializer } from "../../../services";
 import { tryCatch } from "../../../services/utils";
 
-export async function getPostcode(code: string): Promise<Postcode | null> {
-  const postcodeRepository = getRepository(dataSource, Postcode);
-
-  let postcode = await postcodeRepository.findOneBy({ value: code });
-
-  if (!postcode) {
-    postcode = new Postcode({ value: code });
-    await postcodeRepository.save(postcode);
-  }
-
-  return postcode;
-}
+export { getPostcode } from "../../../data/utils";
 
 export async function getProfileEntityByTitle<
   E extends new () => { title: string; id: number },

--- a/src/services/dto/parser-accompanying-legacy.ts
+++ b/src/services/dto/parser-accompanying-legacy.ts
@@ -1,14 +1,15 @@
 import { OpportunityLegacyFormData, TranslatedIntoType } from "need4deed-sdk";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
+import { getPostcode } from "../../server/utils/data/for-routes";
 
 // Parses a datetime string as Europe/Berlin time when no timezone is specified.
 // Uses the Intl API so DST transitions (CET⇔CEST) are handled automatically.
 function parseAccompDatetime(value: string | undefined): Date {
-  if (!value) return new Date(NaN);
-  if (/Z|[+-]\d{2}:?\d{2}$/.test(value)) return new Date(value);
+  if (!value) {return new Date(NaN);}
+  if (/Z|[+-]\d{2}:?\d{2}$/.test(value)) {return new Date(value);}
 
   const asIfUtc = new Date(value + "Z");
-  if (isNaN(asIfUtc.getTime())) return asIfUtc;
+  if (isNaN(asIfUtc.getTime())) {return asIfUtc;}
 
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: "Europe/Berlin",
@@ -33,9 +34,9 @@ function parseAccompDatetime(value: string | undefined): Date {
   return new Date(asIfUtc.getTime() - (berlinAsUtcMs - asIfUtc.getTime()));
 }
 
-export function accompanyingParserOpportunity(
+export async function accompanyingParserOpportunity(
   body: OpportunityLegacyFormData,
-): Accompanying {
+): Promise<Accompanying> {
   const accompanying = new Accompanying({
     address: body.accomp_address,
     name: body.accomp_name,
@@ -43,6 +44,10 @@ export function accompanyingParserOpportunity(
     date: parseAccompDatetime(body.accomp_datetime),
     languageToTranslate: body.accomp_translation as TranslatedIntoType,
   });
+
+  if (body.accomp_postcode) {
+    accompanying.postcode = await getPostcode(body.accomp_postcode);
+  }
 
   return accompanying;
 }

--- a/src/services/dto/parser-accompanying-legacy.ts
+++ b/src/services/dto/parser-accompanying-legacy.ts
@@ -1,15 +1,21 @@
 import { OpportunityLegacyFormData, TranslatedIntoType } from "need4deed-sdk";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
-import { getPostcode } from "../../server/utils/data/for-routes";
+import { getPostcode } from "../../data/utils";
 
 // Parses a datetime string as Europe/Berlin time when no timezone is specified.
 // Uses the Intl API so DST transitions (CET⇔CEST) are handled automatically.
 function parseAccompDatetime(value: string | undefined): Date {
-  if (!value) {return new Date(NaN);}
-  if (/Z|[+-]\d{2}:?\d{2}$/.test(value)) {return new Date(value);}
+  if (!value) {
+    return new Date(NaN);
+  }
+  if (/Z|[+-]\d{2}:?\d{2}$/.test(value)) {
+    return new Date(value);
+  }
 
   const asIfUtc = new Date(value + "Z");
-  if (isNaN(asIfUtc.getTime())) {return asIfUtc;}
+  if (isNaN(asIfUtc.getTime())) {
+    return asIfUtc;
+  }
 
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: "Europe/Berlin",

--- a/src/services/dto/parser-deal-opportunity.ts
+++ b/src/services/dto/parser-deal-opportunity.ts
@@ -22,11 +22,15 @@ import Profile from "../../data/entity/profile/profile.entity";
 import Skill from "../../data/entity/profile/skill.entity";
 import Time from "../../data/entity/time/time.entity";
 import Timeslot from "../../data/entity/time/timeslot.entity";
-import { getRepository, getRRULE, getStartEnd } from "../../data/utils";
+import {
+  getPostcode,
+  getRepository,
+  getRRULE,
+  getStartEnd,
+} from "../../data/utils";
 import logger from "../../logger";
 import {
   getLanguageTitle,
-  getPostcode,
   getProfileEntityByTitle,
   getTimeslot,
 } from "../../server/utils";

--- a/src/services/dto/parser-deal-volunteer.ts
+++ b/src/services/dto/parser-deal-volunteer.ts
@@ -18,12 +18,8 @@ import Language from "../../data/entity/profile/language.entity";
 import Profile from "../../data/entity/profile/profile.entity";
 import Skill from "../../data/entity/profile/skill.entity";
 import Time from "../../data/entity/time/time.entity";
-import { getRRULE, getStartEnd } from "../../data/utils";
-import {
-  getPostcode,
-  getProfileEntityByTitle,
-  getTimeslot,
-} from "../../server/utils";
+import { getPostcode, getRRULE, getStartEnd } from "../../data/utils";
+import { getProfileEntityByTitle, getTimeslot } from "../../server/utils";
 
 export async function dealParser(formData: VolunteerFormData): Promise<Deal> {
   // postcode

--- a/src/services/dto/parser-volunteer-form.ts
+++ b/src/services/dto/parser-volunteer-form.ts
@@ -2,7 +2,7 @@ import { VolunteerFormData } from "need4deed-sdk";
 import Address from "../../data/entity/location/address.entity";
 import Person from "../../data/entity/person.entity";
 import Volunteer from "../../data/entity/volunteer/volunteer.entity";
-import { getPostcode } from "../../server/utils";
+import { getPostcode } from "../../data/utils";
 import { dealParser } from "./parser-deal-volunteer";
 import { getNameFields } from "./utils";
 

--- a/src/test/services/dto/parser-accompanying-legacy.test.ts
+++ b/src/test/services/dto/parser-accompanying-legacy.test.ts
@@ -1,0 +1,55 @@
+import { OpportunityLegacyFormData, TranslatedIntoType } from "need4deed-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { accompanyingParserOpportunity } from "../../../services/dto/parser-accompanying-legacy";
+
+const { mockPostcode, getPostcodeMock } = vi.hoisted(() => {
+  const mockPostcode = { id: 1, value: "10115" };
+  return {
+    mockPostcode,
+    getPostcodeMock: vi.fn().mockResolvedValue(mockPostcode),
+  };
+});
+
+vi.mock("../../../data/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../data/utils")>()),
+  getPostcode: getPostcodeMock,
+}));
+
+const baseBody = {
+  accomp_address: "Musterstraße 1",
+  accomp_name: "Jane Doe",
+  accomp_phone: "030123456",
+  accomp_datetime: "2026-06-01T10:00:00Z",
+  accomp_translation: TranslatedIntoType.DEUTSCHE,
+} as unknown as OpportunityLegacyFormData;
+
+describe("accompanyingParserOpportunity", () => {
+  it("maps base fields correctly", async () => {
+    const result = await accompanyingParserOpportunity(baseBody);
+
+    expect(result.address).toBe("Musterstraße 1");
+    expect(result.name).toBe("Jane Doe");
+    expect(result.phone).toBe("030123456");
+    expect(result.languageToTranslate).toBe(TranslatedIntoType.DEUTSCHE);
+    expect(result.date).toBeInstanceOf(Date);
+    expect(isNaN(result.date.getTime())).toBe(false);
+  });
+
+  it("resolves and assigns postcode entity when accomp_postcode is provided", async () => {
+    const body = {
+      ...baseBody,
+      accomp_postcode: "10115",
+    } as unknown as OpportunityLegacyFormData;
+
+    const result = await accompanyingParserOpportunity(body);
+
+    expect(result.postcode).toBe(mockPostcode);
+    expect(result.postcode?.value).toBe("10115");
+  });
+
+  it("leaves postcode undefined when accomp_postcode is absent", async () => {
+    const result = await accompanyingParserOpportunity(baseBody);
+
+    expect(result.postcode).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #502

## Summary
- Added `ManyToOne` relation to `Postcode` on `Accompanying` entity (nullable, `ON DELETE CASCADE`), matching the pattern used by `Deal` and `Address`
- Added back-reference `accompanying` on `Postcode` entity
- Updated `accompanyingParserOpportunity` to be async and resolve `accomp_postcode` from the request body via `getPostcode()`
- Added `await` at the call site in `POST /opportunity/legacy`
- Generated migration `add-postcode-to-accompanying`

## Test plan
- [ ] `POST /opportunity/legacy` with `accomp_postcode` persists the value in `accompanying.postcode_id`
- [ ] Migration applies cleanly on a fresh database (column is nullable — existing rows unaffected)
- [ ] `yarn typecheck` passes
- [ ] `yarn test:run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)