### PR TITLE
chore: upgrade need4deed-sdk to 0.0.85 (appointmentPostcode -> string)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.3.3",
     "fastify-mailer": "^2.3.1",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "^0.0.84",
+    "need4deed-sdk": "0.0.85",
     "nodemailer": "^7.0.4",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -306,15 +306,15 @@ export default async function opportunityRoutes(
       }
 
       if (accompanying) {
-        const appointmentPostcodeId =
-          request.body.accompanyingDetails?.appointmentPostcode?.id;
-        if (appointmentPostcodeId !== undefined) {
+        const appointmentPostcodeValue =
+          request.body.accompanyingDetails?.appointmentPostcode;
+        if (appointmentPostcodeValue !== undefined) {
           const postcode = await fastify.db.postcodeRepository.findOneBy({
-            id: Number(appointmentPostcodeId),
+            value: appointmentPostcodeValue,
           });
           if (!postcode) {
             throw new BadRequestError(
-              `Postcode id:${appointmentPostcodeId} not found.`,
+              `Postcode "${appointmentPostcodeValue}" not found.`,
             );
           }
           accompanying.postcode = postcode;

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -896,7 +896,7 @@
           "type": "array",
           "items": { "$ref": "OptionById#" }
         },
-        "appointmentPostcode": { "$ref": "OptionById#" },
+        "appointmentPostcode": { "type": "string" },
         "appointmentDistrict": { "$ref": "OptionById#" }
       }
     },
@@ -914,7 +914,7 @@
           "type": "array",
           "items": { "$ref": "OptionById#" }
         },
-        "appointmentPostcode": { "$ref": "OptionById#" }
+        "appointmentPostcode": { "type": "string" }
       },
       "additionalProperties": false
     },

--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -19,8 +19,8 @@ export function dtoOpportunityAccompanying(
         refugeeLanguage: profileLanguage
           .filter(Boolean)
           .map((pl): OptionById => ({ id: pl.language.id })),
-        ...(accompanying.postcode
-          ? { appointmentPostcode: { id: accompanying.postcode.id } }
+        ...(accompanying.postcode?.value
+          ? { appointmentPostcode: accompanying.postcode.value }
           : {}),
         ...(district ? { appointmentDistrict: { id: district.id } } : {}),
       }

--- a/src/test/services/dto/dto-accompanying.test.ts
+++ b/src/test/services/dto/dto-accompanying.test.ts
@@ -58,11 +58,11 @@ describe("dtoOpportunityAccompanying", () => {
     expect(result).not.toHaveProperty("appointmentPostcode");
   });
 
-  it("emits appointmentPostcode { id } when accompanying.postcode is loaded", () => {
+  it("emits appointmentPostcode value when accompanying.postcode is loaded", () => {
     const postcode = new Postcode({ id: 42, value: "10115" });
     const result = dtoOpportunityAccompanying(buildAccompanying({ postcode }));
 
-    expect(result.appointmentPostcode).toEqual({ id: 42 });
+    expect(result.appointmentPostcode).toBe("10115");
   });
 
   it("omits appointmentDistrict when district is undefined", () => {
@@ -98,7 +98,7 @@ describe("dtoOpportunityAccompanying", () => {
       district,
     );
 
-    expect(result.appointmentPostcode).toEqual({ id: 42 });
+    expect(result.appointmentPostcode).toBe("10115");
     expect(result.appointmentDistrict).toEqual({ id: 3 });
   });
 });

--- a/src/test/services/dto/parser-opportunity-patch-data.test.ts
+++ b/src/test/services/dto/parser-opportunity-patch-data.test.ts
@@ -51,7 +51,7 @@ describe("parseOpportunity", () => {
   it("does not set accompanying.postcode (resolved in route handler instead)", () => {
     const result = parseOpportunity({
       accompanyingDetails: {
-        appointmentPostcode: { id: 42 },
+        appointmentPostcode: "10115",
       },
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,10 +3825,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@^0.0.84:
-  version "0.0.84"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.84.tgz#ae691467c11140d9269135c71cb94f0eae7f5685"
-  integrity sha512-v4QltNqZ1cLO50ufPm085mgjpC61FAOgpXoxeQDyQS3qzdyTTs99il8h2DaVFNgSyyPIQcw17VL8QkEfZC9U+A==
+need4deed-sdk@0.0.85:
+  version "0.0.85"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.85.tgz#297b455e3e20fd2a8724cdea78d0d2db2edd0509"
+  integrity sha512-yIKwEGvaKb0JsIeeZKbPs7aceSYA7HhINTZuoa2cUmw6LUDr7lczGjmB63z4585mprEoLyz/dKBg+L9Yk/9x9A==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
- Bump `need4deed-sdk` 0.0.84 → 0.0.85
- SDK 0.0.85 changes `ApiOpportunityAccompanyingDetails.appointmentPostcode` from `OptionById` to `string` (the postcode value, e.g. `"10115"`); `appointmentDistrict` is unchanged
- GET `/opportunity/:id`: dto now emits `accompanying.postcode.value` (string) instead of `{ id }`; response schema updated
- PATCH `/opportunity/:id`: body schema accepts `appointmentPostcode` as a string; route resolves the postcode via `findOneBy({ value })` and returns a 400 referencing the value when not found
- POST `/opportunity/legacy`: no change. `OpportunityLegacyFormData.accomp_postcode` was already `string` in 0.0.84 and remains so; `accompanyingParserOpportunity` already resolves via `getPostcode(string)`

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn test:run` — 158/158 pass (including updated `dto-accompanying` and `parser-opportunity-patch-data` tests)
- [x] `yarn lint` — error count unchanged (21 pre-existing, none in touched files)
- [ ] Manual: GET `/opportunity/:id` for an opportunity with an accompanying postcode → `appointmentPostcode` is the string value
- [ ] Manual: PATCH `/opportunity/:id` with `accompanyingDetails.appointmentPostcode: "10115"` persists; unknown value returns 400 with the value in the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)