### PR TITLE
feat(#488): add id to dtoOpportunityAgent so opportunity profile can link to agent

### DIFF
--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -44,6 +44,7 @@ export function dtoAgentGet(
 
 export function dtoOpportunityAgent(agent: Agent): ApiOpportunityAgent {
   return {
+    id: agent.id,
     type: agent.type,
     name: agent.title,
     address: serializeAddress(agent.representative?.person?.address),


### PR DESCRIPTION
Part of #488.

Adds `id` to the `dtoOpportunityAgent` serializer so `GET /opportunity/:id` includes the agent's numeric ID in the response. The FE uses this to render a link from the opportunity profile header to the agent profile page (FE PR need4deed-org/fe#525).

Depends on: need4deed-org/sdk#100 (adds `id` to `ApiOpportunityAgent` type).