### PR TITLE
update: env and docker compose script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,18 @@
 AWS_SES_REGION=eu-central-1
-AWS_SES_ACCESS_KEY_ID=fake-string
-AWS_SES_SECRET_ACCESS_KEY=fake-string
+AWS_SES_ENDPOINT=http://localhost:4566
 AWS_SES_FROM_EMAIL=no-reply@need4deed.org
-# Optional: override SES endpoint for LocalStack, e.g. http://localstack:4566
-AWS_SES_ENDPOINT=
 # Optional: SES configuration set for bounce/complaint event publishing.
 # Set in deployed environments (e.g. `need4deed-default`); leave empty locally.
 AWS_SES_CONFIGURATION_SET=
 
-CORS_ORIGINS=http://vmpub:3000,http://vmpub:3100,http://vmpub:3200
+CORS_ORIGINS=http://localhost:3000,http://localhost:3100,http://localhost:3200
 CORS_CREDENTIALS=true
 
-URL_EMAIL_VERIFICATION=http://vmpub:3000/verify-email
+URL_EMAIL_VERIFICATION=http://localhost:3000/verify-email
 
 NODE_ENV=development
 JWT_SECRET=fake-string
 
 SLACK_WEBHOOK_URL=fake-string
 
-GOOGLE_WORKSPACE_USER=fake-string
-GOOGLE_WORKSPACE_APP_PASSWORD=fake-string
-GOOGLE_FROM_EMAIL=no-reply@need4deed.org
-
-MOCK_VOLUNTEER_DOC_S3_UPLOAD_URL=http://vmpub:5000
+MOCK_VOLUNTEER_DOC_S3_UPLOAD_URL=http://localhost:5000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,12 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+  localstack:
+    image: localstack/localstack
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=ses
 
 volumes:
   be_database:


### PR DESCRIPTION
## Summary

- Switches local dev env from the `vmpub` hostname over to `localhost` (CORS origins, email-verification URL, mock S3 URL).
- Drops the unused `GOOGLE_WORKSPACE_*` and static SES access-key env vars from `.env.example` — SES auth now uses the default credential chain (locally, the LocalStack endpoint pinned below).
- Pins `AWS_SES_ENDPOINT=http://localhost:4566` for LocalStack.
- Adds a `localstack` service to `docker-compose.yaml` with `SERVICES=ses` exposed on `4566`.

## Test plan

- [x] `.env.example` matches the trimmed-down dev contract
- [ ] After merge: copy `.env.example` to `.env`, `docker compose up`, confirm SES sends via LocalStack

🤖 Generated with [Claude Code](https://claude.com/claude-code)