### PR TITLE
feat: ApiOpportunityGet.contact prefers submitter when still at agent (#588)

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -88,6 +88,7 @@ export default async function opportunityRoutes(
         "deal.time.timeTimeslot.timeslot",
         "agent.agentPerson.person.address.postcode",
         "agent.district",
+        "submittedByPerson.agentPerson",
       ];
 
       const opportunityRepository = fastify.db.opportunityRepository;

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -26,16 +26,28 @@ function getOpportunityDescription(opportunity: Opportunity) {
   return opportunity.info;
 }
 
-function getOpportunityContact(
+// Best-effort: returns the original submitter if they still hold an
+// agent_person row for the opportunity's agent; otherwise falls back to
+// the current agent representative. Not guaranteed to be the submitter.
+export function getOpportunityContact(
   opportunity: Opportunity,
 ): ApiOpportunityContact {
+  const submitter = opportunity.submittedByPerson;
+  const submitterStillAtAgent =
+    !!submitter &&
+    !!opportunity.agentId &&
+    !!submitter.agentPerson?.some((ap) => ap.agentId === opportunity.agentId);
+
+  const person = submitterStillAtAgent
+    ? submitter
+    : opportunity.agent?.representative?.person;
+
   return {
-    id: opportunity.agent?.representative?.person?.id,
-    name: opportunity.agent?.representative?.person?.name,
-    phone: opportunity.agent?.representative?.person?.phone,
-    email: opportunity.agent?.representative?.person?.email,
-    waysToContact:
-      opportunity.agent?.representative?.person?.preferredCommunicationType,
+    id: person?.id,
+    name: person?.name,
+    phone: person?.phone,
+    email: person?.email,
+    waysToContact: person?.preferredCommunicationType,
   };
 }
 

--- a/src/test/services/dto/dto-opportunity.test.ts
+++ b/src/test/services/dto/dto-opportunity.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { getOpportunityContact } from "../../../services/dto/dto-opportunity";
+
+const representativePerson = {
+  id: 100,
+  name: "Coord Carla",
+  phone: "+49-30-1111111",
+  email: "carla@center.de",
+  preferredCommunicationType: ["email"],
+};
+
+const agentWithRepresentative = {
+  id: 42,
+  representative: { person: representativePerson },
+};
+
+describe("getOpportunityContact", () => {
+  it("returns the submitter when submittedByPerson has an agent_person row for the agent", () => {
+    const submitter = {
+      id: 7,
+      name: "Submitter Sam",
+      phone: "+49-30-2222222",
+      email: "sam@center.de",
+      preferredCommunicationType: ["mobilePhone"],
+      agentPerson: [{ agentId: 42 }, { agentId: 999 }],
+    };
+
+    const opportunity = {
+      agentId: 42,
+      agent: agentWithRepresentative,
+      submittedByPersonId: 7,
+      submittedByPerson: submitter,
+    };
+
+    const result = getOpportunityContact(opportunity as any);
+
+    expect(result).toEqual({
+      id: 7,
+      name: "Submitter Sam",
+      phone: "+49-30-2222222",
+      email: "sam@center.de",
+      waysToContact: ["mobilePhone"],
+    });
+  });
+
+  it("falls back to the agent representative when submittedByPerson is unset", () => {
+    const opportunity = {
+      agentId: 42,
+      agent: agentWithRepresentative,
+      submittedByPersonId: null,
+      submittedByPerson: null,
+    };
+
+    const result = getOpportunityContact(opportunity as any);
+
+    expect(result).toEqual({
+      id: 100,
+      name: "Coord Carla",
+      phone: "+49-30-1111111",
+      email: "carla@center.de",
+      waysToContact: ["email"],
+    });
+  });
+
+  it("falls back to the agent representative when the submitter no longer has an agent_person row for this agent", () => {
+    const formerSubmitter = {
+      id: 7,
+      name: "Former Submitter",
+      email: "old@center.de",
+      agentPerson: [{ agentId: 999 }],
+    };
+
+    const opportunity = {
+      agentId: 42,
+      agent: agentWithRepresentative,
+      submittedByPersonId: 7,
+      submittedByPerson: formerSubmitter,
+    };
+
+    const result = getOpportunityContact(opportunity as any);
+
+    expect(result.id).toBe(100);
+    expect(result.name).toBe("Coord Carla");
+  });
+
+  it("falls back when the submitter has no agentPerson rows at all", () => {
+    const looseSubmitter = {
+      id: 7,
+      name: "Loose Submitter",
+      email: "loose@center.de",
+      agentPerson: [],
+    };
+
+    const opportunity = {
+      agentId: 42,
+      agent: agentWithRepresentative,
+      submittedByPersonId: 7,
+      submittedByPerson: looseSubmitter,
+    };
+
+    const result = getOpportunityContact(opportunity as any);
+
+    expect(result.id).toBe(100);
+  });
+
+  it("falls back when the opportunity has no agentId, even if submittedByPerson is set", () => {
+    const submitter = {
+      id: 7,
+      name: "Sam",
+      agentPerson: [{ agentId: 42 }],
+    };
+
+    const opportunity = {
+      agentId: null,
+      agent: agentWithRepresentative,
+      submittedByPersonId: 7,
+      submittedByPerson: submitter,
+    };
+
+    const result = getOpportunityContact(opportunity as any);
+
+    expect(result.id).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

- `getOpportunityContact` (`src/services/dto/dto-opportunity.ts`) now returns `opportunity.submittedByPerson` when that person still has an `agent_person` row for `opportunity.agentId`. Falls back to the previous `agent.representative.person` behaviour otherwise.
- `GET /opportunity/:id` eager-loads `submittedByPerson.agentPerson` so the DTO doesn't need a second query.
- `getOpportunityContact` is now exported and has a one-line JSDoc-style comment documenting the "best-effort: submitter if still here, else current representative" semantics. Documenting this on the SDK's `ApiOpportunityContact` interface is a follow-up on the SDK repo.
- 5 new unit tests in `src/test/services/dto/dto-opportunity.test.ts` cover all branches:
  1. submitter present at agent → returned
  2. submitter unset → fallback
  3. submitter exists but `agent_person` only for *other* agents → fallback
  4. submitter has empty `agentPerson` array → fallback
  5. `opportunity.agentId` is null → fallback

Closes #588.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test:run` — 208/208 (was 203, +5)
- [x] Behaviour matches the issue's truth table

## Out of scope

- SDK-side JSDoc on `ApiOpportunityContact` — separate change on the SDK repo.
- Wiring the legacy POST handler to set `submittedByPersonId` (so this branch ever fires for new submissions) — #589.
- Backfilling existing rows so historical opportunities benefit — #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)