### PR TITLE
fix(#122): correct English skill translations using en field instead of de

### DIFF
--- a/src/data/seeds/field_translation.seed.ts
+++ b/src/data/seeds/field_translation.seed.ts
@@ -297,7 +297,7 @@ async function seedSkills(
 
     if (!existingSkillTranslationsSet.has(`${isoCodeEN}_${en}`)) {
       const translationEN = new FieldTranslation();
-      translationEN.translation = de;
+      translationEN.translation = en;
       translationEN.entityType = EntityTableName.SKILL;
       translationEN.entityId = skill.id;
       translationEN.languageId = langEN.id;


### PR DESCRIPTION
## Summary
- Fixes a copy-paste bug in `seedSkills` where the English translation was incorrectly set to the German (`de`) value instead of the English (`en`) value

## Related
- Closes https://github.com/need4deed-org/be/issues/122

## Test plan
- [ ] Re-seed the database and verify that English skill translations differ from German ones (e.g. "Woodworking" vs "Holzverarbeitung")

🤖 Generated with [Claude Code](https://claude.com/claude-code)