### PR TITLE
test(#226): add tests for tryCatch, getErrorStatusCode, and IsPostcodeConstraint

### DIFF
--- a/src/test/services/utils/index.test.ts
+++ b/src/test/services/utils/index.test.ts
@@ -1,12 +1,15 @@
 import path from "path";
 import { describe, expect, it, vi } from "vitest";
 import { BadRequestError } from "../../../config/error";
+import { BaseError } from "../../../config/error/base";
 import {
   deepMerge,
   getDateObj,
+  getErrorStatusCode,
   isObject,
   isProbablyFileSystemPath,
   pascal2snake,
+  tryCatch,
   tryCatchFn,
 } from "../../../services/utils";
 
@@ -303,5 +306,54 @@ describe("getDateObj()", () => {
     expect(() => getDateObj("2026-01-01", null as any)).toThrow(
       BadRequestError,
     );
+  });
+});
+
+describe("tryCatch", () => {
+  it("returns [value, null] when the promise resolves", async () => {
+    const [result, error] = await tryCatch(Promise.resolve(42));
+    expect(result).toBe(42);
+    expect(error).toBeNull();
+  });
+
+  it("returns [null, error] when the promise rejects", async () => {
+    const boom = new Error("async failure");
+    const [result, error] = await tryCatch(Promise.reject(boom));
+    expect(result).toBeNull();
+    expect(error).toBe(boom);
+  });
+
+  it("captures the correct error type", async () => {
+    const [, error] = await tryCatch<number, TypeError>(
+      Promise.reject(new TypeError("type mismatch")),
+    );
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error?.message).toBe("type mismatch");
+  });
+
+  it("handles a resolved promise with a falsy value", async () => {
+    const [result, error] = await tryCatch(Promise.resolve(0));
+    expect(result).toBe(0);
+    expect(error).toBeNull();
+  });
+});
+
+describe("getErrorStatusCode", () => {
+  it("returns the statusCode from a BaseError", () => {
+    const err = new BaseError("Not found", 404);
+    expect(getErrorStatusCode(err)).toBe(404);
+  });
+
+  it("returns 500 for a plain Error", () => {
+    expect(getErrorStatusCode(new Error("oops"))).toBe(500);
+  });
+
+  it("returns 500 when the error is not a BaseError instance", () => {
+    expect(getErrorStatusCode({ message: "raw object" } as any)).toBe(500);
+  });
+
+  it("returns 500 for null/undefined input", () => {
+    expect(getErrorStatusCode(null as any)).toBe(500);
+    expect(getErrorStatusCode(undefined as any)).toBe(500);
   });
 });

--- a/src/test/services/validators/validators.test.ts
+++ b/src/test/services/validators/validators.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { Country, GermanCity } from "../../../data/types";
+import { IsPostcodeConstraint } from "../../../services/validators/custom";
+
+function makeArgs(countryCode: Country, allowedAreas?: string[]) {
+  return { constraints: [countryCode, allowedAreas] } as any;
+}
+
+describe("IsPostcodeConstraint", () => {
+  const constraint = new IsPostcodeConstraint();
+
+  describe("Germany without city restriction", () => {
+    it("accepts valid German postcodes in the general range", () => {
+      expect(constraint.validate("10115", makeArgs(Country.DE))).toBe(true);
+      expect(constraint.validate("80331", makeArgs(Country.DE))).toBe(true);
+      expect(constraint.validate("99998", makeArgs(Country.DE))).toBe(true);
+    });
+
+    it("rejects postcodes outside the German range", () => {
+      expect(constraint.validate("00000", makeArgs(Country.DE))).toBe(false);
+      expect(constraint.validate("99999", makeArgs(Country.DE))).toBe(false);
+    });
+
+    it("rejects non-numeric strings", () => {
+      expect(constraint.validate("ABCDE", makeArgs(Country.DE))).toBe(false);
+      expect(constraint.validate("", makeArgs(Country.DE))).toBe(false);
+    });
+  });
+
+  describe("Berlin area restriction", () => {
+    it("accepts postcodes within Berlin range", () => {
+      expect(
+        constraint.validate("10115", makeArgs(Country.DE, [GermanCity.BERLIN])),
+      ).toBe(true);
+      expect(
+        constraint.validate("14199", makeArgs(Country.DE, [GermanCity.BERLIN])),
+      ).toBe(true);
+    });
+
+    it("rejects postcodes outside Berlin range", () => {
+      expect(
+        constraint.validate("80331", makeArgs(Country.DE, [GermanCity.BERLIN])),
+      ).toBe(false);
+      expect(
+        constraint.validate("10114", makeArgs(Country.DE, [GermanCity.BERLIN])),
+      ).toBe(false);
+    });
+  });
+
+  describe("Potsdam area restriction", () => {
+    it("accepts postcodes within Potsdam range", () => {
+      expect(
+        constraint.validate(
+          "14467",
+          makeArgs(Country.DE, [GermanCity.POTSDAM]),
+        ),
+      ).toBe(true);
+      expect(
+        constraint.validate(
+          "14482",
+          makeArgs(Country.DE, [GermanCity.POTSDAM]),
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects postcodes outside Potsdam range", () => {
+      expect(
+        constraint.validate(
+          "10115",
+          makeArgs(Country.DE, [GermanCity.POTSDAM]),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("multi-city allowed areas", () => {
+    it("accepts postcodes valid in any of the listed cities", () => {
+      const args = makeArgs(Country.DE, [GermanCity.BERLIN, GermanCity.POTSDAM]);
+      expect(constraint.validate("10115", args)).toBe(true);
+      expect(constraint.validate("14467", args)).toBe(true);
+    });
+
+    it("rejects postcodes valid in neither listed city", () => {
+      const args = makeArgs(Country.DE, [GermanCity.BERLIN, GermanCity.POTSDAM]);
+      expect(constraint.validate("80331", args)).toBe(false);
+    });
+  });
+
+  describe("defaultMessage", () => {
+    it("returns a message containing the property name", () => {
+      const args = { property: "postcode", constraints: [] } as any;
+      expect(constraint.defaultMessage(args)).toContain("postcode");
+    });
+  });
+
+  describe("unsupported country code", () => {
+    it("rejects any postcode for a non-DE country code", () => {
+      expect(constraint.validate("10115", makeArgs("en" as any))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **`src/test/services/utils/index.test.ts`** — adds two new suites to the existing file:
  - `tryCatch` — async result-tuple for resolve and reject, correct error type, falsy resolved value
  - `getErrorStatusCode` — extracts status from `BaseError`, defaults to 500 for plain `Error`, raw objects, and null/undefined
- **`src/test/services/validators/validators.test.ts`** — new file covering `IsPostcodeConstraint`:
  - General DE range, Berlin-only, Potsdam-only, multi-city `allowedAreas`
  - Non-numeric strings, unsupported country code
  - `defaultMessage` includes property name

## Test plan
- [ ] Run `yarn test:run src/test/services/utils/index.test.ts` and confirm new suites pass
- [ ] Run `yarn test:run src/test/services/validators/validators.test.ts` and confirm all cases pass

Closes https://github.com/need4deed-org/be/issues/226

🤖 Generated with [Claude Code](https://claude.com/claude-code)