### PR TITLE
feat: legacy POST resolves submitter, drops Comment PII blob (#589)

### DIFF
--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -4,13 +4,11 @@ import {
   FastifyPluginOptions,
 } from "fastify";
 import {
-  EntityTableName,
   OpportunityLegacyFormData,
   OpportunityStatusType,
 } from "need4deed-sdk";
 import { ILike, In } from "typeorm";
 import { UnauthorizedError } from "../../../config";
-import Comment from "../../../data/entity/comment.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import logger from "../../../logger";
@@ -26,6 +24,7 @@ import {
   getDistrictToOpportunityHandler,
   getOpportunityNotificationText,
   getOpportunityOrphanageAgent,
+  getOrCreateSubmitterPerson,
   writeOpportunityLegacy,
 } from "../../utils";
 
@@ -89,17 +88,17 @@ export default async function opportunityLegacyRoutes(
       const { addDistrictToOpportunity } = getDistrictToOpportunityHandler();
       Object.assign(opportunity, await addDistrictToOpportunity(opportunity));
 
-      const id = await writeOpportunityLegacy(opportunity);
+      if (opportunity.agent?.id) {
+        const submitter = await getOrCreateSubmitterPerson(
+          request.body,
+          opportunity.agent.id,
+        );
+        if (submitter) {
+          opportunity.submittedByPersonId = submitter.id;
+        }
+      }
 
-      const commentRepository = fastify.db.commentRepository;
-      await commentRepository.save(
-        new Comment({
-          text: `${request.body.rac_email}<|>${request.body.rac_full_name}<|>${request.body.rac_address}<|>${request.body.rac_plz}<|>${request.body.rac_phone}`,
-          entityId: id,
-          entityType: EntityTableName.OPPORTUNITY,
-          userId: 1,
-        }),
-      );
+      const id = await writeOpportunityLegacy(opportunity);
 
       fastify.notify.opsAlert(
         getOpportunityNotificationText(opportunity.title),

--- a/src/server/utils/data/get-or-create-submitter-person.ts
+++ b/src/server/utils/data/get-or-create-submitter-person.ts
@@ -1,0 +1,86 @@
+import { AgentRoleType, OpportunityLegacyFormData } from "need4deed-sdk";
+import { DataSource, EntityManager, ILike } from "typeorm";
+import { dataSource } from "../../../data/data-source";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Person from "../../../data/entity/person.entity";
+import { getRepository } from "../../../data/utils";
+
+type SubmitterFields = Pick<
+  OpportunityLegacyFormData,
+  "rac_email" | "rac_full_name" | "rac_phone"
+>;
+
+function splitName(
+  rawName: string | undefined,
+  email: string,
+): { firstName: string; lastName?: string } {
+  const trimmed = (rawName ?? "").trim();
+  if (!trimmed) {
+    return { firstName: email.split("@")[0] || "unknown" };
+  }
+  const [first, ...rest] = trimmed.split(/\s+/);
+  return {
+    firstName: first,
+    lastName: rest.length ? rest.join(" ") : undefined,
+  };
+}
+
+/**
+ * Resolve a Person + AgentPerson link for the submitter of a legacy
+ * opportunity:
+ *
+ *   1. Empty/missing rac_email -> return null (no Person manufactured).
+ *   2. Lookup by email (case-insensitive). If found + AgentPerson row already
+ *      exists for (person, agentId), no-op.
+ *   3. Found + no link -> upsert AgentPerson with VOLUNTEER_COORDINATOR role.
+ *   4. Not found -> create Person from rac_*; upsert AgentPerson with same
+ *      role.
+ *
+ * `manager` defaults to the global dataSource; pass a transactional
+ * EntityManager (or a migration's QueryRunner.manager) to make the writes
+ * atomic with surrounding work.
+ */
+export async function getOrCreateSubmitterPerson(
+  body: SubmitterFields,
+  agentId: number,
+  manager: DataSource | EntityManager = dataSource,
+): Promise<Person | null> {
+  const email = (body.rac_email ?? "").trim();
+  if (!email) {
+    return null;
+  }
+
+  const personRepository = getRepository(manager, Person);
+  const agentPersonRepository = getRepository(manager, AgentPerson);
+
+  let person = await personRepository.findOne({
+    where: { email: ILike(email) },
+  });
+
+  if (!person) {
+    const { firstName, lastName } = splitName(body.rac_full_name, email);
+    person = await personRepository.save(
+      new Person({
+        firstName,
+        lastName,
+        email,
+        phone: body.rac_phone || undefined,
+      }),
+    );
+  }
+
+  const existingLink = await agentPersonRepository.findOne({
+    where: { agentId, personId: person.id },
+  });
+  if (!existingLink) {
+    await agentPersonRepository.save(
+      new AgentPerson({
+        agentId,
+        personId: person.id,
+        role: AgentRoleType.VOLUNTEER_COORDINATOR,
+      }),
+    );
+  }
+
+  return person;
+}

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -8,6 +8,7 @@ export * from "./get-agent-where";
 export * from "./get-language-title";
 export * from "./get-opportunity-orphanage-agent";
 export * from "./get-opportunity-where";
+export * from "./get-or-create-submitter-person";
 export * from "./get-user-where";
 export * from "./get-volunteer-clones";
 export * from "./get-volunteer-form-data";

--- a/src/test/server/utils/data/get-or-create-submitter-person.test.ts
+++ b/src/test/server/utils/data/get-or-create-submitter-person.test.ts
@@ -1,0 +1,156 @@
+import { AgentRoleType } from "need4deed-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AgentPerson from "../../../../data/entity/m2m/agent-person";
+import Person from "../../../../data/entity/person.entity";
+import { getOrCreateSubmitterPerson } from "../../../../server/utils/data/get-or-create-submitter-person";
+
+const personFind = vi.fn();
+const personSave = vi.fn();
+const agentPersonFind = vi.fn();
+const agentPersonSave = vi.fn();
+
+const fakeManager: any = {
+  getRepository: (entity: any) => {
+    switch (entity) {
+      case Person:
+        return { findOne: personFind, save: personSave };
+      case AgentPerson:
+        return { findOne: agentPersonFind, save: agentPersonSave };
+      default:
+        throw new Error(`unexpected repo: ${entity?.name}`);
+    }
+  },
+};
+
+const baseBody = {
+  rac_email: "sam@center.de",
+  rac_full_name: "Sam Submitter",
+  rac_phone: "+49-30-2222222",
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("getOrCreateSubmitterPerson", () => {
+  it("branch 1 — returns null and writes nothing when rac_email is empty", async () => {
+    const result = await getOrCreateSubmitterPerson(
+      { ...baseBody, rac_email: "" },
+      42,
+      fakeManager,
+    );
+
+    expect(result).toBeNull();
+    expect(personFind).not.toHaveBeenCalled();
+    expect(personSave).not.toHaveBeenCalled();
+    expect(agentPersonFind).not.toHaveBeenCalled();
+    expect(agentPersonSave).not.toHaveBeenCalled();
+  });
+
+  it("branch 2 — person found and AgentPerson link already exists: no upsert", async () => {
+    personFind.mockResolvedValueOnce({ id: 7, email: "sam@center.de" });
+    agentPersonFind.mockResolvedValueOnce({
+      id: 100,
+      agentId: 42,
+      personId: 7,
+    });
+
+    const result = await getOrCreateSubmitterPerson(baseBody, 42, fakeManager);
+
+    expect(result).toEqual({ id: 7, email: "sam@center.de" });
+    expect(personSave).not.toHaveBeenCalled();
+    expect(agentPersonSave).not.toHaveBeenCalled();
+  });
+
+  it("branch 3 — person found without link: upserts AgentPerson with VOLUNTEER_COORDINATOR role", async () => {
+    personFind.mockResolvedValueOnce({ id: 7, email: "sam@center.de" });
+    agentPersonFind.mockResolvedValueOnce(null);
+    agentPersonSave.mockImplementation(async (ap: any) => ({ ...ap, id: 999 }));
+
+    const result = await getOrCreateSubmitterPerson(baseBody, 42, fakeManager);
+
+    expect(result?.id).toBe(7);
+    expect(personSave).not.toHaveBeenCalled();
+    expect(agentPersonSave).toHaveBeenCalledTimes(1);
+    expect(agentPersonSave.mock.calls[0][0]).toMatchObject({
+      agentId: 42,
+      personId: 7,
+      role: AgentRoleType.VOLUNTEER_COORDINATOR,
+    });
+  });
+
+  it("branch 4 — person not found: creates Person from rac_*, then upserts AgentPerson", async () => {
+    personFind.mockResolvedValueOnce(null);
+    personSave.mockImplementation(async (p: any) => ({ ...p, id: 55 }));
+    agentPersonFind.mockResolvedValueOnce(null);
+
+    const result = await getOrCreateSubmitterPerson(baseBody, 42, fakeManager);
+
+    expect(personSave).toHaveBeenCalledTimes(1);
+    expect(personSave.mock.calls[0][0]).toMatchObject({
+      firstName: "Sam",
+      lastName: "Submitter",
+      email: "sam@center.de",
+      phone: "+49-30-2222222",
+    });
+
+    expect(result?.id).toBe(55);
+    expect(agentPersonSave).toHaveBeenCalledTimes(1);
+    expect(agentPersonSave.mock.calls[0][0]).toMatchObject({
+      agentId: 42,
+      personId: 55,
+      role: AgentRoleType.VOLUNTEER_COORDINATOR,
+    });
+  });
+
+  it("branch 4 (name fallback) — uses email local-part when rac_full_name is whitespace-only", async () => {
+    personFind.mockResolvedValueOnce(null);
+    personSave.mockImplementation(async (p: any) => ({ ...p, id: 56 }));
+    agentPersonFind.mockResolvedValueOnce(null);
+
+    await getOrCreateSubmitterPerson(
+      { ...baseBody, rac_full_name: "   " },
+      42,
+      fakeManager,
+    );
+
+    expect(personSave.mock.calls[0][0]).toMatchObject({
+      firstName: "sam",
+      lastName: undefined,
+    });
+  });
+
+  it("branch 4 (single-token name) — leaves lastName undefined", async () => {
+    personFind.mockResolvedValueOnce(null);
+    personSave.mockImplementation(async (p: any) => ({ ...p, id: 57 }));
+    agentPersonFind.mockResolvedValueOnce(null);
+
+    await getOrCreateSubmitterPerson(
+      { ...baseBody, rac_full_name: "Cher" },
+      42,
+      fakeManager,
+    );
+
+    expect(personSave.mock.calls[0][0]).toMatchObject({
+      firstName: "Cher",
+      lastName: undefined,
+    });
+  });
+
+  it("branch 4 (multi-word last name) — joins trailing tokens", async () => {
+    personFind.mockResolvedValueOnce(null);
+    personSave.mockImplementation(async (p: any) => ({ ...p, id: 58 }));
+    agentPersonFind.mockResolvedValueOnce(null);
+
+    await getOrCreateSubmitterPerson(
+      { ...baseBody, rac_full_name: "Mary van der Berg" },
+      42,
+      fakeManager,
+    );
+
+    expect(personSave.mock.calls[0][0]).toMatchObject({
+      firstName: "Mary",
+      lastName: "van der Berg",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the per-submission Comment row that legacy `POST /opportunity/legacy` used as a delimited-blob dumping ground for submitter PII (`rac_email<|>rac_full_name<|>rac_address<|>rac_plz<|>rac_phone`, written with `userId: 1`) with a structured Person + AgentPerson upsert. The link is recorded on `Opportunity.submittedByPersonId` (added in #587), which makes `ApiOpportunityGet.contact` (changed in #588) return the actual submitter when they're still at the agent.

### New helper: `getOrCreateSubmitterPerson`

Four-branch resolution (mirrors the issue's contract exactly):

1. Empty `rac_email` → return `null`, no Person manufactured.
2. Person found AND `agent_person` link exists for `(person, agentId)` → no-op.
3. Person found, no link → upsert `AgentPerson(role: VOLUNTEER_COORDINATOR)`.
4. Person not found → create Person from `rac_*` (firstName/lastName split from `rac_full_name`, email, phone) + upsert AgentPerson.

Signature is `(body, agentId, manager?: DataSource | EntityManager)` — same pattern as `createAddress` / `patchAddress` in `for-routes.ts`, so #590's backfill migration can call the helper from a `QueryRunner.manager` without a Fastify dependency.

### Preserved behaviour (per the issue's open-questions section)

- Domain-based authZ in the preHandler is **kept as-is**. Tightening it (full email match or verification challenge) is a separate authZ-scope follow-up.
- Empty/missing `rac_email` still passes the preHandler (the `email ILIKE '%@'` quirk is unchanged); the resolver simply returns `null` and `submittedByPersonId` stays unset, so today's "submission proceeds against orphanage / first agent" behaviour is preserved.

### Scoped out

- **Address creation** from `rac_address` + `rac_plz`. Mentioned in the issue body but `Person.addressId` is nullable and the centre address is already on `Agent`. Easy to layer on later via `createAddress` from `for-routes.ts` when there's a concrete need.
- **Backfill** of existing opportunities' Comment blobs — that's #590.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test:run` — 215/215 (was 208, +7 new)
- [x] All four resolution branches covered, plus name-split edge cases (whitespace-only name falls back to email local-part; single-token name leaves `lastName` undefined; multi-word name joins trailing tokens).

## Files changed

- `src/server/utils/data/get-or-create-submitter-person.ts` — new helper
- `src/server/utils/data/index.ts` — barrel export
- `src/server/routes/opportunity/legacy.routes.ts` — call resolver, remove Comment side-write
- `src/test/server/utils/data/get-or-create-submitter-person.test.ts` — 7 tests

Closes #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)