### PR TITLE
feat(#269): add DELETE /agent/:id endpoint

### DIFF
--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -174,4 +174,29 @@ export default async function agentRoutes(
       });
     },
   );
+
+  fastify.delete<{ Params: ParamsId; Reply: ReplyMessage }>(
+    "/:id",
+    {
+      schema: {
+        params: idParamSchema,
+        response: responseSchema(""),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const agentRepository = fastify.db.agentRepository;
+      const agent = await agentRepository.findOneBy({ id });
+
+      if (!agent) {
+        throw new NotFoundError(`Agent (id:${id}) not found.`);
+      }
+
+      await agentRepository.delete({ id });
+
+      return reply.status(200).send({
+        message: `Agent (id:${id}) deleted successfully`,
+      });
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Adds `DELETE /agent/:id` route following the same pattern as other delete endpoints
- Returns 200 with a confirmation message; 404 if the agent is not found

## Related
- Closes https://github.com/need4deed-org/be/issues/269

## Test plan
- [ ] `DELETE /agent/:id` with a valid id removes the agent and returns 200
- [ ] `DELETE /agent/:id` with a non-existent id returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)