### PR TITLE
feat: wire SES client to ECS task role + configuration set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@ AWS_SES_REGION=eu-central-1
 AWS_SES_ACCESS_KEY_ID=fake-string
 AWS_SES_SECRET_ACCESS_KEY=fake-string
 AWS_SES_FROM_EMAIL=no-reply@need4deed.org
+# Optional: override SES endpoint for LocalStack, e.g. http://localstack:4566
+AWS_SES_ENDPOINT=
+# Optional: SES configuration set for bounce/complaint event publishing.
+# Set in deployed environments (e.g. `need4deed-default`); leave empty locally.
+AWS_SES_CONFIGURATION_SET=
 
 CORS_ORIGINS=http://vmpub:3000,http://vmpub:3100,http://vmpub:3200
 CORS_CREDENTIALS=true

--- a/src/services/notify/transports/email-ses.ts
+++ b/src/services/notify/transports/email-ses.ts
@@ -6,6 +6,7 @@ export class SesEmailTransport implements EmailTransport {
   constructor(private readonly client: SESv2Client) {}
 
   async send(msg: EmailMessage): Promise<void> {
+    const configurationSet = process.env.AWS_SES_CONFIGURATION_SET;
     const cmd = new SendEmailCommand({
       FromEmailAddress: msg.from ?? defaultFrom,
       Destination: { ToAddresses: [msg.to] },
@@ -18,17 +19,26 @@ export class SesEmailTransport implements EmailTransport {
           },
         },
       },
+      ...(configurationSet ? { ConfigurationSetName: configurationSet } : {}),
     });
     await this.client.send(cmd);
   }
 }
 
 export function createSesClient(): SESv2Client {
+  const accessKeyId = process.env.AWS_SES_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SES_SECRET_ACCESS_KEY;
+  // In ECS, static keys would override the task role and break SES auth.
+  // Only set them locally (dev / LocalStack); otherwise let the SDK's
+  // default credential provider chain resolve them.
+  const credentials =
+    accessKeyId && secretAccessKey
+      ? { accessKeyId, secretAccessKey }
+      : undefined;
+
   return new SESv2Client({
     region: process.env.AWS_SES_REGION,
-    credentials: {
-      accessKeyId: process.env.AWS_SES_ACCESS_KEY_ID,
-      secretAccessKey: process.env.AWS_SES_SECRET_ACCESS_KEY,
-    },
+    credentials,
+    endpoint: process.env.AWS_SES_ENDPOINT,
   });
 }

--- a/src/services/notify/transports/email-ses.ts
+++ b/src/services/notify/transports/email-ses.ts
@@ -35,10 +35,11 @@ export function createSesClient(): SESv2Client {
     accessKeyId && secretAccessKey
       ? { accessKeyId, secretAccessKey }
       : undefined;
+  const endpoint = process.env.AWS_SES_ENDPOINT;
 
   return new SESv2Client({
     region: process.env.AWS_SES_REGION,
     credentials,
-    endpoint: process.env.AWS_SES_ENDPOINT,
+    ...(endpoint ? { endpoint } : {}),
   });
 }


### PR DESCRIPTION
## Summary

- `createSesClient` now only sets static credentials when both `AWS_SES_ACCESS_KEY_ID` and `AWS_SES_SECRET_ACCESS_KEY` are present. In ECS the SDK's default credential provider chain resolves the task-role credentials; passing empty static keys previously overrode that and broke SES auth in deployed environments.
- `SendEmailCommand` now passes `ConfigurationSetName` when `AWS_SES_CONFIGURATION_SET` is set, so bounces/complaints flow to the SNS feedback topic provisioned in [n4d-infra#35](https://github.com/need4deed-org/n4d-infra/pull/35).
- Honors `AWS_SES_ENDPOINT` so LocalStack can still be targeted locally.
- Documents both new env vars in `.env.example`.

Closes #584.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn test:run` passes (203/203)
- [ ] Once SES identity is verified in Namecheap, manual send from deployed `pre`/`prod` ECS service delivers and bounce/complaint events show up on the SNS topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)