### PR TITLE
feat(#433): add match status filter to volunteer list endpoint

### DIFF
--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -24,7 +24,7 @@ import {
   volunteerFormParser,
   volunteerListSerializer,
 } from "../../../services";
-import { idParamSchema, responseErrors, responseSchema } from "../../schema";
+import { idParamSchema, responseErrors, responseSchema, volunteerListQuerySchema } from "../../schema";
 import { QuerystringVolunteerGetList, RoutePrefix } from "../../types";
 import {
   fetchVolunteerById,
@@ -147,24 +147,30 @@ export default async function volunteerRoutes(
     "/",
     {
       schema: {
+        querystring: volunteerListQuerySchema,
         response: responseSchema("volunteer-api#", true),
       },
     },
     async (request, reply) => {
-      function engagementWorkaround(query: QuerystringVolunteerGetList) {
+      function filterWorkaround(query: QuerystringVolunteerGetList) {
         if (query.filter) {
           const engagement = [query.filter.engagement]
             .flat()
             .filter(Boolean)
             .map((e) => `vol-${e}`);
+          const match = [query.filter.match]
+            .flat()
+            .filter(Boolean)
+            .map((m) => `vol-${m}`);
           Object.assign(query.filter, {
             engagement: engagement.length ? engagement : undefined,
+            match: match.length ? match : undefined,
           });
         }
         return query;
       }
 
-      const { page, limit, sortOrder, filter } = engagementWorkaround(
+      const { page, limit, sortOrder, filter } = filterWorkaround(
         request.query,
       );
       const [skip, take] = getSkipTake({ page, limit });

--- a/src/server/schema/querystring.ts
+++ b/src/server/schema/querystring.ts
@@ -61,6 +61,32 @@ export const agentListQuerySchema = {
   additionalProperties: false,
 };
 
+export const volunteerListQuerySchema = {
+  type: "object",
+  properties: {
+    ...paginationProps,
+    ...langProp,
+    ...sortOrderProps,
+    filter: {
+      type: "object",
+      properties: {
+        type: { type: "string" },
+        search: { type: "string" },
+        language: { type: "string" },
+        activity: { type: "string" },
+        skill: { type: "string" },
+        availability: { type: "string" },
+        district: { type: "string" },
+        engagement: { type: "array", items: { type: "string" } },
+        match: { type: "array", items: { type: "string" } },
+        accompanying: { type: "boolean" },
+      },
+      additionalProperties: false,
+    },
+  },
+  additionalProperties: false,
+};
+
 export const volunteerOpportunityListQuerySchema = {
   type: "object",
   properties: {

--- a/src/server/types/endpoint-handlers.ts
+++ b/src/server/types/endpoint-handlers.ts
@@ -81,6 +81,7 @@ export interface QuerystringVolunteerFiltering {
     availability?: string;
     district?: string;
     engagement: string | string[];
+    match?: string | string[];
     accompanying?: boolean;
   };
 }

--- a/src/server/utils/data/get-volunteer-where.ts
+++ b/src/server/utils/data/get-volunteer-where.ts
@@ -22,6 +22,11 @@ export function getVolunteerWhere(
           statusEngagement: normalizeStringArrayInput(filter.engagement),
         }
       : {}),
+    ...(filter?.match
+      ? {
+          statusMatch: normalizeStringArrayInput(filter.match),
+        }
+      : {}),
     ...(filter?.search
       ? {
           person: [

--- a/src/server/utils/data/serve-volunteer-list.ts
+++ b/src/server/utils/data/serve-volunteer-list.ts
@@ -119,7 +119,15 @@ export async function getFilteredVolunteers(
   }
 
   // ----------------------------------------------------------------------
-  // 4. STATUS TYPE FILTER (v.volunteer_type)
+  // 4. MATCH STATUS FILTER (v.status_match)
+  // ----------------------------------------------------------------------
+  if (filterParams?.filter?.match?.length) {
+    const matches = toArray(filterParams.filter.match);
+    mvQueryBuilder.andWhere("v.status_match IN (:...matches)", { matches });
+  }
+
+  // ----------------------------------------------------------------------
+  // 5. STATUS TYPE FILTER (v.volunteer_type)
   // ----------------------------------------------------------------------
   if (filterParams?.filter?.statusType?.length) {
     const statusTypes = toArray(filterParams.filter.statusType);


### PR DESCRIPTION
## Summary
- Adds `match` as a filter param to `GET /volunteer`, following the same pattern as `engagement`
- Applies a `vol-` prefix workaround (same as engagement) so FE can send short values
- Adds `match` filter to both the TypeORM `getVolunteerWhere` path and the MV-based `getFilteredVolunteers` path
- Adds `volunteerListQuerySchema` for Fastify querystring validation on the volunteer list route

## Changes
- `src/server/schema/querystring.ts` — new `volunteerListQuerySchema` with `match` array field
- `src/server/types/endpoint-handlers.ts` — `match?: string | string[]` added to volunteer filter
- `src/server/utils/data/get-volunteer-where.ts` — `statusMatch` filter condition
- `src/server/utils/data/serve-volunteer-list.ts` — `status_match IN` filter on MV query
- `src/server/routes/volunteer/volunteer.routes.ts` — match workaround + querystring schema applied

## Related
- Closes https://github.com/need4deed-org/be/issues/433
- Frontend issue: https://github.com/need4deed-org/fe/issues/432

## Test plan
- [ ] `GET /volunteer?filter[match][]=pending-match` returns only volunteers with `vol-pending-match` status
- [ ] `GET /volunteer?filter[match][]=matched&filter[match][]=pending-match` filters by both values
- [ ] Request without `match` param returns all volunteers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)