### PR TITLE
fix: update ApiAccompanying response schema for SDK 0.0.83

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -595,17 +595,7 @@
             "district": { "type": "string" }
           }
         },
-        "accompanyingDetails": {
-          "type": "object",
-          "properties": {
-            "appointmentAddress": { "type": "string" },
-            "appointmentDate": { "type": "string" },
-            "appointmentTime": { "type": "string" },
-            "refugeeNumber": { "type": "string" },
-            "refugeeName": { "type": "string" },
-            "languagesToTranslate": { "type": "integer" }
-          }
-        }
+        "accompanyingDetails": { "$ref": "ApiAccompanying#" }
       },
       "additionalProperties": false
     },

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -246,6 +246,11 @@
       "type": "string",
       "enum": ["opp-pending", "opp-matched", "opp-active", "opp-past"]
     },
+    "TranslatedIntoType": {
+      "$id": "TranslatedIntoType",
+      "type": "string",
+      "enum": ["deutsche", "englishOk", "noTranslation"]
+    },
     "OptionItem": {
       "$id": "OptionItem",
       "type": "object",
@@ -896,7 +901,11 @@
         "appointmentTime": { "type": "string" },
         "refugeeNumber": { "type": "string" },
         "refugeeName": { "type": "string" },
-        "languageToTranslate": { "type": "integer" }
+        "appointmentLanguage": { "$ref": "TranslatedIntoType#" },
+        "refugeeLanguage": {
+          "type": "array",
+          "items": { "$ref": "OptionById#" }
+        }
       }
     },
     "ApiOrganizationPatch": {


### PR DESCRIPTION
Closes #508

## Summary

- Added `TranslatedIntoType` enum definition to `sdk-types.json`
- Replaced stale `languageToTranslate: integer` in `ApiAccompanying` with `appointmentLanguage: TranslatedIntoType` and `refugeeLanguage: OptionById[]`

The DTO was updated in #506 but the response schema was missed, causing Fastify to silently strip `appointmentLanguage` and `refugeeLanguage` from every `GET /opportunity/:id` response.

## Test plan

- [ ] `GET /opportunity/:id` for an accompanying opportunity returns `appointmentLanguage` and `refugeeLanguage` in `accompanyingDetails`

🤖 Generated with [Claude Code](https://claude.com/claude-code)