### PR TITLE
fix(#546): pass dealId to updateOptionList for ProfileLanguage

### DIFF
--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -278,13 +278,13 @@ export default async function volunteerRoutes(
 
         if (languages) {
           const success = await updateOptionList(
-            id,
+            dealId,
             ProfileLanguage,
             languages,
           );
           if (!success) {
             return reply.status(400).send({
-              message: `Languages for volunteer (deal_id:${id}) not updated.`,
+              message: `Languages for volunteer (deal_id:${dealId}) not updated.`,
             });
           }
         }


### PR DESCRIPTION
## Summary

- `updateOptionList` for `ProfileLanguage` was called with `id` (volunteer ID) instead of `dealId`
- This caused the update to silently target an unrelated deal (one whose ID happened to equal the volunteer ID), returning HTTP 200 with no actual change
- Matches the pattern already used by activities, skills, locations, and availability

Closes https://github.com/need4deed-org/be/issues/546

## Test plan
- [ ] Edit a volunteer's language and save — language updates in view mode
- [ ] Other profile fields (availability, districts, activities, skills) still save correctly
- [ ] Saving with wrong data returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)