### PR TITLE
chore: sync entities with DDL — add video-call to communication contact method enum

### DIFF
--- a/src/data/migrations/1779737272182-sync-entities-ddl.ts
+++ b/src/data/migrations/1779737272182-sync-entities-ddl.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class SyncEntitiesDdl1779737272182 implements MigrationInterface {
+  name = "SyncEntitiesDdl1779737272182";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."communication_contact_method_enum" RENAME TO "communication_contact_method_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."communication_contact_method_enum" AS ENUM('email', 'phone-number', 'telegram', 'whatsapp', 'signal', 'sms', 'voicenote', 'video-call')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "communication" ALTER COLUMN "contact_method" TYPE "public"."communication_contact_method_enum" USING "contact_method"::"text"::"public"."communication_contact_method_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."communication_contact_method_enum_old"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."communication_contact_method_enum_old" AS ENUM('email', 'phone-number', 'telegram', 'whatsapp', 'signal', 'sms', 'voicenote')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "communication" ALTER COLUMN "contact_method" TYPE "public"."communication_contact_method_enum_old" USING "contact_method"::"text"::"public"."communication_contact_method_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."communication_contact_method_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."communication_contact_method_enum_old" RENAME TO "communication_contact_method_enum"`,
+    );
+  }
+}


### PR DESCRIPTION
## What

Syncs the database DDL with the entities. The `communication_contact_method_enum` entity had gained a `'video-call'` value that was never captured in a migration.

## Change

New migration `1779737272182-sync-entities-ddl` recreates `communication_contact_method_enum` to include `'video-call'` (Postgres enum rename-swap pattern, with a proper `down`).

Generated via `yarn migration:generate`. A follow-up `migration:generate` reports **"No changes in database schema were found"**, confirming entities and DDL are fully in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)