### PR TITLE
feat: add nullable submittedByPersonId FK to Opportunity (#587)

### DIFF
--- a/src/data/entity/opportunity/opportunity.entity.ts
+++ b/src/data/entity/opportunity/opportunity.entity.ts
@@ -18,6 +18,7 @@ import {
 import Deal from "../deal.entity";
 import District from "../location/district.entity";
 import OpportunityVolunteer from "../m2m/opportunity-volunteer";
+import Person from "../person.entity";
 import Appreciation from "../volunteer/appreciation.entity";
 import Accompanying from "./accompanying.entity";
 import Agent from "./agent.entity";
@@ -108,6 +109,12 @@ export default class Opportunity {
   agent?: Agent;
   @Column({ nullable: true })
   agentId?: number;
+
+  @ManyToOne(() => Person, { nullable: true })
+  @JoinColumn({ name: "submitted_by_person_id" })
+  submittedByPerson?: Person;
+  @Column({ nullable: true })
+  submittedByPersonId?: number;
 
   @ManyToOne(() => District)
   @JoinColumn({ name: "district_id" })

--- a/src/data/migrations/1780167679271-add-submitted-by-person-to-opportunity.ts
+++ b/src/data/migrations/1780167679271-add-submitted-by-person-to-opportunity.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSubmittedByPersonToOpportunity1780167679271
+  implements MigrationInterface
+{
+  name = "AddSubmittedByPersonToOpportunity1780167679271";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" ADD "submitted_by_person_id" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" ADD CONSTRAINT "FK_4f3dd494438470c347902f276d7" FOREIGN KEY ("submitted_by_person_id") REFERENCES "person"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" DROP CONSTRAINT "FK_4f3dd494438470c347902f276d7"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" DROP COLUMN "submitted_by_person_id"`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `Opportunity.submittedByPersonId` (nullable) → `Person` and the matching `submittedByPerson` `@ManyToOne` relation, placed alongside the existing `agentId` block.
- Generated migration `1780167679271-add-submitted-by-person-to-opportunity.ts` adds the column + FK; existing rows default to `NULL`.

This is the structural-only change. No DTO, route, or seed wiring — those land in #588 (DTO), #589 (legacy handler), #590 (backfill).

Closes #587.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test:run` — 203/203
- [x] Migration `up()`/`down()` are symmetric (add column + FK, drop FK + column)
- [ ] After merge: nodemon in the `be` dev container will pick up the migration on next restart per project convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)