### PR TITLE
fix: ApiOpportunityGet.contact.waysToContact serialized as array (#599)

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -710,7 +710,10 @@
                 "name": { "type": "string" },
                 "phone": { "type": "string" },
                 "email": { "type": "string" },
-                "waysToContact": { "$ref": "PreferredCommunicationType#" }
+                "waysToContact": {
+                  "type": "array",
+                  "items": { "$ref": "PreferredCommunicationType#" }
+                }
               }
             },
             "agent": {


### PR DESCRIPTION
## Summary

One-line schema fix. `ApiOpportunityGet.contact.waysToContact` was declared as a scalar `$ref` in `sdk-types.json:713`, but the SDK type is `PreferredCommunicationType[]` and the entity column is `text[]`. Fastify's response serializer enforced the scalar shape and silently coerced the entity's `["mobilePhone"]` array down to the string `"mobilePhone"`, breaking any FE code that iterates the field.

Sibling shapes in the same file already use the array form correctly:
- `ApiPerson.preferredComm` (line 171)
- `ApiOpportunityPatch.contact.waysToContact` (line 590)

This PR just brings the get-side in line:

```diff
-"waysToContact": { "$ref": "PreferredCommunicationType#" }
+"waysToContact": {
+  "type": "array",
+  "items": { "$ref": "PreferredCommunicationType#" }
+}
```

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test:run` — 215/215
- [ ] After merge: hit `GET /opportunity/836` from the dev FE and confirm `contact.waysToContact` is an array, not a string.

Closes #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)