### PR TITLE
feat(#575): align GET /opportunity response with SDK ApiOpportunityGetList

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.3.3",
     "fastify-mailer": "^2.3.1",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.93",
+    "need4deed-sdk": "0.0.94",
     "nodemailer": "^7.0.4",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -632,47 +632,63 @@
         "opp-past"
       ]
     },
+    "OpportunityMatchStatusType": {
+      "$id": "OpportunityMatchStatusType",
+      "type": "string",
+      "enum": [
+        "opp-vol-pending-match",
+        "opp-vol-no-matches",
+        "opp-vol-matched",
+        "opp-vol-needs-rematch",
+        "opp-vol-unmatched",
+        "opp-vol-past"
+      ]
+    },
     "ApiOpportunityGetList": {
       "$id": "ApiOpportunityGetList",
       "type": "object",
       "properties": {
         "id": { "type": "integer" },
-        "volunteerType": { "$ref": "OpportunityType#" },
-        "statusOpportunity": { "$ref": "OpportunityStatusType#" },
         "title": { "type": "string" },
-        "availability": {
+        "category": { "$ref": "OptionById#" },
+        "district": { "$ref": "OptionById#" },
+        "volunteerType": { "$ref": "VolunteerStateTypeType#" },
+        "statusOpportunity": { "$ref": "OpportunityStatusType#" },
+        "statusMatch": { "$ref": "OpportunityMatchStatusType#" },
+        "numberOfVolunteers": { "type": "integer" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "activities": {
           "type": "array",
-          "items": { "$ref": "ApiAvailability#" }
+          "items": { "$ref": "OptionById#" }
         },
         "languages": {
           "type": "array",
           "items": { "$ref": "ApiLanguage#" }
         },
-        "activities": {
+        "availability": {
           "type": "array",
-          "items": { "$ref": "OptionById#" }
+          "items": { "$ref": "ApiAvailability#" }
         },
         "location": { "type": "array", "items": { "$ref": "OptionById#" } },
         "accompanyingDetails": { "$ref": "ApiAccompanying#" },
-        "category": {
-          "type": "object",
-          "properties": { "id": { "type": "integer" } }
-        },
-        "district": {
-          "type": "object",
-          "properties": { "id": { "type": "integer" } }
-        }
+        "agentTitle": { "type": "string" }
       },
       "required": [
         "id",
-        "volunteerType",
-        "statusOpportunity",
         "title",
         "category",
-        "availability",
-        "languages",
+        "district",
+        "volunteerType",
+        "statusOpportunity",
+        "statusMatch",
+        "numberOfVolunteers",
+        "createdAt",
         "activities",
-        "accompanyingDetails"
+        "languages",
+        "availability",
+        "location",
+        "accompanyingDetails",
+        "agentTitle"
       ]
     },
     "ApiOpportunityGet": {

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -46,11 +46,11 @@ export function dtoOpportunityGetList(
     id: opportunity.id,
     title: opportunity.title,
     category: { id: opportunity.deal.profile.categoryId },
-    ...(opportunity.districtId
-      ? { district: { id: opportunity.districtId } }
-      : {}),
+    district: { id: opportunity.district?.id ?? opportunity.districtId },
     volunteerType: opportunity.type,
     statusOpportunity: opportunity.status,
+    statusMatch: opportunity.statusMatch,
+    numberOfVolunteers: opportunity.numberVolunteers,
     createdAt: opportunity.createdAt,
     languages: opportunity.deal.profile.profileLanguage
       .filter(Boolean)
@@ -73,7 +73,7 @@ export function dtoOpportunityGetList(
     availability:
       getAvailabilityTryCatch(opportunity.deal.time?.timeTimeslot) ?? [],
     accompanyingDetails: dtoOpportunityAccompanying(opportunity.accompanying!),
-    statusMatch: opportunity.statusMatch,
+    agentTitle: opportunity.agent?.title ?? "",
   } as ApiOpportunityGetList;
 }
 
@@ -128,11 +128,12 @@ export function dtoOpportunityGet(
     statusOpportunity: opportunityComments.status,
     createdAt: opportunityComments.createdAt,
     category: { id: opportunityComments.deal.profile.categoryId },
-    ...(opportunityComments.districtId
-      ? { district: { id: opportunityComments.districtId } }
-      : {}),
+    district: {
+      id: opportunityComments.district?.id ?? opportunityComments.districtId,
+    },
     description: getOpportunityDescription(opportunityComments) ?? "",
     numberOfVolunteers: opportunityComments.numberVolunteers,
+    agentTitle: opportunityComments.agent?.title ?? "",
     languages: opportunityComments.deal.profile.profileLanguage
       .filter(Boolean)
       .map((pl) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,10 +3825,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.93:
-  version "0.0.93"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.93.tgz#3a4ba180b85e13b67d35ffdcb00ee5428efe9561"
-  integrity sha512-FFE23QIYZxnTW5FP0f7oBsQ/o4oPoPipDbhWso2oU/t39G8nA53BsoYy57d5InuwgE69aSIJrsEV0QYA4yuY4w==
+need4deed-sdk@0.0.94:
+  version "0.0.94"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.94.tgz#61bb69a2d165fc1f639de10317b5fcc9b5a7c9aa"
+  integrity sha512-WxXyJ2/QO8qBuaybxkAd0vYY+BpXbB5iHmj7OSkl4P9wI3yn+T+qsN3W9dtBERhWpzXpS+djcLn3KLhU1pTgXQ==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Closes #575.

## Why

`GET /opportunity` (list) drifted from `need4deed-sdk`. Real fields were being stripped at response serialization (`fast-json-stringify` writes only fields declared in the schema). Same class of fix as #570 (volunteer alignment).

Also bumps the SDK 0.0.93 → 0.0.94, which **added two new required fields** to `ApiOpportunityGetList`: `numberOfVolunteers` and `agentTitle`.

## Changes

### `need4deed-sdk` 0.0.93 → 0.0.94

### `src/server/schema/sdk-types.json`

- **Registered `OpportunityMatchStatusType` enum** (was previously unregistered — its `$ref` resolved to nothing, so `statusMatch` was being stripped silently). 6 DDL values.
- **`ApiOpportunityGetList`**:
  - Added: `statusMatch`, `numberOfVolunteers`, `createdAt`, `agentTitle` (all SDK-required).
  - Replaced inline `category` / `district` with `$ref: OptionById#`.
  - Switched `volunteerType` from `OpportunityType#` to `VolunteerStateTypeType#` (the SDK type — includes `regular-accompanying`, which `OpportunityType` excludes).
  - `required` now matches the SDK (all 15 fields).

### `src/services/dto/dto-opportunity.ts`

- `dtoOpportunityGetList`: always emit `district` (was conditionally omitted — would 500 now that it's required), plus emit `numberOfVolunteers` and `agentTitle`.
- `dtoOpportunityGet`: same — always emit `district`, plus emit `agentTitle` (already emitted `numberOfVolunteers`). Caught by the single endpoint regressing to 500 with `"agentTitle" is required!` during verification.

## Verified live

Logged in as `sarah.doe@need4deed.org` (coordinator) against the running dev BE.

**`GET /opportunity/?page=1&limit=2`** — HTTP 200, all 15 SDK keys present:

```
id, title, category, district, volunteerType, statusOpportunity,
statusMatch, numberOfVolunteers, createdAt, activities, languages,
availability, location, accompanyingDetails, agentTitle
```

Sample (one item): `district: {"id":11}`, `numberOfVolunteers: 1`, `agentTitle: "Bornitzstraße"`, `statusMatch: "opp-vol-no-matches"`.

**Sample of 50** — 0 missing `district`, 0 empty `agentTitle`.

**`GET /opportunity/1`** (single, inherits via `allOf: [ApiOpportunityGetList#, …]`) — HTTP 200, same new fields populated.

`yarn typecheck` clean, `yarn test:run` — 203/203 pass.

## Note on `district` requiredness

`district` is now in `required` (matches SDK type `district: OptionById`, no `?`). The DTOs always emit it as `{ id: opportunity.district?.id ?? opportunity.districtId }` — Fastify enforces `required` at response serialization (it 500'd during verification when I omitted `agentTitle` from `dtoOpportunityGet`), so the contract holds strictly now.

## Out of scope

- `dtoVolunteerOpportunityGetList` + its schema in `volunteer-api-opportunity.json` — the schema is its own broken thing (`additionalProperties: false`, broken `Language#` ref, `activities`/`location` not arrays). Deserves its own ticket.
- Naming inconsistency: SDK uses `ApiOpportunityAccompanyingDetails`, BE registers it as `ApiAccompanying` — same shape, cosmetic.
- Data quirks (`category.id: ""` on some, Unix-epoch `createdAt` on legacy rows) — not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)