### PR TITLE
feat: emit appointmentPostcode and appointmentDistrict in GET /opportunity/:id

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.3.3",
     "fastify-mailer": "^2.3.1",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "^0.0.83",
+    "need4deed-sdk": "^0.0.84",
     "nodemailer": "^7.0.4",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -17,6 +17,7 @@ import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
+import { getDistrictFromPostcode } from "../../../data/utils/get-district";
 import logger from "../../../logger";
 import {
   dtoOpportunityGet,
@@ -133,7 +134,13 @@ export default async function opportunityRoutes(
         await opportunityRepository.save(opportunityUpdates);
       }
 
-      const data = dtoOpportunityGet(opportunityComments);
+      const accompanyingDistrict = opportunityComments.accompanying?.postcode
+        ? await getDistrictFromPostcode(
+            opportunityComments.accompanying.postcode,
+          )
+        : null;
+
+      const data = dtoOpportunityGet(opportunityComments, accompanyingDistrict);
 
       return reply.status(200).send({ message: `Opportunity id:${id}`, data });
     },

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -895,7 +895,9 @@
         "refugeeLanguage": {
           "type": "array",
           "items": { "$ref": "OptionById#" }
-        }
+        },
+        "appointmentPostcode": { "$ref": "OptionById#" },
+        "appointmentDistrict": { "$ref": "OptionById#" }
       }
     },
     "ApiOrganizationPatch": {

--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -1,10 +1,12 @@
 import { ApiOpportunityAccompanyingDetails, OptionById } from "need4deed-sdk";
+import District from "../../data/entity/location/district.entity";
 import ProfileLanguage from "../../data/entity/m2m/profile-language";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
 
 export function dtoOpportunityAccompanying(
   accompanying: Accompanying,
   profileLanguage: ProfileLanguage[] = [],
+  district?: District | null,
 ): ApiOpportunityAccompanyingDetails {
   return accompanying
     ? {
@@ -17,6 +19,10 @@ export function dtoOpportunityAccompanying(
         refugeeLanguage: profileLanguage
           .filter(Boolean)
           .map((pl): OptionById => ({ id: pl.language.id })),
+        ...(accompanying.postcode
+          ? { appointmentPostcode: { id: accompanying.postcode.id } }
+          : {}),
+        ...(district ? { appointmentDistrict: { id: district.id } } : {}),
       }
     : {};
 }

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -6,6 +6,7 @@ import {
   OpportunityType,
 } from "need4deed-sdk";
 import Comment from "../../data/entity/comment.entity";
+import District from "../../data/entity/location/district.entity";
 import Opportunity from "../../data/entity/opportunity/opportunity.entity";
 import logger from "../../logger";
 import { tryCatchFn } from "../utils";
@@ -118,6 +119,7 @@ export function dtoVolunteerOpportunityGetList(
 
 export function dtoOpportunityGet(
   opportunityComments: Opportunity & { comments: Comment[] },
+  accompanyingDistrict?: District | null,
 ): ApiOpportunityGet {
   return {
     id: opportunityComments.id,
@@ -162,6 +164,7 @@ export function dtoOpportunityGet(
     accompanyingDetails: dtoOpportunityAccompanying(
       opportunityComments.accompanying!,
       opportunityComments.deal.profile.profileLanguage,
+      accompanyingDistrict,
     ),
     comments: opportunityComments.comments.map(commentSerializer),
     statusMatch: opportunityComments.statusMatch,

--- a/src/test/services/dto/dto-accompanying.test.ts
+++ b/src/test/services/dto/dto-accompanying.test.ts
@@ -1,0 +1,104 @@
+import { TranslatedIntoType } from "need4deed-sdk";
+import { describe, expect, it } from "vitest";
+import District from "../../../data/entity/location/district.entity";
+import Postcode from "../../../data/entity/location/postcode.entity";
+import ProfileLanguage from "../../../data/entity/m2m/profile-language";
+import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
+import { dtoOpportunityAccompanying } from "../../../services/dto/dto-accompanying";
+
+const buildAccompanying = (overrides: Partial<Accompanying> = {}) =>
+  new Accompanying({
+    address: "Musterstraße 1",
+    name: "Jane Doe",
+    phone: "030123456",
+    date: new Date("2026-06-01T10:30:00Z"),
+    languageToTranslate: TranslatedIntoType.DEUTSCHE,
+    ...overrides,
+  });
+
+const buildProfileLanguage = (languageId: number) =>
+  new ProfileLanguage({
+    language: { id: languageId } as ProfileLanguage["language"],
+  });
+
+describe("dtoOpportunityAccompanying", () => {
+  it("returns an empty object when accompanying is falsy", () => {
+    expect(dtoOpportunityAccompanying(null as unknown as Accompanying)).toEqual(
+      {},
+    );
+  });
+
+  it("maps base fields", () => {
+    const result = dtoOpportunityAccompanying(buildAccompanying());
+
+    expect(result.appointmentAddress).toBe("Musterstraße 1");
+    expect(result.refugeeName).toBe("Jane Doe");
+    expect(result.refugeeNumber).toBe("030123456");
+    expect(result.appointmentLanguage).toBe(TranslatedIntoType.DEUTSCHE);
+    expect(result.appointmentDate).toBe(
+      new Date("2026-06-01T10:30:00Z").toDateString(),
+    );
+    expect(result.appointmentTime).toBe("10:30");
+    expect(result.refugeeLanguage).toEqual([]);
+  });
+
+  it("maps refugeeLanguage from profileLanguage, skipping falsy entries", () => {
+    const result = dtoOpportunityAccompanying(buildAccompanying(), [
+      buildProfileLanguage(7),
+      null as unknown as ProfileLanguage,
+      buildProfileLanguage(9),
+    ]);
+
+    expect(result.refugeeLanguage).toEqual([{ id: 7 }, { id: 9 }]);
+  });
+
+  it("omits appointmentPostcode when accompanying.postcode is absent", () => {
+    const result = dtoOpportunityAccompanying(buildAccompanying());
+
+    expect(result).not.toHaveProperty("appointmentPostcode");
+  });
+
+  it("emits appointmentPostcode { id } when accompanying.postcode is loaded", () => {
+    const postcode = new Postcode({ id: 42, value: "10115" });
+    const result = dtoOpportunityAccompanying(buildAccompanying({ postcode }));
+
+    expect(result.appointmentPostcode).toEqual({ id: 42 });
+  });
+
+  it("omits appointmentDistrict when district is undefined", () => {
+    const result = dtoOpportunityAccompanying(buildAccompanying());
+
+    expect(result).not.toHaveProperty("appointmentDistrict");
+  });
+
+  it("omits appointmentDistrict when district is null", () => {
+    const result = dtoOpportunityAccompanying(buildAccompanying(), [], null);
+
+    expect(result).not.toHaveProperty("appointmentDistrict");
+  });
+
+  it("emits appointmentDistrict { id } when district is provided", () => {
+    const district = new District({ id: 3, title: "Mitte" });
+    const result = dtoOpportunityAccompanying(
+      buildAccompanying(),
+      [],
+      district,
+    );
+
+    expect(result.appointmentDistrict).toEqual({ id: 3 });
+  });
+
+  it("emits both appointmentPostcode and appointmentDistrict together", () => {
+    const postcode = new Postcode({ id: 42, value: "10115" });
+    const district = new District({ id: 3, title: "Mitte" });
+
+    const result = dtoOpportunityAccompanying(
+      buildAccompanying({ postcode }),
+      [],
+      district,
+    );
+
+    expect(result.appointmentPostcode).toEqual({ id: 42 });
+    expect(result.appointmentDistrict).toEqual({ id: 3 });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,10 +3825,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.83:
-  version "0.0.83"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.83.tgz#6940f34ae33ba96c58f6e21a3b8ade58d17e5440"
-  integrity sha512-DvLFddWLj017c8HmZ79FWE/0LUuu/k1/orJUnl3eX/1ZH6mubKKegnKaU0Bew6366z5QOeC/SelCQevWRfrDsg==
+need4deed-sdk@^0.0.84:
+  version "0.0.84"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.84.tgz#ae691467c11140d9269135c71cb94f0eae7f5685"
+  integrity sha512-v4QltNqZ1cLO50ufPm085mgjpC61FAOgpXoxeQDyQS3qzdyTTs99il8h2DaVFNgSyyPIQcw17VL8QkEfZC9U+A==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Closes #517

## Summary

- Bump \`need4deed-sdk\` to \`^0.0.84\` (adds \`appointmentPostcode\` and \`appointmentDistrict\` to \`ApiOpportunityAccompanyingDetails\`)
- Emit \`appointmentPostcode\` from \`accompanying.postcode\` (already loaded as a relation by the route)
- Derive \`appointmentDistrict\` via the existing \`getDistrictFromPostcode\` helper in the route handler, then pass it into \`dtoOpportunityGet\` / \`dtoOpportunityAccompanying\` (keeps the DTO a pure sync transform)
- Add \`appointmentPostcode\` and \`appointmentDistrict\` to the \`ApiAccompanying\` response schema in \`sdk-types.json\` so Fastify doesn't strip them

## Scope note

Only \`GET /opportunity/:id\` is updated. The list endpoints (\`dtoOpportunityGetList\`, \`dtoVolunteerOpportunityGetList\`) still call \`dtoOpportunityAccompanying\` without a district argument — they continue to return the same shape they did before. If the FE needs these two fields in list responses too, that can be a follow-up.

## Test plan

- [ ] \`GET /opportunity/:id\` for an accompanying opportunity with a postcode returns \`appointmentPostcode: { id }\`
- [ ] When that postcode maps to a district, the response also includes \`appointmentDistrict: { id }\`
- [ ] When there's no postcode, neither field is present
- [ ] \`yarn typecheck\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)