### PR TITLE
test(#225): add unit tests for missing DTO serializers

### DIFF
--- a/src/test/services/dto/dto-appreciation.test.ts
+++ b/src/test/services/dto/dto-appreciation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { dtoAppreciation } from "../../../services/dto/dto-appreciation";
+
+describe("dtoAppreciation", () => {
+  const base = {
+    id: 1,
+    title: "T-shirt",
+    dateDue: new Date("2025-01-01"),
+    dateDelivery: new Date("2025-02-01"),
+    volunteerId: 10,
+    opportunityId: 20,
+    userId: 5,
+  };
+
+  it("maps all fields from the entity", () => {
+    const result = dtoAppreciation(base as any);
+    expect(result).toEqual({
+      id: 1,
+      title: "T-shirt",
+      dateDue: base.dateDue,
+      dateDelivery: base.dateDelivery,
+      volunteerId: 10,
+      opportunityId: 20,
+      userId: 5,
+    });
+  });
+
+  it("passes through null/undefined optional fields", () => {
+    const result = dtoAppreciation({
+      ...base,
+      dateDue: undefined,
+      dateDelivery: undefined,
+      opportunityId: undefined,
+      userId: undefined,
+    } as any);
+    expect(result.dateDue).toBeUndefined();
+    expect(result.dateDelivery).toBeUndefined();
+    expect(result.opportunityId).toBeUndefined();
+    expect(result.userId).toBeUndefined();
+  });
+});

--- a/src/test/services/dto/dto-comment.test.ts
+++ b/src/test/services/dto/dto-comment.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { commentSerializer } from "../../../services/dto/dto-comment";
+
+describe("commentSerializer", () => {
+  it("maps all comment fields correctly", () => {
+    const comment = {
+      id: 7,
+      text: "Great volunteer!",
+      entityId: 42,
+      entityType: "volunteer",
+      updatedAt: new Date("2025-03-10"),
+      user: { person: { name: "Coordinator Jane" } },
+    };
+
+    const result = commentSerializer(comment as any);
+
+    expect(result).toEqual({
+      id: 7,
+      content: "Great volunteer!",
+      entityId: 42,
+      entityType: "volunteer",
+      authorName: "Coordinator Jane",
+      timestamp: comment.updatedAt,
+    });
+  });
+
+  it("returns undefined authorName when user has no person", () => {
+    const comment = {
+      id: 8,
+      text: "Note",
+      entityId: 1,
+      entityType: "opportunity",
+      updatedAt: new Date(),
+      user: {},
+    };
+
+    const result = commentSerializer(comment as any);
+    expect(result.authorName).toBeUndefined();
+  });
+
+  it("returns undefined authorName when user is missing", () => {
+    const comment = {
+      id: 9,
+      text: "Note",
+      entityId: 1,
+      entityType: "opportunity",
+      updatedAt: new Date(),
+    };
+
+    const result = commentSerializer(comment as any);
+    expect(result.authorName).toBeUndefined();
+  });
+});

--- a/src/test/services/dto/dto-document.test.ts
+++ b/src/test/services/dto/dto-document.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { documentSerializer } from "../../../services/dto/dto-document";
+
+vi.mock("../../../server/utils", () => ({
+  getDocumentUrl: vi.fn((key: string) => `https://cdn.example.com/${key}`),
+}));
+
+describe("documentSerializer", () => {
+  it("maps all document fields and builds the URL from s3Key", () => {
+    const doc = {
+      id: 3,
+      type: "cgc",
+      originalName: "certificate.pdf",
+      s3Key: "docs/user-1/certificate.pdf",
+      mimeType: "application/pdf",
+      createdAt: new Date("2025-01-15"),
+    };
+
+    const result = documentSerializer(doc as any);
+
+    expect(result).toEqual({
+      id: 3,
+      type: "cgc",
+      originalName: "certificate.pdf",
+      url: "https://cdn.example.com/docs/user-1/certificate.pdf",
+      mimeType: "application/pdf",
+      createdAt: doc.createdAt,
+    });
+  });
+
+  it("calls getDocumentUrl with the s3Key", async () => {
+    const { getDocumentUrl } = await import("../../../server/utils");
+    const doc = {
+      id: 4,
+      type: "passport",
+      originalName: "id.jpg",
+      s3Key: "docs/user-2/id.jpg",
+      mimeType: "image/jpeg",
+      createdAt: new Date(),
+    };
+
+    documentSerializer(doc as any);
+    expect(getDocumentUrl).toHaveBeenCalledWith("docs/user-2/id.jpg");
+  });
+});

--- a/src/test/services/dto/dto-opportunity-volunteer.test.ts
+++ b/src/test/services/dto/dto-opportunity-volunteer.test.ts
@@ -1,0 +1,81 @@
+import { OpportunityVolunteerStatusType } from "need4deed-sdk";
+import { describe, expect, it, vi } from "vitest";
+import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
+import {
+  opportunityOpportunityVolunteerDTO,
+  volunteerOpportunityVolunteerDTO,
+} from "../../../services/dto/dto-opportunity-volunteer";
+
+vi.mock("../../../services/dto/utils", () => ({
+  getOptionItems: vi.fn(() => [{ id: 1, title: "Reading" }]),
+  getLanguages: vi.fn(() => [{ id: "en", title: "English", proficiency: "fluent" }]),
+  getAvailability: vi.fn(() => [{ id: 1, day: "MO", daytime: "08-11" }]),
+}));
+
+function makeOV(overrides: Partial<OpportunityVolunteer> = {}): OpportunityVolunteer {
+  return new OpportunityVolunteer({
+    id: 1,
+    status: OpportunityVolunteerStatusType.APPLIED,
+    volunteerId: 10,
+    opportunityId: 20,
+    updatedAt: new Date("2025-01-01"),
+    opportunity: { title: "German Lessons" } as any,
+    volunteer: {
+      statusType: "regular",
+      statusEngagement: "active",
+      person: { name: "Jane Doe", avatarUrl: "https://cdn.example.com/a.png" },
+      deal: {
+        profile: { profileActivity: [], profileSkill: [], profileLanguage: [] },
+        time: { timeTimeslot: [] },
+        location: { locationDistrict: [] },
+      },
+    } as any,
+    ...overrides,
+  });
+}
+
+describe("volunteerOpportunityVolunteerDTO", () => {
+  it("returns the expected shape for a valid OpportunityVolunteer", () => {
+    const ov = makeOV();
+    const result = volunteerOpportunityVolunteerDTO(ov);
+
+    expect(result.id).toBe(1);
+    expect(result.status).toBe(OpportunityVolunteerStatusType.APPLIED);
+    expect(result.volunteerId).toBe(10);
+    expect(result.opportunityId).toBe(20);
+    expect(result.title).toBe("German Lessons");
+    expect(result.updatedAt).toEqual(new Date("2025-01-01"));
+  });
+
+  it("throws when the input is not an OpportunityVolunteer instance", () => {
+    const plain = { id: 1 } as any;
+    expect(() => volunteerOpportunityVolunteerDTO(plain)).toThrow(
+      "Wrong opportunity-volunteer format.",
+    );
+  });
+});
+
+describe("opportunityOpportunityVolunteerDTO", () => {
+  it("returns the expected shape including volunteer details", () => {
+    const ov = makeOV();
+    const result = opportunityOpportunityVolunteerDTO(ov);
+
+    expect(result.id).toBe(1);
+    expect(result.volunteerId).toBe(10);
+    expect(result.opportunityId).toBe(20);
+    expect(result.name).toBe("Jane Doe");
+    expect(result.avatarUrl).toBe("https://cdn.example.com/a.png");
+    expect(result.volunteeringType).toBe("regular");
+    expect(result.engagement).toBe("active");
+    expect(result.activities).toBeDefined();
+    expect(result.languages).toBeDefined();
+    expect(result.availability).toBeDefined();
+    expect(result.locations).toBeDefined();
+  });
+
+  it("throws when the input is not an OpportunityVolunteer instance", () => {
+    expect(() => opportunityOpportunityVolunteerDTO({} as any)).toThrow(
+      "Wrong opportunity-volunteer format.",
+    );
+  });
+});

--- a/src/test/services/dto/dto-user.test.ts
+++ b/src/test/services/dto/dto-user.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { serializeUserToMeDTO } from "../../../services/dto/dto-user";
+
+describe("serializeUserToMeDTO", () => {
+  it("maps all user fields from entity to API shape", () => {
+    const user = {
+      id: 1,
+      email: "test@example.com",
+      isActive: true,
+      role: "admin",
+      language: "de",
+      timezone: "Europe/Berlin",
+      person: {
+        firstName: "Ada",
+        name: "Ada Lovelace",
+        avatarUrl: "https://cdn.example.com/avatar.png",
+      },
+    };
+
+    const result = serializeUserToMeDTO(user as any);
+
+    expect(result).toEqual({
+      id: 1,
+      email: "test@example.com",
+      isActive: true,
+      role: "admin",
+      firstName: "Ada",
+      fullName: "Ada Lovelace",
+      avatarUrl: "https://cdn.example.com/avatar.png",
+      isoCode: "de",
+      timezone: "Europe/Berlin",
+    });
+  });
+
+  it("falls back to empty strings when person fields are missing", () => {
+    const user = {
+      id: 2,
+      email: "no-person@example.com",
+      isActive: false,
+      role: "coordinator",
+      language: null,
+      timezone: null,
+      person: null,
+    };
+
+    const result = serializeUserToMeDTO(user as any);
+
+    expect(result.firstName).toBe("");
+    expect(result.fullName).toBe("");
+    expect(result.avatarUrl).toBe("");
+  });
+
+  it("falls back to default isoCode 'en' and timezone 'CET' when not set", () => {
+    const user = {
+      id: 3,
+      email: "defaults@example.com",
+      isActive: true,
+      role: "user",
+      language: null,
+      timezone: null,
+      person: { firstName: "Sam", name: "Sam Smith", avatarUrl: "" },
+    };
+
+    const result = serializeUserToMeDTO(user as any);
+    expect(result.isoCode).toBe("en");
+    expect(result.timezone).toBe("CET");
+  });
+});

--- a/src/test/services/dto/dto-volunteer.test.ts
+++ b/src/test/services/dto/dto-volunteer.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  volunteerListSerializer,
+  volunteerSerializer,
+} from "../../../services/dto/dto-volunteer";
+
+vi.mock("../../../services/dto/utils", () => ({
+  getLanguages: vi.fn(() => [{ id: "de", title: "German", proficiency: "fluent" }]),
+  getAvailability: vi.fn(() => [{ id: 1, day: "MO", daytime: "08-11" }]),
+  getOptionItems: vi.fn(() => [{ id: 1, title: "Teaching" }]),
+  getTitles: vi.fn(() => ["Teaching"]),
+}));
+
+function makeVolunteer(overrides = {}) {
+  return {
+    id: 1,
+    statusEngagement: "active",
+    statusType: "regular",
+    statusCGC: "yes",
+    statusVaccination: "yes",
+    statusCgcProcess: null,
+    statusCommunication: null,
+    statusAppreciation: null,
+    statusMatch: "vol-matched",
+    dateReturn: null,
+    preferredCommunicationType: "email",
+    infoAbout: "About me",
+    infoExperience: "Experience",
+    statusVaccinationDate: null,
+    statusCGCApplicationDate: null,
+    statusCGCDate: null,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-06-01"),
+    person: {
+      id: 5,
+      name: "Jane Doe",
+      firstName: "Jane",
+      lastName: "Doe",
+      middleName: null,
+      email: "jane@example.com",
+      phone: "+491234567",
+      landline: null,
+      avatarUrl: "https://cdn.example.com/avatar.png",
+      address: null,
+    },
+    deal: {
+      profile: {
+        profileLanguage: [],
+        profileActivity: [],
+        profileSkill: [],
+      },
+      time: { timeTimeslot: [] },
+      location: { locationDistrict: [] },
+    },
+    ...overrides,
+  };
+}
+
+describe("volunteerListSerializer", () => {
+  it("maps core volunteer fields to list shape", () => {
+    const result = volunteerListSerializer(makeVolunteer() as any);
+
+    expect(result).toBeDefined();
+    expect(result!.id).toBe(1);
+    expect(result!.statusEngagement).toBe("active");
+    expect(result!.statusType).toBe("regular");
+    expect(result!.name).toBe("Jane Doe");
+    expect(result!.avatarUrl).toBe("https://cdn.example.com/avatar.png");
+    expect(Array.isArray(result!.languages)).toBe(true);
+    expect(Array.isArray(result!.activities)).toBe(true);
+    expect(Array.isArray(result!.skills)).toBe(true);
+    expect(Array.isArray(result!.locations)).toBe(true);
+  });
+
+  it("returns null avatarUrl when person has no avatar", () => {
+    const v = makeVolunteer({ person: { ...makeVolunteer().person, avatarUrl: null } });
+    const result = volunteerListSerializer(v as any);
+    expect(result).toBeDefined();
+    expect(result!.avatarUrl).toBeNull();
+  });
+});
+
+describe("volunteerSerializer", () => {
+  it("maps all volunteer fields to the detail shape", () => {
+    const comments: any[] = [
+      {
+        id: 10,
+        text: "Good volunteer",
+        entityId: 1,
+        entityType: "volunteer",
+        updatedAt: new Date("2025-02-01"),
+        user: { id: 3, person: { name: "Coordinator A" } },
+      },
+    ];
+    const timedEvents: any[] = [
+      { id: 20, timestamp: new Date("2025-03-01"), content: "Matched" },
+    ];
+
+    const result = volunteerSerializer(
+      makeVolunteer() as any,
+      comments,
+      timedEvents,
+    );
+
+    expect(result.id).toBe(1);
+    expect(result.person.email).toBe("jane@example.com");
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0].content).toBe("Good volunteer");
+    expect(result.timelineLogs).toHaveLength(1);
+    expect(result.timelineLogs[0].content).toBe("Matched");
+    expect(result.statusMatch).toBe("vol-matched");
+    expect(result.createdAt).toEqual(new Date("2025-01-01"));
+  });
+
+  it("uses 'Unknown Author' when comment user has no person", () => {
+    const comments = [
+      {
+        id: 11,
+        text: "Note",
+        entityId: 1,
+        entityType: "volunteer",
+        updatedAt: new Date(),
+        user: { id: 4 },
+      },
+    ];
+
+    const result = volunteerSerializer(makeVolunteer() as any, comments as any, []);
+    expect(result.comments[0].authorName).toBe("Unknown Author");
+  });
+});


### PR DESCRIPTION
## Summary
Adds tests for the 6 DTO files in `src/services/dto/` that had no coverage:

- `dto-appreciation.test.ts` — field mapping and optional null pass-through
- `dto-comment.test.ts` — field mapping and missing `user`/`person` edge cases
- `dto-document.test.ts` — field mapping, mocks `getDocumentUrl`, verifies it receives the correct `s3Key`
- `dto-user.test.ts` — field mapping, empty-string fallbacks when `person` is null, default `isoCode`/`timezone`
- `dto-opportunity-volunteer.test.ts` — both DTOs, `instanceof` error path, all output fields including `locations`
- `dto-volunteer.test.ts` — `volunteerListSerializer` and `volunteerSerializer` with mocked utils, `Unknown Author` edge case; uses `expect(result).toBeDefined()` before field assertions so silent serializer errors surface

## Test plan
- [ ] Run `yarn test:run src/test/services/dto/` and confirm all tests pass

Closes https://github.com/need4deed-org/be/issues/225

🤖 Generated with [Claude Code](https://claude.com/claude-code)