### PR TITLE
feat: add UNIQUE(opportunity_id, volunteer_id) to OpportunityVolunteer

### DIFF
--- a/src/data/entity/m2m/opportunity-volunteer.ts
+++ b/src/data/entity/m2m/opportunity-volunteer.ts
@@ -8,12 +8,14 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Unique,
   UpdateDateColumn,
 } from "typeorm";
 import Opportunity from "../opportunity/opportunity.entity";
 import Volunteer from "../volunteer/volunteer.entity";
 
 @Entity()
+@Unique(["opportunityId", "volunteerId"])
 export default class OpportunityVolunteer {
   constructor(opportunityVolunteer?: Partial<OpportunityVolunteer>) {
     if (opportunityVolunteer) {

--- a/src/data/migrations/1779738026660-add-unique-opp-vol.ts
+++ b/src/data/migrations/1779738026660-add-unique-opp-vol.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Remove rows that would violate the new UNIQUE (opportunity_id, volunteer_id)
+// constraint, keeping exactly one row per pair. A single ranking expresses both
+// rules: prefer the matched row when statuses differ, otherwise keep the latest.
+//   1. status = 'opp-matched' first (so a differing-status group keeps the matched one)
+//   2. then most recently created, then highest id (so a same-status group keeps the latest)
+const sqlDedupe = `
+DELETE FROM opportunity_volunteer
+WHERE id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY opportunity_id, volunteer_id
+        ORDER BY (status::text = 'opp-matched') DESC, created_at DESC, id DESC
+      ) AS rn
+    FROM opportunity_volunteer
+  ) ranked
+  WHERE rn > 1
+);
+`;
+
+export class AddUniqueOppVol1779738026660 implements MigrationInterface {
+  name = "AddUniqueOppVol1779738026660";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(sqlDedupe);
+    await queryRunner.query(
+      `ALTER TABLE "opportunity_volunteer" ADD CONSTRAINT "UQ_ef61e09ab1a57be86168bd83378" UNIQUE ("opportunity_id", "volunteer_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "opportunity_volunteer" DROP CONSTRAINT "UQ_ef61e09ab1a57be86168bd83378"`,
+    );
+  }
+}


### PR DESCRIPTION
## What

Adds a `@Unique(["opportunityId", "volunteerId"])` constraint to the `OpportunityVolunteer` entity so a volunteer can have at most one match record per opportunity.

## Pre-existing duplicates

The dev and **production** databases already contain rows that violate this. The migration removes them *before* adding the constraint, keeping exactly one row per `(opportunity_id, volunteer_id)` pair via a single window-function ranking:

- prefer `status = 'opp-matched'` when statuses differ
- otherwise keep the latest (`created_at DESC`, then `id DESC`)

In dev this deleted 4 violators across 4 groups; the correct survivors (2 matched, 2 latest-pending) remain. Verified afterwards: 0 duplicates, constraint present, no schema drift, `typecheck` passes.

### Edge case
A group with differing statuses but *no* `opp-matched` falls back to keeping the latest. None exist in dev; prod may differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)