### PR TITLE
fix: restore ApiAccompanying response schema for SDK 0.0.83 (re-do of #508)

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -595,17 +595,7 @@
             "district": { "type": "string" }
           }
         },
-        "accompanyingDetails": {
-          "type": "object",
-          "properties": {
-            "appointmentAddress": { "type": "string" },
-            "appointmentDate": { "type": "string" },
-            "appointmentTime": { "type": "string" },
-            "refugeeNumber": { "type": "string" },
-            "refugeeName": { "type": "string" },
-            "languagesToTranslate": { "type": "integer" }
-          }
-        }
+        "accompanyingDetails": { "$ref": "ApiAccompanying#" }
       },
       "additionalProperties": false
     },

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -246,6 +246,11 @@
       "type": "string",
       "enum": ["opp-pending", "opp-matched", "opp-active", "opp-past"]
     },
+    "TranslatedIntoType": {
+      "$id": "TranslatedIntoType",
+      "type": "string",
+      "enum": ["deutsche", "englishOk", "noTranslation"]
+    },
     "OptionItem": {
       "$id": "OptionItem",
       "type": "object",
@@ -896,7 +901,11 @@
         "appointmentTime": { "type": "string" },
         "refugeeNumber": { "type": "string" },
         "refugeeName": { "type": "string" },
-        "languageToTranslate": { "type": "integer" }
+        "appointmentLanguage": { "$ref": "TranslatedIntoType#" },
+        "refugeeLanguage": {
+          "type": "array",
+          "items": { "$ref": "OptionById#" }
+        }
       }
     },
     "ApiOrganizationPatch": {


### PR DESCRIPTION
Re-applies #508/#509 after develop's history rewrite. **Stacked on #512** (DTO update) — base will auto-update to \`develop\` once #512 merges.

## Summary

- Add \`TranslatedIntoType\` enum definition to \`sdk-types.json\`
- Replace stale \`languageToTranslate: integer\` in \`ApiAccompanying\` with \`appointmentLanguage: TranslatedIntoType\` and \`refugeeLanguage: OptionById[]\`
- Replace inlined \`accompanyingDetails\` in \`ApiVolunteerOpportunityPatch\` with a \`$ref\` to \`ApiAccompanying\` so both schemas stay in sync

The DTO update (#506 redo, PR #512) makes the API emit \`appointmentLanguage\` / \`refugeeLanguage\` but the response schema still promises \`languageToTranslate\` — Fastify silently strips the new fields from every \`GET /opportunity/:id\` response. This PR fixes that mismatch.

## Test plan

- [ ] \`GET /opportunity/:id\` for an accompanying opportunity returns \`appointmentLanguage\` and \`refugeeLanguage\` in \`accompanyingDetails\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)