### PR TITLE
fix(#438): add opp-inactive to OpportunityStatusType schema; add activity filter

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -622,7 +622,7 @@
     "OpportunityStatusType": {
       "$id": "OpportunityStatusType",
       "type": "string",
-      "enum": ["opp-new", "opp-searching", "opp-active", "opp-past"]
+      "enum": ["opp-new", "opp-searching", "opp-active", "opp-inactive", "opp-past"]
     },
     "ApiOpportunityGetList": {
       "$id": "ApiOpportunityGetList",

--- a/src/server/utils/data/get-opportunity-where.ts
+++ b/src/server/utils/data/get-opportunity-where.ts
@@ -48,5 +48,18 @@ export function getOpportunityWhere(
           },
         }
       : {}),
+    ...(filter?.activity
+      ? {
+          deal: {
+            profile: {
+              profileActivity: {
+                activity: {
+                  id: normalizeStringArrayInput(filter.activity),
+                },
+              },
+            },
+          },
+        }
+      : {}),
   } as FindOptionsWhere<Opportunity>;
 }


### PR DESCRIPTION
## Summary

- Adds `"opp-inactive"` to `OpportunityStatusType` enum in `src/server/schema/sdk-types.json` so Fastify's AJV validator accepts the value
- Adds activity filter support to `getOpportunityWhere` utility

## Root cause

The BE migration `1777284365646-add-inactive-to-opp-status.ts` added `opp-inactive` to the PostgreSQL enum, but the JSON schema used by Fastify for request validation (`sdk-types.json`) was never updated — causing a 400 "Validation failed" error whenever the FE sends `opp-inactive` as a status value.

## Related

- Closes https://github.com/need4deed-org/be/issues/438
- Closes https://github.com/need4deed-org/fe/issues/459

🤖 Generated with [Claude Code](https://claude.com/claude-code)