### PR TITLE
feat: restore accompanying DTO for SDK 0.0.83 (re-do of #506)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.3.3",
     "fastify-mailer": "^2.3.1",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "^0.0.82",
+    "need4deed-sdk": "^0.0.83",
     "nodemailer": "^7.0.4",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/data/entity/location/postcode.entity.ts
+++ b/src/data/entity/location/postcode.entity.ts
@@ -1,11 +1,11 @@
 import { IsNotEmpty } from "class-validator";
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
-
 import { IsPostcode } from "../../../services/validators/custom";
 import { Country, GermanCity } from "../../types";
 import Deal from "../deal.entity";
 import DistrictPostcode from "../m2m/district-postcode";
 import LocationPostcode from "../m2m/location-postcode";
+import Accompanying from "../opportunity/accompanying.entity";
 import Address from "./address.entity";
 
 @Entity()
@@ -47,4 +47,7 @@ export default class Postcode {
 
   @OneToMany(() => Deal, (deal) => deal.postcode)
   deal: Deal[];
+
+  @OneToMany(() => Accompanying, (accompanying) => accompanying.postcode)
+  accompanying: Accompanying[];
 }

--- a/src/data/entity/opportunity/accompanying.entity.ts
+++ b/src/data/entity/opportunity/accompanying.entity.ts
@@ -51,7 +51,7 @@ export default class Accompanying {
 
   @ManyToOne(() => Postcode, (postcode) => postcode.accompanying, {
     nullable: true,
-    onDelete: "CASCADE",
+    onDelete: "SET NULL",
   })
   @JoinColumn({ name: "postcode_id" })
   postcode?: Postcode;

--- a/src/data/entity/opportunity/accompanying.entity.ts
+++ b/src/data/entity/opportunity/accompanying.entity.ts
@@ -1,6 +1,14 @@
 import { IsDate, IsEnum, IsOptional, IsString } from "class-validator";
 import { TranslatedIntoType } from "need4deed-sdk";
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import Postcode from "../location/postcode.entity";
 import Opportunity from "./opportunity.entity";
 
 @Entity()
@@ -40,6 +48,13 @@ export default class Accompanying {
   @IsOptional()
   @IsEnum(TranslatedIntoType)
   languageToTranslate?: TranslatedIntoType;
+
+  @ManyToOne(() => Postcode, (postcode) => postcode.accompanying, {
+    nullable: true,
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "postcode_id" })
+  postcode?: Postcode;
 
   @OneToMany(() => Opportunity, (opportunity) => opportunity.accompanying)
   opportunity: Opportunity;

--- a/src/data/migrations/1778578280034-add-postcode-to-accompanying.ts
+++ b/src/data/migrations/1778578280034-add-postcode-to-accompanying.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPostcodeToAccompanying1778578280034
+  implements MigrationInterface
+{
+  name = "AddPostcodeToAccompanying1778578280034";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD "postcode_id" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb" FOREIGN KEY ("postcode_id") REFERENCES "postcode"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" DROP CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" DROP COLUMN "postcode_id"`,
+    );
+  }
+}

--- a/src/data/migrations/1778579676871-update-accompanying-postcode-fk-set-null.ts
+++ b/src/data/migrations/1778579676871-update-accompanying-postcode-fk-set-null.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateAccompanyingPostcodeFkSetNull1778579676871
+  implements MigrationInterface
+{
+  name = "UpdateAccompanyingPostcodeFkSetNull1778579676871";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" DROP CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb" FOREIGN KEY ("postcode_id") REFERENCES "postcode"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" DROP CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD CONSTRAINT "FK_a48f002dffae26a9642e2f7cefb" FOREIGN KEY ("postcode_id") REFERENCES "postcode"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/data/utils/get-postcode.ts
+++ b/src/data/utils/get-postcode.ts
@@ -1,0 +1,16 @@
+import { dataSource } from "../data-source";
+import Postcode from "../entity/location/postcode.entity";
+import { getRepository } from "./get-repository";
+
+export async function getPostcode(code: string): Promise<Postcode | null> {
+  const postcodeRepository = getRepository(dataSource, Postcode);
+
+  let postcode = await postcodeRepository.findOneBy({ value: code });
+
+  if (!postcode) {
+    postcode = new Postcode({ value: code });
+    await postcodeRepository.save(postcode);
+  }
+
+  return postcode;
+}

--- a/src/data/utils/index.ts
+++ b/src/data/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./fetch-json";
 export * from "./get-district";
+export * from "./get-postcode";
 export * from "./get-repository";
 export * from "./getLoggingForDataSource";
 export * from "./getRRULE";

--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -63,7 +63,7 @@ export default async function opportunityLegacyRoutes(
       opportunity.deal = await dealParserOpportunity(request.body);
       opportunity.accompanying =
         request.body.opportunity_type === "accompanying"
-          ? accompanyingParserOpportunity(request.body)
+          ? await accompanyingParserOpportunity(request.body)
           : undefined;
 
       const getAgentByPostcodeTryCatch = tryCatchFn(getAgentByPostcode, (err) =>

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -44,9 +44,7 @@ import {
   getOpportunityOrphanageAgent,
   getOpportunityWhere,
   getOrCreateTimeslot,
-  getTranslationType,
   patchEntity,
-  setTranslationType,
   updateOptionList,
 } from "../../utils";
 import opportunityLegacyRoutes from "./legacy.routes";
@@ -81,6 +79,7 @@ export default async function opportunityRoutes(
       const id = request.params.id;
       const relations = [
         "accompanying",
+        "accompanying.postcode",
         "deal.profile.profileLanguage.language",
         "deal.profile.profileActivity.activity",
         "deal.profile.profileSkill.skill",
@@ -132,12 +131,6 @@ export default async function opportunityRoutes(
       if (opportunityUpdates.length) {
         const opportunityRepository = fastify.db.opportunityRepository;
         await opportunityRepository.save(opportunityUpdates);
-      }
-
-      if (opportunityComments.accompanying) {
-        opportunityComments.accompanying.langCode = await setTranslationType(
-          opportunityComments.accompanying.languageToTranslate!, // TODO: this needs to be sorted
-        );
       }
 
       const data = dtoOpportunityGet(opportunityComments);
@@ -306,15 +299,9 @@ export default async function opportunityRoutes(
       }
 
       if (accompanying) {
-        const languageToTranslate = accompanying.languageToTranslate
-          ? await getTranslationType(Number(accompanying.languageToTranslate))
-          : undefined;
-        const patchData = languageToTranslate !== undefined
-          ? Object.assign(accompanying, { languageToTranslate })
-          : accompanying;
         const success = await patchEntity(
           Accompanying,
-          patchData,
+          accompanying,
           opportunity.accompanyingId,
         );
         if (!success) {

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -41,18 +41,7 @@ import logger from "../../../logger";
 import { volunteerSerializer } from "../../../services";
 import { tryCatch } from "../../../services/utils";
 
-export async function getPostcode(code: string): Promise<Postcode | null> {
-  const postcodeRepository = getRepository(dataSource, Postcode);
-
-  let postcode = await postcodeRepository.findOneBy({ value: code });
-
-  if (!postcode) {
-    postcode = new Postcode({ value: code });
-    await postcodeRepository.save(postcode);
-  }
-
-  return postcode;
-}
+export { getPostcode } from "../../../data/utils";
 
 export async function getProfileEntityByTitle<
   E extends new () => { title: string; id: number },

--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -1,8 +1,10 @@
-import { ApiOpportunityAccompanyingDetails } from "need4deed-sdk";
+import { ApiOpportunityAccompanyingDetails, OptionById } from "need4deed-sdk";
+import ProfileLanguage from "../../data/entity/m2m/profile-language";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
 
 export function dtoOpportunityAccompanying(
   accompanying: Accompanying,
+  profileLanguage: ProfileLanguage[] = [],
 ): ApiOpportunityAccompanyingDetails {
   return accompanying
     ? {
@@ -11,7 +13,10 @@ export function dtoOpportunityAccompanying(
         appointmentTime: `${String(accompanying.date.getUTCHours()).padStart(2, "0")}:${String(accompanying.date.getUTCMinutes()).padStart(2, "0")}`,
         refugeeNumber: accompanying.phone,
         refugeeName: accompanying.name,
-        languageToTranslate: accompanying.langCode,
+        appointmentLanguage: accompanying.languageToTranslate,
+        refugeeLanguage: profileLanguage
+          .filter(Boolean)
+          .map((pl): OptionById => ({ id: pl.language.id })),
       }
     : {};
 }

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -108,7 +108,10 @@ export function dtoVolunteerOpportunityGetList(
       })),
     availability:
       getAvailabilityTryCatch(opportunity.deal.time?.timeTimeslot) ?? [],
-    accompanyingDetails: dtoOpportunityAccompanying(opportunity.accompanying!),
+    accompanyingDetails: dtoOpportunityAccompanying(
+      opportunity.accompanying!,
+      opportunity.deal.profile.profileLanguage,
+    ),
     statusMatch: opportunity.statusMatch,
   } as ApiVolunteerOpportunityGetList;
 }
@@ -158,6 +161,7 @@ export function dtoOpportunityGet(
     agent: dtoOpportunityAgent(opportunityComments.agent!),
     accompanyingDetails: dtoOpportunityAccompanying(
       opportunityComments.accompanying!,
+      opportunityComments.deal.profile.profileLanguage,
     ),
     comments: opportunityComments.comments.map(commentSerializer),
     statusMatch: opportunityComments.statusMatch,

--- a/src/services/dto/parser-accompanying-legacy.ts
+++ b/src/services/dto/parser-accompanying-legacy.ts
@@ -1,16 +1,59 @@
 import { OpportunityLegacyFormData, TranslatedIntoType } from "need4deed-sdk";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
+import { getPostcode } from "../../server/utils/data/for-routes";
 
-export function accompanyingParserOpportunity(
+// Parses a datetime string as Europe/Berlin time when no timezone is specified.
+// Uses the Intl API so DST transitions (CET⇔CEST) are handled automatically.
+function parseAccompDatetime(value: string | undefined): Date {
+  if (!value) {
+    return new Date(NaN);
+  }
+  if (/Z|[+-]\d{2}:?\d{2}$/.test(value)) {
+    return new Date(value);
+  }
+
+  const asIfUtc = new Date(value + "Z");
+  if (isNaN(asIfUtc.getTime())) {
+    return asIfUtc;
+  }
+
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Europe/Berlin",
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    hour12: false,
+  }).formatToParts(asIfUtc);
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value ?? 0);
+  const berlinAsUtcMs = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour") % 24,
+    get("minute"),
+    get("second"),
+  );
+  return new Date(asIfUtc.getTime() - (berlinAsUtcMs - asIfUtc.getTime()));
+}
+
+export async function accompanyingParserOpportunity(
   body: OpportunityLegacyFormData,
-): Accompanying {
+): Promise<Accompanying> {
   const accompanying = new Accompanying({
     address: body.accomp_address,
     name: body.accomp_name,
     phone: body.accomp_phone,
-    date: new Date(body.accomp_datetime),
+    date: parseAccompDatetime(body.accomp_datetime),
     languageToTranslate: body.accomp_translation as TranslatedIntoType,
   });
+
+  if (body.accomp_postcode) {
+    accompanying.postcode = await getPostcode(body.accomp_postcode);
+  }
 
   return accompanying;
 }

--- a/src/services/dto/parser-accompanying-legacy.ts
+++ b/src/services/dto/parser-accompanying-legacy.ts
@@ -1,6 +1,6 @@
 import { OpportunityLegacyFormData, TranslatedIntoType } from "need4deed-sdk";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
-import { getPostcode } from "../../server/utils/data/for-routes";
+import { getPostcode } from "../../data/utils";
 
 // Parses a datetime string as Europe/Berlin time when no timezone is specified.
 // Uses the Intl API so DST transitions (CET⇔CEST) are handled automatically.

--- a/src/services/dto/parser-deal-opportunity.ts
+++ b/src/services/dto/parser-deal-opportunity.ts
@@ -22,11 +22,15 @@ import Profile from "../../data/entity/profile/profile.entity";
 import Skill from "../../data/entity/profile/skill.entity";
 import Time from "../../data/entity/time/time.entity";
 import Timeslot from "../../data/entity/time/timeslot.entity";
-import { getRepository, getRRULE, getStartEnd } from "../../data/utils";
+import {
+  getPostcode,
+  getRepository,
+  getRRULE,
+  getStartEnd,
+} from "../../data/utils";
 import logger from "../../logger";
 import {
   getLanguageTitle,
-  getPostcode,
   getProfileEntityByTitle,
   getTimeslot,
 } from "../../server/utils";

--- a/src/services/dto/parser-deal-volunteer.ts
+++ b/src/services/dto/parser-deal-volunteer.ts
@@ -18,12 +18,8 @@ import Language from "../../data/entity/profile/language.entity";
 import Profile from "../../data/entity/profile/profile.entity";
 import Skill from "../../data/entity/profile/skill.entity";
 import Time from "../../data/entity/time/time.entity";
-import { getRRULE, getStartEnd } from "../../data/utils";
-import {
-  getPostcode,
-  getProfileEntityByTitle,
-  getTimeslot,
-} from "../../server/utils";
+import { getPostcode, getRRULE, getStartEnd } from "../../data/utils";
+import { getProfileEntityByTitle, getTimeslot } from "../../server/utils";
 
 export async function dealParser(formData: VolunteerFormData): Promise<Deal> {
   // postcode

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -1,7 +1,6 @@
 import {
   ApiOpportunityPatch,
   LangPurpose,
-  TranslatedIntoType,
 } from "need4deed-sdk";
 import { getNameFields } from "..";
 import { BadRequestError } from "../../config";
@@ -50,8 +49,7 @@ export function parseOpportunity(body: ApiOpportunityPatch) {
                 : undefined,
             phone: body.accompanyingDetails?.refugeeNumber,
             name: body.accompanyingDetails?.refugeeName,
-            languageToTranslate: body.accompanyingDetails
-              ?.languageToTranslate as unknown as TranslatedIntoType,
+            languageToTranslate: body.accompanyingDetails?.appointmentLanguage,
           } as Partial<Accompanying>)
         : {},
       languages: [

--- a/src/services/dto/parser-volunteer-form.ts
+++ b/src/services/dto/parser-volunteer-form.ts
@@ -2,7 +2,7 @@ import { VolunteerFormData } from "need4deed-sdk";
 import Address from "../../data/entity/location/address.entity";
 import Person from "../../data/entity/person.entity";
 import Volunteer from "../../data/entity/volunteer/volunteer.entity";
-import { getPostcode } from "../../server/utils";
+import { getPostcode } from "../../data/utils";
 import { dealParser } from "./parser-deal-volunteer";
 import { getNameFields } from "./utils";
 

--- a/src/test/services/dto/parser-accompanying-legacy.test.ts
+++ b/src/test/services/dto/parser-accompanying-legacy.test.ts
@@ -1,0 +1,55 @@
+import { OpportunityLegacyFormData, TranslatedIntoType } from "need4deed-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { accompanyingParserOpportunity } from "../../../services/dto/parser-accompanying-legacy";
+
+const { mockPostcode, getPostcodeMock } = vi.hoisted(() => {
+  const mockPostcode = { id: 1, value: "10115" };
+  return {
+    mockPostcode,
+    getPostcodeMock: vi.fn().mockResolvedValue(mockPostcode),
+  };
+});
+
+vi.mock("../../../data/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../data/utils")>()),
+  getPostcode: getPostcodeMock,
+}));
+
+const baseBody = {
+  accomp_address: "Musterstraße 1",
+  accomp_name: "Jane Doe",
+  accomp_phone: "030123456",
+  accomp_datetime: "2026-06-01T10:00:00Z",
+  accomp_translation: TranslatedIntoType.DEUTSCHE,
+} as unknown as OpportunityLegacyFormData;
+
+describe("accompanyingParserOpportunity", () => {
+  it("maps base fields correctly", async () => {
+    const result = await accompanyingParserOpportunity(baseBody);
+
+    expect(result.address).toBe("Musterstraße 1");
+    expect(result.name).toBe("Jane Doe");
+    expect(result.phone).toBe("030123456");
+    expect(result.languageToTranslate).toBe(TranslatedIntoType.DEUTSCHE);
+    expect(result.date).toBeInstanceOf(Date);
+    expect(isNaN(result.date.getTime())).toBe(false);
+  });
+
+  it("resolves and assigns postcode entity when accomp_postcode is provided", async () => {
+    const body = {
+      ...baseBody,
+      accomp_postcode: "10115",
+    } as unknown as OpportunityLegacyFormData;
+
+    const result = await accompanyingParserOpportunity(body);
+
+    expect(result.postcode).toBe(mockPostcode);
+    expect(result.postcode?.value).toBe("10115");
+  });
+
+  it("leaves postcode undefined when accomp_postcode is absent", async () => {
+    const result = await accompanyingParserOpportunity(baseBody);
+
+    expect(result.postcode).toBeUndefined();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,10 +3825,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.82:
-  version "0.0.82"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.82.tgz#a1e85c26bc496fffc1d9fbdf3bef0ab211919ff5"
-  integrity sha512-Wqt/p62QY3AAzkGWAvE7NG/0XQ/lC8rrXKTI2OHRT7NIsrENtT01EQ+lKXnnQQOUQT82COTR62KAe16PQ8FqpA==
+need4deed-sdk@^0.0.83:
+  version "0.0.83"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.83.tgz#6940f34ae33ba96c58f6e21a3b8ade58d17e5440"
+  integrity sha512-DvLFddWLj017c8HmZ79FWE/0LUuu/k1/orJUnl3eX/1ZH6mubKKegnKaU0Bew6366z5QOeC/SelCQevWRfrDsg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Replaces #512 (auto-closed when #510's branch was deleted on merge). Same content, retargeted to \`develop\`.

## Summary

- Bump \`need4deed-sdk\` to \`^0.0.83\`
- Replace \`languageToTranslate\` (number/langCode) with \`appointmentLanguage\` (\`TranslatedIntoType\`) — reads enum value directly from entity, removes the \`setTranslationType()\` roundtrip
- Add \`refugeeLanguage\` (\`OptionById[]\`) mapped from \`deal.profile.profileLanguage\`
- Load \`accompanying.postcode\` relation in \`GET /opportunity/:id\` (now available from #510)
- Fix \`parser-opportunity-patch-data\` to use \`appointmentLanguage\` field name
- Drop the now-pointless \`getTranslationType\` roundtrip in PATCH accompanying

## Schema mismatch warning

After this merges, the API response schema in \`sdk-types.json\` still promises \`languageToTranslate: integer\` while the DTO emits \`appointmentLanguage\` / \`refugeeLanguage\`. Fastify will silently strip the new fields from responses. Follow-up PR #513 fixes this.

## Test plan

- [ ] \`yarn typecheck\` passes (it does locally)
- [ ] \`GET /opportunity/:id\` for an accompanying opportunity returns \`appointmentLanguage\` (after #513 merges)
- [ ] \`PATCH /opportunity/:id\` with \`appointmentLanguage\` persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)