### PR TITLE
feat: GET /user — add role filter + honour sortOrder (#602)

### DIFF
--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -1,6 +1,6 @@
 import { validate } from "class-validator";
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiUserGet, UserRole } from "need4deed-sdk";
+import { ApiUserGet, SortOrder, UserRole } from "need4deed-sdk";
 import { FindOptionsWhere } from "typeorm";
 import Person, { PersonUpdateType } from "../../data/entity/person.entity";
 import User from "../../data/entity/user.entity";
@@ -35,16 +35,17 @@ export default async function userRoutes(
       onRequest: [fastify.authenticate()],
     },
     async (request, reply) => {
-      const { page, limit, search } = request.query;
+      const { page, limit, search, role, sortOrder } = request.query;
       const [skip, take] = getSkipTake({ page, limit });
+      const direction = sortOrder === SortOrder.OldToNew ? "ASC" : "DESC";
 
       const userRepository = fastify.db.userRepository;
       const [users, count] = await userRepository.findAndCount({
-        where: getUserWhere(search) as FindOptionsWhere<User>,
+        where: getUserWhere(search, role) as FindOptionsWhere<User>,
         relations: ["person"],
         skip,
         take,
-        order: { id: "DESC" },
+        order: { id: direction },
       });
 
       const data = users.map(serializeUserToMeDTO);

--- a/src/server/schema/querystring.ts
+++ b/src/server/schema/querystring.ts
@@ -125,7 +125,9 @@ export const userListQuerySchema = {
   type: "object",
   properties: {
     ...paginationProps,
+    ...sortOrderProps,
     search: { type: "string" },
+    role: getRef("UserRole#"),
   },
   additionalProperties: false,
 };

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -766,6 +766,11 @@
       "type": "string",
       "enum": ["agent-high", "agent-low", "agent-unknown"]
     },
+    "UserRole": {
+      "$id": "UserRole",
+      "type": "string",
+      "enum": ["user", "coordinator", "agent", "volunteer", "admin"]
+    },
     "AgentVolunteerSearchType": {
       "$id": "AgentVolunteerSearchType",
       "type": "string",

--- a/src/server/types/endpoint-handlers.ts
+++ b/src/server/types/endpoint-handlers.ts
@@ -1,4 +1,4 @@
-import { Lang, SortOrder } from "need4deed-sdk";
+import { Lang, SortOrder, UserRole } from "need4deed-sdk";
 
 export interface ParamsId {
   id: number;
@@ -89,4 +89,6 @@ export type QuerystringVolunteerGetList = QuerystringPaginationLanguage &
 
 export interface QuerystringUserList extends QuerystringPagination {
   search?: string;
+  sortOrder?: SortOrder;
+  role?: UserRole;
 }

--- a/src/server/utils/data/get-user-where.ts
+++ b/src/server/utils/data/get-user-where.ts
@@ -1,9 +1,11 @@
+import { UserRole } from "need4deed-sdk";
 import { ILike } from "typeorm";
 
-export function getUserWhere(search?: string) {
+export function getUserWhere(search?: string, role?: UserRole) {
   // `person.name` is a calculated getter (firstName + middleName + lastName),
   // so there is no column to match — search the underlying columns instead.
   return {
+    ...(role ? { role } : {}),
     ...(search
       ? {
           person: [

--- a/src/test/server/utils/data/get-user-where.test.ts
+++ b/src/test/server/utils/data/get-user-where.test.ts
@@ -1,0 +1,39 @@
+import { UserRole } from "need4deed-sdk";
+import { ILike } from "typeorm";
+import { describe, expect, it } from "vitest";
+import { getUserWhere } from "../../../../server/utils/data/get-user-where";
+
+describe("getUserWhere", () => {
+  it("returns an empty object when neither search nor role is provided", () => {
+    expect(getUserWhere()).toEqual({});
+  });
+
+  it("returns just `role` when only role is provided", () => {
+    expect(getUserWhere(undefined, UserRole.COORDINATOR)).toEqual({
+      role: UserRole.COORDINATOR,
+    });
+  });
+
+  it("returns ILIKE OR-clauses on person name columns when only search is provided", () => {
+    const where = getUserWhere("Alice");
+    expect(where).toEqual({
+      person: [
+        { firstName: ILike("%Alice%") },
+        { middleName: ILike("%Alice%") },
+        { lastName: ILike("%Alice%") },
+      ],
+    });
+  });
+
+  it("combines role + search at the top level (AND semantics in TypeORM)", () => {
+    const where = getUserWhere("Bob", UserRole.AGENT);
+    expect(where).toEqual({
+      role: UserRole.AGENT,
+      person: [
+        { firstName: ILike("%Bob%") },
+        { middleName: ILike("%Bob%") },
+        { lastName: ILike("%Bob%") },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Unblocks FE PR [need4deed-org/fe#537](https://github.com/need4deed-org/fe/pull/537) (autocomplete `@`-mentions in comments). The FE calls `GET /user?role=coordinator` to populate the mention menu; today's `GET /user` ignores `role`, has default `limit=12`, and silently ignores `sortOrder` — so the FE would only see at most 12 coordinators (and possibly zero, if the most-recent dozen users are non-coordinators).

### Changes

- **`sdk-types.json`** — add `UserRole` (was inlined in `ApiUserMe`; now reusable as `$ref: UserRole#`).
- **`userListQuerySchema`** — add `role` (`$ref: UserRole#`) and `sortOrder` (existing `sortOrderProps`).
- **`QuerystringUserList`** — extend with `role?: UserRole` and `sortOrder?: SortOrder`.
- **`getUserWhere(search, role)`** — applies both clauses at the top level (AND semantics in TypeORM). Pure-function tested across all four combinations.
- **`GET /user` handler** — destructures `role` + `sortOrder` from the query; passes `role` to `getUserWhere`, picks `id ASC` for `OldToNew`, `DESC` otherwise. Existing callers (no params) see no behaviour change.

No auth change. `GET /user` remains accessible to any authed user, by design — the comment-tagging case it supports is the documented reason for that decision.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test:run` — 219/219 (was 215, +4 new for `getUserWhere`)
- [x] Local server boots with the new schema (no startup-time route-registration error)
- [ ] After merge: FE consumes the new contract via `?role=coordinator`. Confirm pagination is sufficient (default `limit=12`, max `120`) once the FE switches to filtered call.

## Out of scope

- Raising `paginationProps.limit.maximum` (120) — coordinator counts well below that today.
- Switching the order column from `id` to `createdAt` — kept on `id` for safety; monotonically increasing so equivalent ordering.
- The `ApiUserMe.role` schema still inlines the enum (line 326-328 of `sdk-types.json`); could be flipped to `$ref: UserRole#` in a follow-up cleanup. Not strictly needed for this PR's contract.

Closes #602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)