### PR TITLE
fix(#554): persist appointmentPostcode when patching accompanying details

### DIFF
--- a/src/data/entity/opportunity/accompanying.entity.ts
+++ b/src/data/entity/opportunity/accompanying.entity.ts
@@ -49,6 +49,9 @@ export default class Accompanying {
   @IsEnum(TranslatedIntoType)
   languageToTranslate?: TranslatedIntoType;
 
+  @Column({ name: "postcode_id", nullable: true })
+  postcodeId?: number;
+
   @ManyToOne(() => Postcode, (postcode) => postcode.accompanying, {
     nullable: true,
     onDelete: "SET NULL",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -44,6 +44,7 @@ import {
   getOpportunityOrphanageAgent,
   getOpportunityWhere,
   getOrCreateTimeslot,
+  getPostcode,
   getSkipTake,
   patchEntity,
   updateOptionList,
@@ -324,15 +325,13 @@ export default async function opportunityRoutes(
         const appointmentPostcodeValue =
           request.body.accompanyingDetails?.appointmentPostcode;
         if (appointmentPostcodeValue !== undefined) {
-          const postcode = await fastify.db.postcodeRepository.findOneBy({
-            value: appointmentPostcodeValue,
-          });
+          const postcode = await getPostcode(appointmentPostcodeValue);
           if (!postcode) {
             throw new BadRequestError(
               `Postcode "${appointmentPostcodeValue}" not found.`,
             );
           }
-          accompanying.postcode = postcode;
+          accompanying.postcodeId = postcode.id;
         }
         const success = await patchEntity(
           Accompanying,


### PR DESCRIPTION
## Summary

- `patchEntity` uses TypeORM's `update()` which skips relation objects — `accompanying.postcode = postcode` was silently discarded, so `postcode_id` was never written to the DB
- Added explicit `postcodeId` FK column to `Accompanying` entity (no migration needed — the column already exists as the FK for the `postcode` relation)
- Changed `accompanying.postcode = postcode` → `accompanying.postcodeId = postcode.id` so the FK is passed as a scalar and `update()` writes it
- Replaced `findOneBy + BadRequestError` with `getPostcode` (same helper used by the legacy form) so coordinators can enter a new valid postcode in the dashboard without getting a 400

Closes https://github.com/need4deed-org/be/issues/554

## Test plan
- [ ] Fill in appointment postcode via the legacy public form → open opportunity in dashboard → postcode is displayed
- [ ] Edit appointment postcode in dashboard → save → postcode is displayed correctly
- [ ] Enter a postcode that doesn't yet exist in DB → save succeeds (auto-created)