### PR TITLE
fix(#375): return ISO date from accompanying DTO; save date without time

### DIFF
--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -11,7 +11,7 @@ export function dtoOpportunityAccompanying(
   return accompanying
     ? {
         appointmentAddress: accompanying.address,
-        appointmentDate: accompanying.date.toDateString(),
+        appointmentDate: accompanying.date.toISOString().split("T")[0],
         appointmentTime: `${String(accompanying.date.getUTCHours()).padStart(2, "0")}:${String(accompanying.date.getUTCMinutes()).padStart(2, "0")}`,
         refugeeNumber: accompanying.phone,
         refugeeName: accompanying.name,

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -51,14 +51,12 @@ export function parseOpportunity(body: ApiOpportunityPatch) {
       accompanying: accompanyingDetails
         ? ({
             address: accompanyingDetails.appointmentAddress,
-            date:
-              accompanyingDetails.appointmentDate &&
-              accompanyingDetails.appointmentTime
-                ? getDateObj(
-                    accompanyingDetails.appointmentDate,
-                    accompanyingDetails.appointmentTime,
-                  )
-                : undefined,
+            date: accompanyingDetails.appointmentDate
+              ? getDateObj(
+                  accompanyingDetails.appointmentDate,
+                  accompanyingDetails.appointmentTime || "00:00",
+                )
+              : undefined,
             phone: accompanyingDetails.refugeeNumber,
             name: accompanyingDetails.refugeeName,
             languageToTranslate: accompanyingDetails.appointmentLanguage,


### PR DESCRIPTION
## Summary

Two bugs in the accompanying details flow that caused the date field to break:

1. **`dto-accompanying.ts`** — `toDateString()` returns a locale-dependent string like `"Mon Apr 27 2026"` which the FE date picker (`new Date(str)`) can't reliably parse. Changed to `toISOString().split("T")[0]` → `"2026-04-27"`.

2. **`parser-opportunity-patch-data.ts`** — Date was silently discarded when `appointmentTime` was absent from the PATCH body (`date && time ? save : undefined`). Changed to only require `appointmentDate`, defaulting time to `"00:00"` if missing.

## Related

- Closes https://github.com/need4deed-org/be/issues/450
- Closes https://github.com/need4deed-org/fe/issues/375

🤖 Generated with [Claude Code](https://claude.com/claude-code)