### PR TITLE
fix(#433): guard vol- prefix to prevent double-prefixing on engagement/match filters

### DIFF
--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -157,11 +157,11 @@ export default async function volunteerRoutes(
           const engagement = [query.filter.engagement]
             .flat()
             .filter(Boolean)
-            .map((e) => `vol-${e}`);
+            .map((e) => (e.startsWith("vol-") ? e : `vol-${e}`));
           const match = [query.filter.match]
             .flat()
             .filter(Boolean)
-            .map((m) => `vol-${m}`);
+            .map((m) => (m.startsWith("vol-") ? m : `vol-${m}`));
           Object.assign(query.filter, {
             engagement: engagement.length ? engagement : undefined,
             match: match.length ? match : undefined,


### PR DESCRIPTION
## Summary

Adds an idempotency check to the `vol-` prefix workaround in the volunteer list route.

Previously `.map((e) => `vol-${e}`)` would produce `vol-vol-xxx` if a value already carried the prefix (e.g. a direct API call or a client that pre-prefixes). Now the prefix is only added when not already present.

Applies to both `engagement` and `match` filter values.

> Note: the full match-filter feature (`statusMatch` in `getVolunteerWhere`, `match` in `QuerystringVolunteerFiltering`, schema update) was already merged into develop via earlier PRs.

Closes https://github.com/need4deed-org/be/issues/433

## Test plan

- [ ] `GET /volunteer?filter[engagement]=active` → `statusEngagement = vol-active` (prefix added)
- [ ] `GET /volunteer?filter[engagement]=vol-active` → `statusEngagement = vol-active` (no double prefix)
- [ ] Same for `filter[match]`
- [ ] Existing volunteer list without filters returns results as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)