### PR TITLE
feat(#539): accept agent.id on PATCH /opportunity/{id} to re-link agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.3.3",
     "fastify-mailer": "^2.3.1",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.85",
+    "need4deed-sdk": "0.0.86",
     "nodemailer": "^7.0.4",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
   ApiOpportunityGet,
   ApiOpportunityGetList,
+  ApiOpportunityPatch,
   SortOrder,
   UserRole,
 } from "need4deed-sdk";
@@ -21,7 +22,6 @@ import logger from "../../../logger";
 import {
   dtoOpportunityGet,
   dtoOpportunityGetList,
-  OpportunityPatchBody,
   parseOpportunity,
 } from "../../../services";
 import {
@@ -238,7 +238,7 @@ export default async function opportunityRoutes(
 
   fastify.patch<{
     Params: ParamsId;
-    Body: OpportunityPatchBody;
+    Body: ApiOpportunityPatch;
     Reply: ReplyMessage;
   }>(
     "/:id",
@@ -269,13 +269,13 @@ export default async function opportunityRoutes(
         opportunity: opportunityObj,
         contact,
         agent,
-        agentLinkId,
         accompanying,
         languages,
         schedule,
         skills,
         activities,
       } = parseOpportunity(request.body);
+      const agentLinkId = request.body.agent?.id;
       logger.debug(
         `PATCH /opportunity/{id} ${JSON.stringify(parseOpportunity(request.body))}`,
       );
@@ -305,7 +305,7 @@ export default async function opportunityRoutes(
           where: { id: agentLinkId },
         });
         if (!linkedAgent) {
-          throw new BadRequestError(`Agent (id:${agentLinkId}) not found.`);
+          throw new NotFoundError(`Agent (id:${agentLinkId}) not found.`);
         }
         const success = await patchEntity(
           Opportunity,
@@ -313,7 +313,7 @@ export default async function opportunityRoutes(
           opportunity.id,
         );
         if (!success) {
-          throw new Error("Relinking opportunity agent failed.");
+          throw new BadRequestError("Relinking opportunity agent failed.");
         }
       } else if (agent) {
         const success = await patchEntity(Agent, agent, opportunity.agentId);

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -2,7 +2,6 @@ import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
   ApiOpportunityGet,
   ApiOpportunityGetList,
-  ApiOpportunityPatch,
   SortOrder,
   UserRole,
 } from "need4deed-sdk";
@@ -22,6 +21,7 @@ import logger from "../../../logger";
 import {
   dtoOpportunityGet,
   dtoOpportunityGetList,
+  OpportunityPatchBody,
   parseOpportunity,
 } from "../../../services";
 import {
@@ -238,7 +238,7 @@ export default async function opportunityRoutes(
 
   fastify.patch<{
     Params: ParamsId;
-    Body: ApiOpportunityPatch;
+    Body: OpportunityPatchBody;
     Reply: ReplyMessage;
   }>(
     "/:id",
@@ -269,6 +269,7 @@ export default async function opportunityRoutes(
         opportunity: opportunityObj,
         contact,
         agent,
+        agentLinkId,
         accompanying,
         languages,
         schedule,
@@ -299,7 +300,22 @@ export default async function opportunityRoutes(
         }
       }
 
-      if (agent) {
+      if (agentLinkId !== undefined) {
+        const linkedAgent = await fastify.db.agentRepository.findOne({
+          where: { id: agentLinkId },
+        });
+        if (!linkedAgent) {
+          throw new BadRequestError(`Agent (id:${agentLinkId}) not found.`);
+        }
+        const success = await patchEntity(
+          Opportunity,
+          { agentId: agentLinkId } as Partial<Opportunity>,
+          opportunity.id,
+        );
+        if (!success) {
+          throw new Error("Relinking opportunity agent failed.");
+        }
+      } else if (agent) {
         const success = await patchEntity(Agent, agent, opportunity.agentId);
         if (!success) {
           throw new Error("Patching agent failed while patching opportunity.");

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -694,6 +694,7 @@
             "agent": {
               "type": "object",
               "properties": {
+                "id": { "type": "integer" },
                 "type": { "$ref": "AgentType#" },
                 "name": { "type": "string" },
                 "address": { "type": "string" },

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -590,6 +590,7 @@
         "agent": {
           "type": "object",
           "properties": {
+            "id": { "type": "integer" },
             "name": { "type": "string" },
             "address": { "type": "string" },
             "district": { "type": "string" }
@@ -617,7 +618,13 @@
     "OpportunityStatusType": {
       "$id": "OpportunityStatusType",
       "type": "string",
-      "enum": ["opp-new", "opp-searching", "opp-active", "opp-inactive", "opp-past"]
+      "enum": [
+        "opp-new",
+        "opp-searching",
+        "opp-active",
+        "opp-inactive",
+        "opp-past"
+      ]
     },
     "ApiOpportunityGetList": {
       "$id": "ApiOpportunityGetList",

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -44,6 +44,7 @@ export function dtoAgentGet(
 
 export function dtoOpportunityAgent(agent: Agent): ApiOpportunityAgent {
   return {
+    id: agent.id,
     type: agent.type,
     name: agent.title,
     address: serializeAddress(agent.representative?.person?.address),

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -7,17 +7,6 @@ import { DataId } from "../../server/types";
 import { getEmptyPropsNull } from "../../server/utils/common";
 import { getDateObj } from "../utils";
 
-export type OpportunityAgentPatchBody = {
-  id?: number;
-  name?: string;
-  address?: string;
-  district?: string;
-};
-
-export type OpportunityPatchBody = Omit<ApiOpportunityPatch, "agent"> & {
-  agent?: OpportunityAgentPatchBody;
-};
-
 type LanguagePatchItem = { id: number | string; purpose: LangPurpose };
 
 function dedupeLanguages(items: LanguagePatchItem[]): LanguagePatchItem[] {
@@ -32,14 +21,12 @@ function dedupeLanguages(items: LanguagePatchItem[]): LanguagePatchItem[] {
   });
 }
 
-export function parseOpportunity(body: OpportunityPatchBody) {
+export function parseOpportunity(body: ApiOpportunityPatch) {
   if (!body) {
     throw new BadRequestError("invalid body for parseOpportunity.");
   }
   const accompanyingDetails = body.accompanyingDetails;
   const agentBody = body?.agent;
-  const agentLinkId =
-    typeof agentBody?.id === "number" ? agentBody.id : undefined;
   return {
     ...getEmptyPropsNull({
       opportunity: {
@@ -58,7 +45,7 @@ export function parseOpportunity(body: OpportunityPatchBody) {
           }
         : {},
       agent:
-        agentBody && agentLinkId === undefined
+        agentBody && agentBody.id === undefined
           ? ({
               title: agentBody.name,
             } as Partial<Agent>)
@@ -95,6 +82,5 @@ export function parseOpportunity(body: OpportunityPatchBody) {
       activities: (body?.activities || []) as DataId[],
       schedule: (body.schedule || []) as DataId[],
     }),
-    agentLinkId,
   };
 }

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -7,6 +7,17 @@ import { DataId } from "../../server/types";
 import { getEmptyPropsNull } from "../../server/utils/common";
 import { getDateObj } from "../utils";
 
+export type OpportunityAgentPatchBody = {
+  id?: number;
+  name?: string;
+  address?: string;
+  district?: string;
+};
+
+export type OpportunityPatchBody = Omit<ApiOpportunityPatch, "agent"> & {
+  agent?: OpportunityAgentPatchBody;
+};
+
 type LanguagePatchItem = { id: number | string; purpose: LangPurpose };
 
 function dedupeLanguages(items: LanguagePatchItem[]): LanguagePatchItem[] {
@@ -21,11 +32,14 @@ function dedupeLanguages(items: LanguagePatchItem[]): LanguagePatchItem[] {
   });
 }
 
-export function parseOpportunity(body: ApiOpportunityPatch) {
+export function parseOpportunity(body: OpportunityPatchBody) {
   if (!body) {
     throw new BadRequestError("invalid body for parseOpportunity.");
   }
   const accompanyingDetails = body.accompanyingDetails;
+  const agentBody = body?.agent;
+  const agentLinkId =
+    typeof agentBody?.id === "number" ? agentBody.id : undefined;
   return {
     ...getEmptyPropsNull({
       opportunity: {
@@ -43,11 +57,12 @@ export function parseOpportunity(body: ApiOpportunityPatch) {
             preferredCommunicationType: body?.contact?.waysToContact,
           }
         : {},
-      agent: body?.agent
-        ? ({
-            title: body?.agent?.name,
-          } as Partial<Agent>)
-        : {},
+      agent:
+        agentBody && agentLinkId === undefined
+          ? ({
+              title: agentBody.name,
+            } as Partial<Agent>)
+          : {},
       accompanying: accompanyingDetails
         ? ({
             address: accompanyingDetails.appointmentAddress,
@@ -80,5 +95,6 @@ export function parseOpportunity(body: ApiOpportunityPatch) {
       activities: (body?.activities || []) as DataId[],
       schedule: (body.schedule || []) as DataId[],
     }),
+    agentLinkId,
   };
 }

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -77,6 +77,7 @@ describe("dtoAgentGet", () => {
 describe("dtoOpportunityAgent", () => {
   it("should map agent to opportunity format with localized district", () => {
     const mockAgent = {
+      id: 7,
       type: "Provider",
       title: "Clinic X",
       districtId: "dist_1",
@@ -87,6 +88,7 @@ describe("dtoOpportunityAgent", () => {
     const result = dtoOpportunityAgent(mockAgent as any);
 
     expect(result).toEqual({
+      id: 7,
       type: "Provider",
       name: "Clinic X",
       address: "serialized_address",

--- a/src/test/services/dto/parser-opportunity-patch-data.test.ts
+++ b/src/test/services/dto/parser-opportunity-patch-data.test.ts
@@ -104,12 +104,11 @@ describe("parseOpportunity", () => {
     ]);
   });
 
-  it("surfaces agent.id as agentLinkId and skips in-place agent edit", () => {
+  it("skips in-place agent edit when agent.id is sent (relink intent)", () => {
     const result = parseOpportunity({
       agent: { id: 42 },
     });
 
-    expect(result.agentLinkId).toBe(42);
     expect(result.agent).toBeNull();
   });
 
@@ -118,11 +117,10 @@ describe("parseOpportunity", () => {
       agent: { name: "RAC Tegel" },
     });
 
-    expect(result.agentLinkId).toBeUndefined();
     expect(result.agent).toMatchObject({ title: "RAC Tegel" });
   });
 
-  it("treats agent.id as a relink even when other fields are present", () => {
+  it("skips in-place agent edit when agent.id is sent even with other fields", () => {
     const result = parseOpportunity({
       agent: {
         id: 7,
@@ -132,7 +130,6 @@ describe("parseOpportunity", () => {
       },
     });
 
-    expect(result.agentLinkId).toBe(7);
     expect(result.agent).toBeNull();
   });
 });

--- a/src/test/services/dto/parser-opportunity-patch-data.test.ts
+++ b/src/test/services/dto/parser-opportunity-patch-data.test.ts
@@ -103,4 +103,36 @@ describe("parseOpportunity", () => {
       { id: 5, purpose: LangPurpose.TRANSLATION },
     ]);
   });
+
+  it("surfaces agent.id as agentLinkId and skips in-place agent edit", () => {
+    const result = parseOpportunity({
+      agent: { id: 42 },
+    });
+
+    expect(result.agentLinkId).toBe(42);
+    expect(result.agent).toBeNull();
+  });
+
+  it("keeps existing in-place agent edit when no agent.id is sent", () => {
+    const result = parseOpportunity({
+      agent: { name: "RAC Tegel" },
+    });
+
+    expect(result.agentLinkId).toBeUndefined();
+    expect(result.agent).toMatchObject({ title: "RAC Tegel" });
+  });
+
+  it("treats agent.id as a relink even when other fields are present", () => {
+    const result = parseOpportunity({
+      agent: {
+        id: 7,
+        name: "ignored",
+        address: "ignored",
+        district: "ignored",
+      },
+    });
+
+    expect(result.agentLinkId).toBe(7);
+    expect(result.agent).toBeNull();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,10 +3825,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.85:
-  version "0.0.85"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.85.tgz#297b455e3e20fd2a8724cdea78d0d2db2edd0509"
-  integrity sha512-yIKwEGvaKb0JsIeeZKbPs7aceSYA7HhINTZuoa2cUmw6LUDr7lczGjmB63z4585mprEoLyz/dKBg+L9Yk/9x9A==
+need4deed-sdk@0.0.86:
+  version "0.0.86"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.86.tgz#bcd10ab5f0cf32a66c5c24a8c7cfb023b87259a5"
+  integrity sha512-9qczqBHlq+KU5tD41DOCfJIyHQRvl7+AJIvyx1nuurYQEBcyNCN6dLBEK3/kwZWx7RzydGj3DgvF7PIeVccICw==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Closes #539.

## Summary
- `PATCH /opportunity/{id}` now accepts `{ agent: { id: <existing_id> } }` as an explicit re-link reference; the opportunity's `agentId` is updated to point at the existing agent without mutating the agent's name/address/district.
- The legacy `{ name, address, district }` shape still works for in-place edits (recommendation per the issue: deprecate once the frontend cuts over).
- When `agent.id` is present, it wins — other fields on `agent` are ignored.
- Swagger (`/swagger/json`) now reflects `id` on `ApiVolunteerOpportunityPatch.agent`.

## Implementation
- `src/server/schema/sdk-types.json` — added `id: integer` to `ApiVolunteerOpportunityPatch.agent`.
- `src/services/dto/parser-opportunity-patch-data.ts` — new local types `OpportunityAgentPatchBody` / `OpportunityPatchBody` (the SDK type is stale on `agent` shape); parser surfaces `agentLinkId` and skips the in-place agent patch when an id is sent.
- `src/server/routes/opportunity/opportunity.routes.ts` — when `agentLinkId` is set, verify the agent exists (400 if not) and update `opportunity.agentId`; otherwise fall back to the existing in-place agent patch.
- `src/test/services/dto/parser-opportunity-patch-data.test.ts` — 3 new parser tests (relink, legacy in-place edit, id-wins).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test:run` (161/161 pass)
- [ ] Manual: `PATCH /opportunity/<id>` with `{ "agent": { "id": <other_agent_id> } }` → 200; subsequent `GET` shows the new agent inlined; the previously-linked agent record is untouched.
- [ ] Manual: `PATCH /opportunity/<id>` with `{ "agent": { "id": 99999999 } }` → 400 `Agent (id:99999999) not found.`
- [ ] Manual: `PATCH /opportunity/<id>` with the legacy `{ "agent": { "name": "..." } }` shape still patches the title in place.
- [ ] Confirm Swagger UI exposes the new `id` field on the agent body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)