### PR TITLE
chore: bump need4deed-sdk to 0.0.91 + reconcile agent contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.3.3",
     "fastify-mailer": "^2.3.1",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.86",
+    "need4deed-sdk": "0.0.91",
     "nodemailer": "^7.0.4",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -78,6 +78,8 @@ export default async function agentRoutes(
         "address.postcode",
         "district",
         "opportunity.opportunityVolunteer",
+        "agentPerson.person",
+        "organization",
       ];
       const [agents, count] = await agentRepository.findAndCount({
         where,

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -811,6 +811,8 @@
         "district": { "$ref": "Option#" },
         "trustLevel": { "$ref": "AgentTrustType#" },
         "activeVolunteers": { "type": "integer" },
+        "numActiveVolunteers": { "type": "integer" },
+        "email": { "type": "string" },
         "volunteerSearch": { "$ref": "AgentVolunteerSearchType#" }
       }
     },
@@ -821,8 +823,10 @@
         "id",
         "title",
         "type",
-        "district",
+        "trustLevel",
         "activeVolunteers",
+        "numActiveVolunteers",
+        "email",
         "volunteerSearch"
       ]
     },
@@ -869,7 +873,11 @@
             },
             "statusEngagement": { "$ref": "AgentEngagementStatusType#" },
             "agentDetails": { "$ref": "AgentDetails#" },
-            "comments": { "type": "array", "items": { "$ref": "ApiComment#" } }
+            "comments": { "type": "array", "items": { "$ref": "ApiComment#" } },
+            "languages": {
+              "type": "array",
+              "items": { "$ref": "ApiLanguage#" }
+            }
           }
         }
       ]
@@ -885,9 +893,16 @@
         "id",
         "title",
         "type",
-        "district",
+        "trustLevel",
         "activeVolunteers",
-        "volunteerSearch"
+        "numActiveVolunteers",
+        "email",
+        "volunteerSearch",
+        "createdAt",
+        "statusEngagement",
+        "agentDetails",
+        "comments",
+        "languages"
       ]
     },
     "ApiAccompanying": {

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -18,6 +18,9 @@ export function dtoAgentGetList(agent: Agent): ApiAgentGetList {
     trustLevel: agent.trustLevel,
     volunteerSearch: agent.searchStatus,
     activeVolunteers: agent.activeVolunteers,
+    numActiveVolunteers: agent.activeVolunteers,
+    email:
+      agent.representative?.person?.email || agent.organization?.email || "",
     district: { id: agent.districtId, title: { de: agent?.district?.title } },
   };
 }
@@ -39,6 +42,11 @@ export function dtoAgentGet(
     statusEngagement: agent.engagementStatus,
     agentDetails: dtoAgentDetails(agent),
     comments: agent.comments?.map(commentSerializer),
+    languages:
+      agent.agentLanguage?.map((al) => ({
+        id: al.languageId,
+        title: al.language?.title ?? "",
+      })) || [],
   };
 }
 

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -151,6 +151,8 @@ describe("dtoAgentGetList", () => {
       title: "Helping Hands",
       type: "NGO",
       activeVolunteers: 10,
+      numActiveVolunteers: 10,
+      email: "",
       district: {
         id: 201,
         title: { de: "Mitte" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,10 +3825,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.86:
-  version "0.0.86"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.86.tgz#bcd10ab5f0cf32a66c5c24a8c7cfb023b87259a5"
-  integrity sha512-9qczqBHlq+KU5tD41DOCfJIyHQRvl7+AJIvyx1nuurYQEBcyNCN6dLBEK3/kwZWx7RzydGj3DgvF7PIeVccICw==
+need4deed-sdk@0.0.91:
+  version "0.0.91"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.91.tgz#1d7408c939c59ce8b471c53869bbeb56ac5be37c"
+  integrity sha512-pwQEMaIZ74Zse60YEHVVw4nAl2x46G5zNegvz1G2qV0kOj5TmAWThFh9NBzBo5rY0Mw64JBGzq257OZ/7bUPjg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## What

Upgrades `need4deed-sdk` `0.0.86 → 0.0.91` (`yarn upgrade need4deed-sdk --latest`) and adapts the agent contract, which the bump broke (2 typecheck errors in `dto-agent.ts`).

### SDK 0.0.91 contract changes
- `VoidableProps<T, K extends keyof T = keyof T>` — only the listed keys `K` become optional/nullable; with no `K` (default `keyof T`) all props stay voidable. Previously *all* props were always voidable.
- `ApiAgentGetList = VoidableProps<AgentGetList, "district">` — added required `email` + `numActiveVolunteers`.
- `ApiAgentGet` — added required `languages: ApiLanguage[]`.
- `ApiAgentPatch` — unchanged in practice (still fully voidable).

### Changes
- **`dtoAgentGetList`** — `email` (representative's person email → organization email → `""`), `numActiveVolunteers` (= `activeVolunteers`).
- **`dtoAgentGet`** — `languages` mapped from `agentLanguage`.
- **`GET /agent` list query** — now loads `agentPerson.person` + `organization` so `email` resolves (detail query already loaded them).
- **`sdk-types.json`** — `AgentList` += `email`/`numActiveVolunteers`; `AgentId` += `languages` (`ApiLanguage#`); `district` dropped from `required` on `ApiAgentGetList`/`ApiAgentGet`.
- **Test** — updated `dtoAgentGetList` exact-shape expectation.

## Assumptions (flagging for review)
- `email` source = representative email, falling back to organization email (no `Agent.email` column exists).
- `numActiveVolunteers` treated as a duplicate/rename of `activeVolunteers`.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn lint` clean on changed files
- [x] `yarn test:run` — 200 tests pass
- [x] `sdk-types.json` valid JSON