### PR TITLE
fix(#552): resolve TypeScript build errors blocking CI

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -227,7 +227,7 @@ export default async function opportunityRoutes(
       const data = opportunitiesCategoryDistrict.map(dtoOpportunityGetList);
 
       return reply.status(200).send({
-        message: `Opportunities page:${page}.`,
+        message: `Opportunities page:${request.query.page}.`,
         data,
         count,
       });

--- a/src/test/services/dto/dto-opportunity-volunteer.test.ts
+++ b/src/test/services/dto/dto-opportunity-volunteer.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../services/dto/utils", () => ({
 function makeOV(overrides: Partial<OpportunityVolunteer> = {}): OpportunityVolunteer {
   return new OpportunityVolunteer({
     id: 1,
-    status: OpportunityVolunteerStatusType.APPLIED,
+    status: OpportunityVolunteerStatusType.PENDING,
     volunteerId: 10,
     opportunityId: 20,
     updatedAt: new Date("2025-01-01"),
@@ -40,7 +40,7 @@ describe("volunteerOpportunityVolunteerDTO", () => {
     const result = volunteerOpportunityVolunteerDTO(ov);
 
     expect(result.id).toBe(1);
-    expect(result.status).toBe(OpportunityVolunteerStatusType.APPLIED);
+    expect(result.status).toBe(OpportunityVolunteerStatusType.PENDING);
     expect(result.volunteerId).toBe(10);
     expect(result.opportunityId).toBe(20);
     expect(result.title).toBe("German Lessons");


### PR DESCRIPTION
## Summary

Fixes the two TypeScript errors causing `build-be / build` to fail in CI (https://github.com/need4deed-org/n4d-infra/actions/runs/26227064823/job/77176837152).

- `opportunity.routes.ts:230`: used bare `page` variable that was never in scope — changed to `request.query.page`
- `dto-opportunity-volunteer.test.ts`: referenced `OpportunityVolunteerStatusType.APPLIED` which does not exist in the SDK — replaced with `PENDING`

Closes https://github.com/need4deed-org/be/issues/552

## Test plan
- [ ] `yarn build` passes with no TypeScript errors
- [ ] CI `build-be / build` passes on develop