### PR TITLE
feat(#570): align GET /volunteer response with SDK ApiVolunteerGetList

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.3.3",
     "fastify-mailer": "^2.3.1",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.91",
+    "need4deed-sdk": "0.0.93",
     "nodemailer": "^7.0.4",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -234,7 +234,13 @@
     "VolunteerStateMatchType": {
       "$id": "VolunteerStateMatchType",
       "type": "string",
-      "enum": ["matched", "needs-rematching"]
+      "enum": [
+        "vol-no-matches",
+        "vol-pending-match",
+        "vol-matched",
+        "vol-needs-rematch",
+        "vol-past"
+      ]
     },
     "VolunteerStateCGCType": {
       "$id": "VolunteerStateCGCType",

--- a/src/server/schema/volunteer-api.json
+++ b/src/server/schema/volunteer-api.json
@@ -12,25 +12,31 @@
         "name": {
           "type": "string"
         },
-        "avatarUrl": {
+        "email": {
           "type": "string"
+        },
+        "avatarUrl": {
+          "type": ["string", "null"]
         },
         "statusEngagement": {
           "$ref": "VolunteerStateEngagementType#"
         },
         "statusType": {
-          "$ref": "VolunteerStateType#"
-        },
-        "stateEngagement": {
-          "$ref": "VolunteerStateEngagementType#"
-        },
-        "stateType": {
           "$ref": "VolunteerStateTypeType#"
+        },
+        "statusMatch": {
+          "oneOf": [{ "$ref": "VolunteerStateMatchType#" }, { "type": "null" }]
+        },
+        "statusCommunication": {
+          "oneOf": [
+            { "$ref": "VolunteerStateCommunicationType#" },
+            { "type": "null" }
+          ]
         },
         "languages": {
           "type": "array",
           "items": {
-            "$ref": "Language#"
+            "$ref": "ApiLanguage#"
           }
         },
         "availability": {
@@ -42,31 +48,34 @@
         "activities": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "OptionItem#"
           }
         },
         "skills": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "OptionItem#"
           }
         },
         "locations": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "OptionItem#"
           }
         }
       },
       "required": [
         "id",
         "name",
+        "email",
         "avatarUrl",
+        "statusEngagement",
+        "statusType",
         "languages",
         "availability",
         "activities",
-        "locations",
-        "skills"
+        "skills",
+        "locations"
       ],
       "additionalProperties": false
     }

--- a/src/services/dto/dto-volunteer.ts
+++ b/src/services/dto/dto-volunteer.ts
@@ -9,13 +9,7 @@ import Comment from "../../data/entity/comment.entity";
 import Timeline from "../../data/entity/timeline.entity";
 import Volunteer from "../../data/entity/volunteer/volunteer.entity";
 import logger from "../../logger";
-import {
-  getAvailability,
-  getLanguages,
-  getOptionItems,
-  getTitles,
-} from "./utils";
-
+import { getAvailability, getLanguages, getOptionItems } from "./utils";
 
 export function volunteerListSerializer(
   volunteer: Volunteer,
@@ -24,16 +18,19 @@ export function volunteerListSerializer(
     const id = volunteer.id;
     const statusEngagement = volunteer.statusEngagement;
     const statusType = volunteer.statusType;
+    const statusMatch = volunteer.statusMatch ?? null;
+    const statusCommunication = volunteer.statusCommunication ?? null;
     const name = volunteer.person.name;
+    const email = volunteer.person.email;
     const avatarUrl = volunteer.person?.avatarUrl || null;
     const languages = getLanguages(volunteer.deal.profile.profileLanguage);
     const availability = getAvailability(volunteer.deal.time?.timeTimeslot);
-    const activities = getTitles(
+    const activities = getOptionItems(
       volunteer.deal.profile.profileActivity,
       "activity",
     );
-    const skills = getTitles(volunteer.deal.profile.profileSkill, "skill");
-    const locations = getTitles(
+    const skills = getOptionItems(volunteer.deal.profile.profileSkill, "skill");
+    const locations = getOptionItems(
       volunteer.deal.location?.locationDistrict,
       "district",
     );
@@ -42,7 +39,10 @@ export function volunteerListSerializer(
       id,
       statusEngagement,
       statusType,
+      statusMatch,
+      statusCommunication,
       name,
+      email,
       avatarUrl,
       languages,
       availability,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,10 +3825,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.91:
-  version "0.0.91"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.91.tgz#1d7408c939c59ce8b471c53869bbeb56ac5be37c"
-  integrity sha512-pwQEMaIZ74Zse60YEHVVw4nAl2x46G5zNegvz1G2qV0kOj5TmAWThFh9NBzBo5rY0Mw64JBGzq257OZ/7bUPjg==
+need4deed-sdk@0.0.93:
+  version "0.0.93"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.93.tgz#3a4ba180b85e13b67d35ffdcb00ee5428efe9561"
+  integrity sha512-FFE23QIYZxnTW5FP0f7oBsQ/o4oPoPipDbhWso2oU/t39G8nA53BsoYy57d5InuwgE69aSIJrsEV0QYA4yuY4w==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Closes #570.

## Why

`GET /volunteer` (list) drifted from the SDK. Because Fastify serializes responses against the JSON-schema and strips unknown fields, several real volunteer fields were being silently dropped on the wire.

## Changes

- **`need4deed-sdk`** 0.0.91 → 0.0.93
- **`src/server/schema/volunteer-api.json`** — exactly matches SDK `ApiVolunteerGetList`:
  - adds `email`, `statusMatch`, `statusCommunication`
  - drops phantom `stateEngagement` / `stateType`
  - `activities` / `skills` / `locations` items → `OptionItem#` (was plain `string`)
  - fixes broken `Language#` → `ApiLanguage#`
  - `statusMatch` / `statusCommunication` are `oneOf [ref, null]` to model `VoidableProps`
- **`src/server/schema/sdk-types.json`** — `VolunteerStateMatchType` enum updated to the actual DDL values (`vol-no-matches`, `vol-pending-match`, `vol-matched`, `vol-needs-rematch`, `vol-past`). Without this the new `statusMatch` field would still have been stripped at serialization time.
- **`src/services/dto/dto-volunteer.ts`** — `volunteerListSerializer` now emits `email`, `statusMatch`, `statusCommunication` and uses `getOptionItems` (not `getTitles`) so activities/skills/locations are `OptionItem[]`.

## Verified

- `yarn typecheck` clean
- `yarn test:run` — 203 tests pass
- `be` container reloads cleanly after restart; published `/swagger/json` reflects the new shape (all 13 properties, voidable refs as `oneOf [ref, null]`, `OptionItem` items, full DDL match enum)

## Follow-up

#571 — wire `getFilteredVolunteers` (MV-backed search/filter) into the route. Several field-name mismatches there need their own design pass; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)