### PR TITLE
feat(#488): expose agent id in opportunity agent DTO

### DIFF
--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -44,10 +44,14 @@ export function dtoAgentGet(
 
 export function dtoOpportunityAgent(agent: Agent): ApiOpportunityAgent {
   return {
+    id: agent.id,
     type: agent.type,
     name: agent.title,
     address: serializeAddress(agent.representative?.person?.address),
-    district: { id: agent.districtId, title: { de: agent.district?.title } },
+    district: {
+      id: agent.districtId,
+      title: { de: agent.district?.title, en: agent.district?.title },
+    },
   };
 }
 


### PR DESCRIPTION
Adds `id` to `dtoOpportunityAgent` so the FE can navigate to the agent profile from an opportunity.

Depends on SDK: https://github.com/need4deed-org/sdk/pull/117
Needed by FE: https://github.com/need4deed-org/fe/pull/525

🤖 Generated with [Claude Code](https://claude.com/claude-code)