### PR TITLE
test(#222): add schema sync check

### DIFF
--- a/src/test/data/index.test.ts
+++ b/src/test/data/index.test.ts
@@ -25,3 +25,44 @@ describe("TypeORM Sanity Check", () => {
     expect(count).toBeGreaterThanOrEqual(0);
   });
 });
+
+describe("Schema Sync Check", () => {
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = await createTestServer();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  it("should have entity metadata registered for all core entities", () => {
+    const ds = fastify.db.userRepository.manager.dataSource;
+    const entityNames = ds.entityMetadatas.map((m) => m.name);
+    expect(entityNames).toContain("User");
+    expect(entityNames).toContain("Volunteer");
+    expect(entityNames).toContain("Opportunity");
+    expect(entityNames).toContain("Agent");
+    expect(entityNames).toContain("Deal");
+    expect(entityNames.length).toBeGreaterThan(10);
+  });
+
+  it("should have a DB table for every registered entity", async () => {
+    const ds = fastify.db.userRepository.manager.dataSource;
+    for (const metadata of ds.entityMetadatas) {
+      if (metadata.tableType === "view") continue;
+      const result: { exists: string }[] = await ds.query(
+        `SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_schema = 'public' AND table_name = $1
+        )`,
+        [metadata.tableName],
+      );
+      expect(
+        result[0].exists,
+        `Table "${metadata.tableName}" (entity: ${metadata.name}) is missing from the database`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `Schema Sync Check` suite to `src/test/data/index.test.ts`
- Verifies all core entity names are registered in TypeORM metadata (User, Volunteer, Opportunity, Agent, Deal)
- Queries `information_schema.tables` to confirm every registered entity has a matching DB table, skipping view entities

## Test plan
- [ ] Run `yarn test:run` with a running DB and confirm both new tests pass
- [ ] Confirm `VolunteerListMV` (a `@ViewEntity`) is correctly skipped by the `tableType === "view"` guard

Closes https://github.com/need4deed-org/be/issues/222

🤖 Generated with [Claude Code](https://claude.com/claude-code)