### PR TITLE
feat(#285): add 201/204 status code support to responseSchema and fix route status codes

### DIFF
--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -146,13 +146,13 @@ export default async function agentRoutes(
     },
   );
 
-  fastify.patch<{ Params: ParamsId; Body: ApiAgentPatch; Reply: ReplyMessage }>(
+  fastify.patch<{ Params: ParamsId; Body: ApiAgentPatch; Reply: null }>(
     "/:id",
     {
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiAgentPatch#" },
-        response: responseSchema(""),
+        response: responseSchema({ statusCode: 204 }),
       },
     },
     async (request, reply) => {
@@ -169,9 +169,7 @@ export default async function agentRoutes(
 
       await agentRepository.save(agentObj);
 
-      return reply.status(200).send({
-        message: `Agent (id:${id}) patched successfully`,
-      });
+      return reply.status(204).send();
     },
   );
 }

--- a/src/server/routes/m2m/opportunity-volunteer.routes.ts
+++ b/src/server/routes/m2m/opportunity-volunteer.routes.ts
@@ -22,7 +22,7 @@ export default async function m2mOpportunityVolunteerRoutes(
     {
       schema: {
         body: { $ref: "ApiVolunteerOpportunityPost#" },
-        response: responseSchema(""),
+        response: responseSchema({ statusCode: 201 }),
       },
     },
     async (request, reply) => {
@@ -32,7 +32,7 @@ export default async function m2mOpportunityVolunteerRoutes(
       const opportunityVolunteer = new OpportunityVolunteer(request.body);
       await opportunityVolunteerRepository.save(opportunityVolunteer);
 
-      return reply.status(200).send({
+      return reply.status(201).send({
         message: `Created M2M opportunityId:${opportunityVolunteer.opportunityId}, volunteerId:${opportunityVolunteer.volunteerId}, status:${opportunityVolunteer.status}.`,
       });
     },
@@ -40,7 +40,7 @@ export default async function m2mOpportunityVolunteerRoutes(
 
   fastify.patch<{
     Params: ParamsId;
-    Reply: ReplyMessage;
+    Reply: null;
     Body: { status: OpportunityVolunteerStatusType };
   }>(
     "/:id",
@@ -48,7 +48,7 @@ export default async function m2mOpportunityVolunteerRoutes(
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiOpportunityVolunteerPatch#" },
-        response: responseSchema(""),
+        response: responseSchema({ statusCode: 204 }),
       },
     },
     async (request, reply) => {
@@ -77,21 +77,19 @@ export default async function m2mOpportunityVolunteerRoutes(
         reload: true,
       });
 
-      return reply.status(200).send({
-        message: `M2M relation id:${id} has been updated.`,
-      });
+      return reply.status(204).send();
     },
   );
 
   fastify.delete<{
     Params: ParamsId;
-    Reply: ReplyMessage;
+    Reply: null;
   }>(
     "/:id",
     {
       schema: {
         params: idParamSchema,
-        response: responseSchema(""),
+        response: responseSchema({ statusCode: 204 }),
       },
     },
     async (request, reply) => {
@@ -113,9 +111,7 @@ export default async function m2mOpportunityVolunteerRoutes(
 
       await opportunityVolunteerRepository.delete({ id });
 
-      return reply.status(200).send({
-        message: `M2M relation id:${id} has been deleted.`,
-      });
+      return reply.status(204).send();
     },
   );
 }

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -239,14 +239,14 @@ export default async function opportunityRoutes(
   fastify.patch<{
     Params: ParamsId;
     Body: ApiOpportunityPatch;
-    Reply: ReplyMessage;
+    Reply: null;
   }>(
     "/:id",
     {
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiVolunteerOpportunityPatch#" },
-        response: responseSchema(""),
+        response: responseSchema({ statusCode: 204 }),
       },
     },
     async (request, reply) => {
@@ -387,9 +387,7 @@ export default async function opportunityRoutes(
         }
       }
 
-      return reply
-        .status(200)
-        .send({ message: "Opportunity has been patched." });
+      return reply.status(204).send();
     },
   );
 }

--- a/src/server/routes/organization.routes.ts
+++ b/src/server/routes/organization.routes.ts
@@ -16,11 +16,11 @@ export default async function organizationRoutes(
   fastify.patch<{
     Params: ParamsId;
     Body: ApiOrganizationPatch;
-    Reply: ReplyMessage;
+    Reply: null;
   }>(
     "/:id",
     {
-      schema: { params: idParamSchema, response: responseSchema("") },
+      schema: { params: idParamSchema, response: responseSchema({ statusCode: 204 }) },
     },
     async (request, reply) => {
       const { id } = request.params;
@@ -36,9 +36,7 @@ export default async function organizationRoutes(
 
       await organizationRepository.save(organizationPatched);
 
-      return reply
-        .status(200)
-        .send({ message: `Organization (id:${id} has been patched.)` });
+      return reply.status(204).send();
     },
   );
 }

--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -376,7 +376,7 @@ export default async function volunteerRoutes(
       schema: {
         body: { $ref: "volunteer-form-data" },
         response: {
-          200: {
+          201: {
             type: "object",
             properties: {
               message: { type: "string" },
@@ -410,7 +410,7 @@ export default async function volunteerRoutes(
           await updateLeads(leads);
         }
 
-        return reply.status(200).send({
+        return reply.status(201).send({
           message: "Volunteer stored.",
           data: { id },
         });

--- a/src/server/schema/response-schema.ts
+++ b/src/server/schema/response-schema.ts
@@ -1,24 +1,47 @@
 import { getRef } from "../utils";
 import { responseErrors } from "./responseErrors";
 
+interface ResponseSchemaOptions {
+  dataSchemaRef?: string;
+  isArray?: boolean;
+  count?: boolean;
+  statusCode?: 200 | 201 | 204;
+}
+
 export function responseSchema(
-  dataSchemaRef: string,
+  refOrOptions: string | ResponseSchemaOptions,
   isArray = false,
   count = isArray,
 ) {
+  const opts: ResponseSchemaOptions =
+    typeof refOrOptions === "string"
+      ? { dataSchemaRef: refOrOptions, isArray, count }
+      : refOrOptions;
+
+  const {
+    dataSchemaRef = "",
+    isArray: isArr = false,
+    count: withCount = isArr,
+    statusCode = 200,
+  } = opts;
+
+  if (statusCode === 204) {
+    return {
+      204: { type: "null" },
+      ...responseErrors,
+    };
+  }
+
   return {
-    200: {
+    [statusCode]: {
       type: "object",
       properties: {
         message: { type: "string" },
-        ...(count ? { count: { type: "number" } } : {}),
+        ...(withCount ? { count: { type: "number" } } : {}),
         ...(dataSchemaRef
           ? {
-              data: isArray
-                ? {
-                    type: "array",
-                    items: getRef(dataSchemaRef),
-                  }
+              data: isArr
+                ? { type: "array", items: getRef(dataSchemaRef) }
                 : getRef(dataSchemaRef),
             }
           : {}),


### PR DESCRIPTION
## Summary
- Extends `responseSchema` to accept an options object with a `statusCode` field (200/201/204)
- 204 responses use `{ type: 'null' }` schema (no body)
- Updates POST routes to return 201, PATCH/DELETE routes that return no body to return 204
- Existing positional call signature (`responseSchema(ref, isArray, count)`) remains fully compatible

## Changes
- `src/server/schema/response-schema.ts` — new options object signature + 204 support
- `src/server/routes/m2m/opportunity-volunteer.routes.ts` — POST→201, PATCH→204, DELETE→204
- `src/server/routes/agent/agent.routes.ts` — PATCH→204
- `src/server/routes/organization.routes.ts` — PATCH→204
- `src/server/routes/opportunity/opportunity.routes.ts` — PATCH→204
- `src/server/routes/volunteer/volunteer.routes.ts` — POST→201

## Related
- Closes https://github.com/need4deed-org/be/issues/285

## Test plan
- [ ] POST /m2m/opportunity-volunteer returns 201
- [ ] PATCH /agent/:id returns 204 with no body
- [ ] DELETE /m2m/opportunity-volunteer/:id returns 204 with no body
- [ ] Existing GET endpoints still return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)