### PR TITLE
feat: restore accompanying DTO for SDK 0.0.83 (re-do of #506)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.3.3",
     "fastify-mailer": "^2.3.1",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "^0.0.82",
+    "need4deed-sdk": "^0.0.83",
     "nodemailer": "^7.0.4",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -44,9 +44,7 @@ import {
   getOpportunityOrphanageAgent,
   getOpportunityWhere,
   getOrCreateTimeslot,
-  getTranslationType,
   patchEntity,
-  setTranslationType,
   updateOptionList,
 } from "../../utils";
 import opportunityLegacyRoutes from "./legacy.routes";
@@ -81,6 +79,7 @@ export default async function opportunityRoutes(
       const id = request.params.id;
       const relations = [
         "accompanying",
+        "accompanying.postcode",
         "deal.profile.profileLanguage.language",
         "deal.profile.profileActivity.activity",
         "deal.profile.profileSkill.skill",
@@ -132,12 +131,6 @@ export default async function opportunityRoutes(
       if (opportunityUpdates.length) {
         const opportunityRepository = fastify.db.opportunityRepository;
         await opportunityRepository.save(opportunityUpdates);
-      }
-
-      if (opportunityComments.accompanying) {
-        opportunityComments.accompanying.langCode = await setTranslationType(
-          opportunityComments.accompanying.languageToTranslate!, // TODO: this needs to be sorted
-        );
       }
 
       const data = dtoOpportunityGet(opportunityComments);
@@ -306,15 +299,9 @@ export default async function opportunityRoutes(
       }
 
       if (accompanying) {
-        const languageToTranslate = accompanying.languageToTranslate
-          ? await getTranslationType(Number(accompanying.languageToTranslate))
-          : undefined;
-        const patchData = languageToTranslate !== undefined
-          ? Object.assign(accompanying, { languageToTranslate })
-          : accompanying;
         const success = await patchEntity(
           Accompanying,
-          patchData,
+          accompanying,
           opportunity.accompanyingId,
         );
         if (!success) {

--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -1,8 +1,10 @@
-import { ApiOpportunityAccompanyingDetails } from "need4deed-sdk";
+import { ApiOpportunityAccompanyingDetails, OptionById } from "need4deed-sdk";
+import ProfileLanguage from "../../data/entity/m2m/profile-language";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
 
 export function dtoOpportunityAccompanying(
   accompanying: Accompanying,
+  profileLanguage: ProfileLanguage[] = [],
 ): ApiOpportunityAccompanyingDetails {
   return accompanying
     ? {
@@ -11,7 +13,10 @@ export function dtoOpportunityAccompanying(
         appointmentTime: `${String(accompanying.date.getUTCHours()).padStart(2, "0")}:${String(accompanying.date.getUTCMinutes()).padStart(2, "0")}`,
         refugeeNumber: accompanying.phone,
         refugeeName: accompanying.name,
-        languageToTranslate: accompanying.langCode,
+        appointmentLanguage: accompanying.languageToTranslate,
+        refugeeLanguage: profileLanguage
+          .filter(Boolean)
+          .map((pl): OptionById => ({ id: pl.language.id })),
       }
     : {};
 }

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -108,7 +108,10 @@ export function dtoVolunteerOpportunityGetList(
       })),
     availability:
       getAvailabilityTryCatch(opportunity.deal.time?.timeTimeslot) ?? [],
-    accompanyingDetails: dtoOpportunityAccompanying(opportunity.accompanying!),
+    accompanyingDetails: dtoOpportunityAccompanying(
+      opportunity.accompanying!,
+      opportunity.deal.profile.profileLanguage,
+    ),
     statusMatch: opportunity.statusMatch,
   } as ApiVolunteerOpportunityGetList;
 }
@@ -158,6 +161,7 @@ export function dtoOpportunityGet(
     agent: dtoOpportunityAgent(opportunityComments.agent!),
     accompanyingDetails: dtoOpportunityAccompanying(
       opportunityComments.accompanying!,
+      opportunityComments.deal.profile.profileLanguage,
     ),
     comments: opportunityComments.comments.map(commentSerializer),
     statusMatch: opportunityComments.statusMatch,

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -1,7 +1,6 @@
 import {
   ApiOpportunityPatch,
   LangPurpose,
-  TranslatedIntoType,
 } from "need4deed-sdk";
 import { getNameFields } from "..";
 import { BadRequestError } from "../../config";
@@ -50,8 +49,7 @@ export function parseOpportunity(body: ApiOpportunityPatch) {
                 : undefined,
             phone: body.accompanyingDetails?.refugeeNumber,
             name: body.accompanyingDetails?.refugeeName,
-            languageToTranslate: body.accompanyingDetails
-              ?.languageToTranslate as unknown as TranslatedIntoType,
+            languageToTranslate: body.accompanyingDetails?.appointmentLanguage,
           } as Partial<Accompanying>)
         : {},
       languages: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,10 +3825,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.82:
-  version "0.0.82"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.82.tgz#a1e85c26bc496fffc1d9fbdf3bef0ab211919ff5"
-  integrity sha512-Wqt/p62QY3AAzkGWAvE7NG/0XQ/lC8rrXKTI2OHRT7NIsrENtT01EQ+lKXnnQQOUQT82COTR62KAe16PQ8FqpA==
+need4deed-sdk@^0.0.83:
+  version "0.0.83"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.83.tgz#6940f34ae33ba96c58f6e21a3b8ade58d17e5440"
+  integrity sha512-DvLFddWLj017c8HmZ79FWE/0LUuu/k1/orJUnl3eX/1ZH6mubKKegnKaU0Bew6366z5QOeC/SelCQevWRfrDsg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Re-applies #506 after develop's history rewrite. **Stacked on #510** (postcode infra) — base will auto-update to \`develop\` once #510 merges.

## Summary

- Bump \`need4deed-sdk\` to \`^0.0.83\`
- Replace \`languageToTranslate\` (number/langCode) with \`appointmentLanguage\` (\`TranslatedIntoType\`) — reads enum value directly from entity, removes the \`setTranslationType()\` roundtrip
- Add \`refugeeLanguage\` (\`OptionById[]\`) mapped from \`deal.profile.profileLanguage\`
- Load \`accompanying.postcode\` relation in \`GET /opportunity/:id\` (depends on #510)
- Fix \`parser-opportunity-patch-data\` to use \`appointmentLanguage\` field name
- Drop the now-pointless \`getTranslationType\` roundtrip in PATCH accompanying

## Why now

The SDK in \`node_modules\` is already 0.0.83, so develop's code referencing \`languageToTranslate\` produces two TypeScript errors. This PR fixes those.

## Schema mismatch warning

After this merges, the API response schema in \`sdk-types.json\` still promises \`languageToTranslate: integer\` while the DTO emits \`appointmentLanguage\` / \`refugeeLanguage\`. Fastify will silently strip the new fields from responses. Follow-up PR (re-do of #508) fixes this.

## Test plan

- [ ] \`yarn typecheck\` passes
- [ ] \`GET /opportunity/:id\` for an accompanying opportunity returns \`appointmentLanguage\` (after the #508 redo merges)
- [ ] \`PATCH /opportunity/:id\` with \`appointmentLanguage\` persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)