### PR TITLE
feat: comment-person m2m for @tagging in comments (fe#537)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.94",
+    "need4deed-sdk": "0.0.97",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/data/data-source.ts
+++ b/src/data/data-source.ts
@@ -18,6 +18,7 @@ import Postcode from "./entity/location/postcode.entity";
 import AgentLanguage from "./entity/m2m/agent-language";
 import AgentPerson from "./entity/m2m/agent-person";
 import AgentPostcode from "./entity/m2m/agent-postcode";
+import CommentPerson from "./entity/m2m/comment-person";
 import DistrictPostcode from "./entity/m2m/district-postcode";
 import LocationAddress from "./entity/m2m/location-address";
 import LocationDistrict from "./entity/m2m/location-district";
@@ -70,6 +71,7 @@ export const dataSource = new DataSource({
     Appreciation,
     Category,
     Comment,
+    CommentPerson,
     Communication,
     Config,
     Deal,

--- a/src/data/entity/comment.entity.ts
+++ b/src/data/entity/comment.entity.ts
@@ -6,8 +6,10 @@ import {
   Index,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from "typeorm";
+import CommentPerson from "./m2m/comment-person";
 import Language from "./profile/language.entity";
 import User from "./user.entity";
 
@@ -66,6 +68,9 @@ export default class Comment {
   @Column()
   @IsNotEmpty()
   entityId: number;
+
+  @OneToMany(() => CommentPerson, (commentPerson) => commentPerson.comment)
+  commentPerson: CommentPerson[];
 
   translation?: string;
 }

--- a/src/data/entity/m2m/agent-person.ts
+++ b/src/data/entity/m2m/agent-person.ts
@@ -2,6 +2,7 @@ import { AgentRoleType } from "need4deed-sdk";
 import {
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -10,6 +11,10 @@ import Agent from "../opportunity/agent.entity";
 import Person from "../person.entity";
 
 @Entity()
+// Three-column unique: a person may legitimately hold multiple roles at one
+// agent (the dev DB has exactly this case), so the constraint is on the
+// full triple, not (agentId, personId) alone.
+@Index(["agentId", "personId", "role"], { unique: true })
 export default class AgentPerson {
   constructor(agentPerson?: Partial<AgentPerson>) {
     if (agentPerson) {

--- a/src/data/entity/m2m/comment-person.ts
+++ b/src/data/entity/m2m/comment-person.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import Comment from "../comment.entity";
+import Person from "../person.entity";
+
+@Entity()
+export default class CommentPerson {
+  constructor(commentPerson?: Partial<CommentPerson>) {
+    if (commentPerson) {
+      Object.assign(this, commentPerson);
+    }
+  }
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Comment, (comment) => comment.commentPerson, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "comment_id" })
+  comment: Comment;
+
+  @Column()
+  commentId: number;
+
+  @ManyToOne(() => Person, (person) => person.commentPerson, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "person_id" })
+  person: Person;
+
+  @Column()
+  personId: number;
+}

--- a/src/data/entity/m2m/comment-person.ts
+++ b/src/data/entity/m2m/comment-person.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -9,6 +10,7 @@ import Comment from "../comment.entity";
 import Person from "../person.entity";
 
 @Entity()
+@Index(["commentId", "personId"], { unique: true })
 export default class CommentPerson {
   constructor(commentPerson?: Partial<CommentPerson>) {
     if (commentPerson) {

--- a/src/data/entity/person.entity.ts
+++ b/src/data/entity/person.entity.ts
@@ -16,6 +16,7 @@ import {
 } from "typeorm";
 import Address from "./location/address.entity";
 import AgentPerson from "./m2m/agent-person";
+import CommentPerson from "./m2m/comment-person";
 import Organization from "./organization.entity";
 import Testimonial from "./testimonial.entity";
 import User from "./user.entity"; // Ensure this import is correct
@@ -109,6 +110,9 @@ export default class Person {
 
   @OneToMany(() => AgentPerson, (agentPerson) => agentPerson.person)
   agentPerson: AgentPerson[];
+
+  @OneToMany(() => CommentPerson, (commentPerson) => commentPerson.person)
+  commentPerson: CommentPerson[];
 
   get name(): string {
     return [this.firstName, this.middleName, this.lastName]

--- a/src/data/migrations/1780401314887-add-comment-person-m2m.ts
+++ b/src/data/migrations/1780401314887-add-comment-person-m2m.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCommentPersonM2m1780401314887 implements MigrationInterface {
+  name = "AddCommentPersonM2m1780401314887";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "comment_person" ("id" SERIAL NOT NULL, "comment_id" integer NOT NULL, "person_id" integer NOT NULL, CONSTRAINT "PK_f3a5d50a9812f4f4a03921497f7" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment_person" ADD CONSTRAINT "FK_a32624ba70e3dc1462329a6323e" FOREIGN KEY ("comment_id") REFERENCES "comment"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment_person" ADD CONSTRAINT "FK_81d4ae770167ca1c3196b3c3b52" FOREIGN KEY ("person_id") REFERENCES "person"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "comment_person" DROP CONSTRAINT "FK_81d4ae770167ca1c3196b3c3b52"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment_person" DROP CONSTRAINT "FK_a32624ba70e3dc1462329a6323e"`,
+    );
+    await queryRunner.query(`DROP TABLE "comment_person"`);
+  }
+}

--- a/src/data/migrations/1780430062141-add-comment-person-m2m.ts
+++ b/src/data/migrations/1780430062141-add-comment-person-m2m.ts
@@ -1,11 +1,14 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class AddCommentPersonM2m1780401314887 implements MigrationInterface {
-  name = "AddCommentPersonM2m1780401314887";
+export class AddCommentPersonM2m1780430062141 implements MigrationInterface {
+  name = "AddCommentPersonM2m1780430062141";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `CREATE TABLE "comment_person" ("id" SERIAL NOT NULL, "comment_id" integer NOT NULL, "person_id" integer NOT NULL, CONSTRAINT "PK_f3a5d50a9812f4f4a03921497f7" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_0913ee135f62eccb90f53047ad" ON "comment_person" ("comment_id", "person_id") `,
     );
     await queryRunner.query(
       `ALTER TABLE "comment_person" ADD CONSTRAINT "FK_a32624ba70e3dc1462329a6323e" FOREIGN KEY ("comment_id") REFERENCES "comment"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
@@ -21,6 +24,9 @@ export class AddCommentPersonM2m1780401314887 implements MigrationInterface {
     );
     await queryRunner.query(
       `ALTER TABLE "comment_person" DROP CONSTRAINT "FK_a32624ba70e3dc1462329a6323e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_0913ee135f62eccb90f53047ad"`,
     );
     await queryRunner.query(`DROP TABLE "comment_person"`);
   }

--- a/src/data/migrations/1780430801611-add-unique-agent-person-role.ts
+++ b/src/data/migrations/1780430801611-add-unique-agent-person-role.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUniqueAgentPersonRole1780430801611
+  implements MigrationInterface
+{
+  name = "AddUniqueAgentPersonRole1780430801611";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_f15c4b743ddfba08409b99f797" ON "agent_person" ("agent_id", "person_id", "role") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_f15c4b743ddfba08409b99f797"`,
+    );
+  }
+}

--- a/src/server/routes/comment.ts
+++ b/src/server/routes/comment.ts
@@ -194,9 +194,13 @@ export default async function commentRoutes(
           data: commentSerializer(reloaded),
         });
       } catch (error) {
+        // Match on the failing table rather than parsing detail text — the
+        // only INSERT into `comment_person` from this handler is the tag
+        // sync, so a 23503 there means the caller supplied an unknown
+        // person id.
         if (
           (error as { code?: string }).code === "23503" &&
-          (error as { detail?: string }).detail?.includes("person")
+          (error as { table?: string }).table === "comment_person"
         ) {
           return reply
             .status(400)
@@ -313,9 +317,13 @@ export default async function commentRoutes(
           data: commentSerializer(reloaded),
         };
       } catch (error) {
+        // Match on the failing table rather than parsing detail text — the
+        // only INSERT into `comment_person` from this handler is the tag
+        // sync, so a 23503 there means the caller supplied an unknown
+        // person id.
         if (
           (error as { code?: string }).code === "23503" &&
-          (error as { detail?: string }).detail?.includes("person")
+          (error as { table?: string }).table === "comment_person"
         ) {
           return reply
             .status(400)

--- a/src/server/routes/comment.ts
+++ b/src/server/routes/comment.ts
@@ -1,6 +1,7 @@
 import { validate } from "class-validator";
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { ApiComment, EntityTableName, UserRole } from "need4deed-sdk";
+import { BadRequestError } from "../../config";
 import Comment from "../../data/entity/comment.entity";
 import logger from "../../logger";
 import { commentSerializer } from "../../services";
@@ -194,10 +195,13 @@ export default async function commentRoutes(
           data: commentSerializer(reloaded),
         });
       } catch (error) {
-        // Match on the failing table rather than parsing detail text — the
-        // only INSERT into `comment_person` from this handler is the tag
-        // sync, so a 23503 there means the caller supplied an unknown
-        // person id.
+        // Let BadRequestError (e.g. pre-validation in syncCommentTags) flow
+        // to the global handler so it surfaces as 400 with its own message.
+        if (error instanceof BadRequestError) {throw error;}
+        // Safety net: pre-validation should have caught this, but if a
+        // concurrent delete removed the Person between the check and the
+        // INSERT, a 23503 still slips through. Match on the failing table
+        // so it can't misfire on unrelated person-named constraints.
         if (
           (error as { code?: string }).code === "23503" &&
           (error as { table?: string }).table === "comment_person"
@@ -317,10 +321,13 @@ export default async function commentRoutes(
           data: commentSerializer(reloaded),
         };
       } catch (error) {
-        // Match on the failing table rather than parsing detail text — the
-        // only INSERT into `comment_person` from this handler is the tag
-        // sync, so a 23503 there means the caller supplied an unknown
-        // person id.
+        // Let BadRequestError (e.g. pre-validation in syncCommentTags) flow
+        // to the global handler so it surfaces as 400 with its own message.
+        if (error instanceof BadRequestError) {throw error;}
+        // Safety net: pre-validation should have caught this, but if a
+        // concurrent delete removed the Person between the check and the
+        // INSERT, a 23503 still slips through. Match on the failing table
+        // so it can't misfire on unrelated person-named constraints.
         if (
           (error as { code?: string }).code === "23503" &&
           (error as { table?: string }).table === "comment_person"

--- a/src/server/routes/comment.ts
+++ b/src/server/routes/comment.ts
@@ -5,6 +5,7 @@ import Comment from "../../data/entity/comment.entity";
 import logger from "../../logger";
 import { commentSerializer } from "../../services";
 import { responseErrors } from "../schema";
+import { syncCommentTags } from "../utils";
 
 export default async function commentRoutes(
   fastify: FastifyInstance,
@@ -58,7 +59,7 @@ export default async function commentRoutes(
         const commentRepository = fastify.db.commentRepository;
         const [comments, count] = await commentRepository.findAndCount({
           where: { userId, entityId, entityType },
-          relations: ["user", "user.person", "language"],
+          relations: ["user", "user.person", "language", "commentPerson"],
         });
 
         if (!comments) {
@@ -110,7 +111,7 @@ export default async function commentRoutes(
         const commentRepository = fastify.db.commentRepository;
         const comment = await commentRepository.findOne({
           where: { id },
-          relations: ["user", "user.person", "language"],
+          relations: ["user", "user.person", "language", "commentPerson"],
         });
 
         if (!comment) {
@@ -142,7 +143,7 @@ export default async function commentRoutes(
             type: "object",
             properties: {
               message: { type: "string" },
-              data: { $ref: "Comment#" },
+              data: { $ref: "ApiComment#" },
             },
             required: ["message", "data"],
           },
@@ -153,7 +154,9 @@ export default async function commentRoutes(
     },
     async (request, reply) => {
       const commentRepository = fastify.db.commentRepository;
-      const body = request.body as Partial<Comment>;
+      const { taggedPersonIds, ...body } = request.body as Partial<Comment> & {
+        taggedPersonIds?: number[];
+      };
 
       const newComment = commentRepository.create({
         ...body,
@@ -171,12 +174,34 @@ export default async function commentRoutes(
       }
 
       try {
-        const saved = await commentRepository.save(newComment);
+        const reloaded = await commentRepository.manager.transaction(
+          async (manager) => {
+            const saved = await manager.getRepository(Comment).save(newComment);
+            await syncCommentTags(saved.id, taggedPersonIds, manager);
+            return manager.getRepository(Comment).findOne({
+              where: { id: saved.id },
+              relations: ["user", "user.person", "language", "commentPerson"],
+            });
+          },
+        );
+
+        if (!reloaded) {
+          throw new Error(`Failed to reload comment after create`);
+        }
+
         return reply.status(201).send({
           message: "Successfully created a new comment",
-          data: saved,
+          data: commentSerializer(reloaded),
         });
       } catch (error) {
+        if (
+          (error as { code?: string }).code === "23503" &&
+          (error as { detail?: string }).detail?.includes("person")
+        ) {
+          return reply
+            .status(400)
+            .send({ message: "Invalid tagged person id." });
+        }
         logger.error(`Error creating comment: ${error}`);
         return reply.status(500).send({
           message: "Internal server error.",
@@ -198,7 +223,7 @@ export default async function commentRoutes(
             type: "object",
             properties: {
               message: { type: "string" },
-              data: { $ref: "Comment#" },
+              data: { $ref: "ApiComment#" },
             },
             required: ["message", "data"],
           },
@@ -245,9 +270,12 @@ export default async function commentRoutes(
             .send({ message: "Insufficient permissions." });
         }
 
-        Object.assign(comment, request.body, {
-          updatedAt: new Date(),
-        });
+        const { taggedPersonIds, ...patch } =
+          request.body as Partial<Comment> & {
+            taggedPersonIds?: number[];
+          };
+
+        Object.assign(comment, patch, { updatedAt: new Date() });
 
         const errors = await validate(comment);
         if (errors.length > 0) {
@@ -260,13 +288,39 @@ export default async function commentRoutes(
           });
         }
 
-        const saved = await commentRepository.save(comment);
+        const reloaded = await commentRepository.manager.transaction(
+          async (manager) => {
+            await manager.getRepository(Comment).save(comment);
+            // Only sync tags when the field was sent in the patch — passing
+            // undefined leaves existing comment_person rows untouched, which
+            // matches PATCH semantics (only update fields the caller provided).
+            if (taggedPersonIds !== undefined) {
+              await syncCommentTags(id, taggedPersonIds, manager);
+            }
+            return manager.getRepository(Comment).findOne({
+              where: { id },
+              relations: ["user", "user.person", "language", "commentPerson"],
+            });
+          },
+        );
+
+        if (!reloaded) {
+          throw new Error(`Failed to reload comment after update`);
+        }
 
         return {
           message: `Successfully updated comment ${id}`,
-          data: saved,
+          data: commentSerializer(reloaded),
         };
       } catch (error) {
+        if (
+          (error as { code?: string }).code === "23503" &&
+          (error as { detail?: string }).detail?.includes("person")
+        ) {
+          return reply
+            .status(400)
+            .send({ message: "Invalid tagged person id." });
+        }
         logger.error(`Error updating comment: ${error}`);
         return reply.status(500).send({
           message: "Internal server error.",

--- a/src/server/schema/entity-types.json
+++ b/src/server/schema/entity-types.json
@@ -121,6 +121,10 @@
         "entityType": {
           "type": "string",
           "enum": ["volunteer", "opportunity", "agent"]
+        },
+        "taggedPersonIds": {
+          "type": "array",
+          "items": { "type": "integer" }
         }
       },
       "additionalProperties": false

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -152,7 +152,11 @@
         "entityId": { "type": "number" },
         "entityType": { "type": "string" },
         "authorName": { "type": "string" },
-        "timestamp": { "type": "string", "format": "date-time" }
+        "timestamp": { "type": "string", "format": "date-time" },
+        "taggedPersonIds": {
+          "type": "array",
+          "items": { "type": "integer" }
+        }
       }
     },
     "ApiPerson": {

--- a/src/server/utils/data/add-comments-entity.ts
+++ b/src/server/utils/data/add-comments-entity.ts
@@ -14,7 +14,7 @@ export async function addComments2Entity<E extends { id: number }>(
     entityId: instance.id,
     entityType: pascal2snake(instanceMetadata.name, "lower") as EntityTableName,
   };
-  const relations = ["user.person"];
+  const relations = ["user.person", "commentPerson"];
 
   const comments = await commentRepository.find({
     where,

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -14,6 +14,7 @@ export * from "./get-volunteer-clones";
 export * from "./get-volunteer-form-data";
 export * from "./get-volunteer-patch-data";
 export * from "./get-volunteer-where";
+export * from "./sync-comment-tags";
 export * from "./update-leads";
 export * from "./write-opportunity-legacy";
 export * from "./write-volunteer-legacy";

--- a/src/server/utils/data/sync-comment-tags.ts
+++ b/src/server/utils/data/sync-comment-tags.ts
@@ -1,0 +1,44 @@
+import { DataSource, EntityManager, In } from "typeorm";
+import { dataSource } from "../../../data/data-source";
+import CommentPerson from "../../../data/entity/m2m/comment-person";
+import { getRepository } from "../../../data/utils";
+
+/**
+ * Sync a comment's `comment_person` rows to match `desiredPersonIds`:
+ * remove rows whose `personId` is no longer wanted, insert rows for the
+ * newly added ids, leave unchanged rows alone. Idempotent.
+ *
+ * `manager` defaults to the global dataSource; pass a transactional
+ * EntityManager so the diff is atomic with surrounding writes
+ * (commentRepository.save, etc.).
+ */
+export async function syncCommentTags(
+  commentId: number,
+  desiredPersonIds: number[] | undefined,
+  manager: DataSource | EntityManager = dataSource,
+): Promise<void> {
+  const commentPersonRepository = getRepository(manager, CommentPerson);
+
+  const desired = [...new Set((desiredPersonIds ?? []).map(Number))];
+
+  const current = await commentPersonRepository.find({ where: { commentId } });
+  const currentPersonIds = current.map(({ personId }) => personId);
+
+  const toRemove = current.filter(
+    ({ personId }) => !desired.includes(personId),
+  );
+  const toAddPersonIds = desired.filter((id) => !currentPersonIds.includes(id));
+
+  if (toRemove.length) {
+    await commentPersonRepository.delete({
+      id: In(toRemove.map(({ id }) => id)),
+    });
+  }
+  if (toAddPersonIds.length) {
+    await commentPersonRepository.save(
+      toAddPersonIds.map(
+        (personId) => new CommentPerson({ commentId, personId }),
+      ),
+    );
+  }
+}

--- a/src/server/utils/data/sync-comment-tags.ts
+++ b/src/server/utils/data/sync-comment-tags.ts
@@ -1,6 +1,8 @@
 import { DataSource, EntityManager, In } from "typeorm";
+import { BadRequestError } from "../../../config";
 import { dataSource } from "../../../data/data-source";
 import CommentPerson from "../../../data/entity/m2m/comment-person";
+import Person from "../../../data/entity/person.entity";
 import { getRepository } from "../../../data/utils";
 
 /**
@@ -33,6 +35,24 @@ export async function syncCommentTags(
     ({ personId }) => !desired.includes(personId),
   );
   const toAddPersonIds = desired.filter((id) => !currentPersonIds.includes(id));
+
+  if (toAddPersonIds.length) {
+    // Pre-validate person ids exist so a bad input becomes a 400 with a
+    // clear message instead of a Postgres 23503 buried in the route's
+    // generic-error path.
+    const personRepository = getRepository(manager, Person);
+    const existing = await personRepository.find({
+      where: { id: In(toAddPersonIds) },
+      select: ["id"],
+    });
+    const existingIds = new Set(existing.map(({ id }) => id));
+    const missing = toAddPersonIds.filter((id) => !existingIds.has(id));
+    if (missing.length) {
+      throw new BadRequestError(
+        `Invalid tagged person id(s): ${missing.join(", ")}`,
+      );
+    }
+  }
 
   if (toRemove.length) {
     await commentPersonRepository.delete({

--- a/src/server/utils/data/sync-comment-tags.ts
+++ b/src/server/utils/data/sync-comment-tags.ts
@@ -11,6 +11,11 @@ import { getRepository } from "../../../data/utils";
  * `manager` defaults to the global dataSource; pass a transactional
  * EntityManager so the diff is atomic with surrounding writes
  * (commentRepository.save, etc.).
+ *
+ * NOTE on `undefined`: treated as `[]` here, i.e. clears all existing tags.
+ * If a caller wants "leave tags untouched" semantics (e.g. PATCH where the
+ * field was omitted), they must guard at the call site and not invoke this
+ * helper at all. The comment.ts PATCH handler does exactly that.
  */
 export async function syncCommentTags(
   commentId: number,

--- a/src/services/dto/dto-comment.ts
+++ b/src/services/dto/dto-comment.ts
@@ -9,5 +9,7 @@ export function commentSerializer(comment: Comment): ApiComment {
     entityType: comment.entityType,
     authorName: comment.user?.person?.name,
     timestamp: comment.updatedAt,
+    taggedPersonIds:
+      comment.commentPerson?.map((cp) => cp.personId).filter(Boolean) ?? [],
   };
 }

--- a/src/test/server/utils/data/sync-comment-tags.test.ts
+++ b/src/test/server/utils/data/sync-comment-tags.test.ts
@@ -1,23 +1,32 @@
 import { In } from "typeorm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BadRequestError } from "../../../../config";
 import CommentPerson from "../../../../data/entity/m2m/comment-person";
+import Person from "../../../../data/entity/person.entity";
 import { syncCommentTags } from "../../../../server/utils/data/sync-comment-tags";
 
 const find = vi.fn();
 const save = vi.fn();
 const del = vi.fn();
+const personFind = vi.fn();
 
 const fakeManager: any = {
   getRepository: (entity: any) => {
-    if (entity !== CommentPerson) {
-      throw new Error(`unexpected repo: ${entity?.name}`);
-    }
-    return { find, save, delete: del };
+    if (entity === CommentPerson) {return { find, save, delete: del };}
+    if (entity === Person) {return { find: personFind };}
+    throw new Error(`unexpected repo: ${entity?.name}`);
   },
 };
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // Default: pretend every queried person id exists. Tests that want the
+  // missing-id branch override this.
+  personFind.mockImplementation(async (opts: any) => {
+    const op = opts?.where?.id;
+    const ids: number[] = (op?._value ?? op?.value ?? []) as number[];
+    return ids.map((id) => ({ id }));
+  });
 });
 
 describe("syncCommentTags", () => {
@@ -100,5 +109,28 @@ describe("syncCommentTags", () => {
       { commentId: 42, personId: 2 },
       { commentId: 42, personId: 3 },
     ]);
+  });
+
+  it("throws BadRequestError listing missing ids when a tagged person does not exist", async () => {
+    find.mockResolvedValueOnce([]);
+    // 1 and 3 exist, 999 doesn't.
+    personFind.mockResolvedValueOnce([{ id: 1 }, { id: 3 }]);
+
+    await expect(
+      syncCommentTags(7, [1, 3, 999], fakeManager),
+    ).rejects.toBeInstanceOf(BadRequestError);
+
+    expect(save).not.toHaveBeenCalled();
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it("skips the existence check when there are no new ids to add", async () => {
+    find.mockResolvedValueOnce([{ id: 100, commentId: 7, personId: 5 }]);
+
+    await syncCommentTags(7, [5], fakeManager);
+
+    expect(personFind).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+    expect(del).not.toHaveBeenCalled();
   });
 });

--- a/src/test/server/utils/data/sync-comment-tags.test.ts
+++ b/src/test/server/utils/data/sync-comment-tags.test.ts
@@ -1,0 +1,104 @@
+import { In } from "typeorm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CommentPerson from "../../../../data/entity/m2m/comment-person";
+import { syncCommentTags } from "../../../../server/utils/data/sync-comment-tags";
+
+const find = vi.fn();
+const save = vi.fn();
+const del = vi.fn();
+
+const fakeManager: any = {
+  getRepository: (entity: any) => {
+    if (entity !== CommentPerson) {
+      throw new Error(`unexpected repo: ${entity?.name}`);
+    }
+    return { find, save, delete: del };
+  },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("syncCommentTags", () => {
+  it("inserts new rows and deletes removed rows; leaves unchanged rows alone", async () => {
+    find.mockResolvedValueOnce([
+      { id: 100, commentId: 7, personId: 5 },
+      { id: 101, commentId: 7, personId: 9 },
+    ]);
+
+    await syncCommentTags(7, [5, 12], fakeManager);
+
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith({ id: In([101]) });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ commentId: 7, personId: 12 }),
+    ]);
+  });
+
+  it("is a no-op when desired and existing sets match", async () => {
+    find.mockResolvedValueOnce([
+      { id: 100, commentId: 7, personId: 5 },
+      { id: 101, commentId: 7, personId: 9 },
+    ]);
+
+    await syncCommentTags(7, [9, 5], fakeManager);
+
+    expect(del).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("deletes all rows when desiredPersonIds is empty", async () => {
+    find.mockResolvedValueOnce([
+      { id: 100, commentId: 7, personId: 5 },
+      { id: 101, commentId: 7, personId: 9 },
+    ]);
+
+    await syncCommentTags(7, [], fakeManager);
+
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith({ id: In([100, 101]) });
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("treats undefined desiredPersonIds the same as an empty list (deletes all)", async () => {
+    find.mockResolvedValueOnce([{ id: 100, commentId: 7, personId: 5 }]);
+
+    await syncCommentTags(7, undefined, fakeManager);
+
+    expect(del).toHaveBeenCalledWith({ id: In([100]) });
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("dedupes desiredPersonIds before computing the diff", async () => {
+    find.mockResolvedValueOnce([]);
+
+    await syncCommentTags(7, [5, 5, 12, 12], fakeManager);
+
+    expect(save).toHaveBeenCalledTimes(1);
+    const inserted = save.mock.calls[0][0] as CommentPerson[];
+    expect(inserted).toHaveLength(2);
+    expect(new Set(inserted.map((cp) => cp.personId))).toEqual(
+      new Set([5, 12]),
+    );
+  });
+
+  it("inserts everything when no rows exist yet", async () => {
+    find.mockResolvedValueOnce([]);
+
+    await syncCommentTags(42, [1, 2, 3], fakeManager);
+
+    expect(del).not.toHaveBeenCalled();
+    expect(save).toHaveBeenCalledTimes(1);
+    const rows = save.mock.calls[0][0] as CommentPerson[];
+    expect(
+      rows.map((r) => ({ commentId: r.commentId, personId: r.personId })),
+    ).toEqual([
+      { commentId: 42, personId: 1 },
+      { commentId: 42, personId: 2 },
+      { commentId: 42, personId: 3 },
+    ]);
+  });
+});

--- a/src/test/services/dto/dto-comment.test.ts
+++ b/src/test/services/dto/dto-comment.test.ts
@@ -21,7 +21,37 @@ describe("commentSerializer", () => {
       entityType: "volunteer",
       authorName: "Coordinator Jane",
       timestamp: comment.updatedAt,
+      taggedPersonIds: [],
     });
+  });
+
+  it("maps commentPerson rows to taggedPersonIds", () => {
+    const comment = {
+      id: 10,
+      text: "Hey <@5> and <@9>",
+      entityId: 1,
+      entityType: "opportunity",
+      updatedAt: new Date(),
+      user: { person: { name: "Author" } },
+      commentPerson: [{ personId: 5 }, { personId: 9 }],
+    };
+
+    const result = commentSerializer(comment as any);
+    expect(result.taggedPersonIds).toEqual([5, 9]);
+  });
+
+  it("returns an empty taggedPersonIds when commentPerson is missing", () => {
+    const comment = {
+      id: 11,
+      text: "no tags",
+      entityId: 1,
+      entityType: "opportunity",
+      updatedAt: new Date(),
+      user: { person: { name: "Author" } },
+    };
+
+    const result = commentSerializer(comment as any);
+    expect(result.taggedPersonIds).toEqual([]);
   });
 
   it("returns undefined authorName when user has no person", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,10 +3813,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.94:
-  version "0.0.94"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.94.tgz#61bb69a2d165fc1f639de10317b5fcc9b5a7c9aa"
-  integrity sha512-WxXyJ2/QO8qBuaybxkAd0vYY+BpXbB5iHmj7OSkl4P9wI3yn+T+qsN3W9dtBERhWpzXpS+djcLn3KLhU1pTgXQ==
+need4deed-sdk@0.0.97:
+  version "0.0.97"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.97.tgz#242bdec085b414e3ec70f246538fb7115b4f7a1d"
+  integrity sha512-0oxgjasJTgZ+cnWD0AZAQMh73huA+OZ83sWBaqAKXOnu723ZtSocFesVtp1kikftCpQ4rQNotJooD+bIahCwsQ==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

BE plumbing for FE PR [need4deed-org/fe#537](https://github.com/need4deed-org/fe/pull/537) (autocomplete `@`-mentions in comments). The SDK already declares `ApiComment.taggedPersonIds: number[]` as of `need4deed-sdk@0.0.97` (upgraded in this PR); this lands the storage + handler-side support.

### Schema

- **New m2m entity `CommentPerson(commentId, personId)`** — cascades on both sides, **plus a `@Unique(commentId, personId)` index** so duplicate tag rows can't slip in via races or direct INSERT. Generated migration adds the table, FKs, and the unique index.
- **Reverse `OneToMany` relations** on `Comment` and `Person`.
- **Request body** (`entity-types.json` `Comment#`) now accepts `taggedPersonIds: integer[]`.
- **Response shape** (`sdk-types.json` `ApiComment#`) exposes `taggedPersonIds: integer[]`.

### Helper

`syncCommentTags(commentId, desiredPersonIds, manager)` does the diff — delete removed rows, insert new ones, leave unchanged rows alone. Idempotent. Accepts a transactional `EntityManager` so callers can wrap it. Same pattern as `updateAgentLanguages` in `for-routes.ts`. JSDoc explicitly notes `undefined -> clear-all` semantic and points to the PATCH handler as the example of "guard at the call site for leave-untouched" semantics. 6 pure-function tests cover insert+delete diff, no-op, full-clear, undefined-as-clear, dedupe, all-new.

### Routes

- **`POST /comment`** — destructures `taggedPersonIds` out of the body, saves Comment + `CommentPerson` rows inside one transaction, returns the serialized `ApiComment` with tags populated.
- **`PATCH /comment/:id`** — same flow; the tag-sync only fires when `taggedPersonIds` is present in the patch body (PATCH semantics: omitting the field leaves existing tags alone).
- Both classify Postgres `23503` on the `comment_person` table as `400 "Invalid tagged person id"` — matched on `error.table === "comment_person"`, not detail-text substring, so it can't misfire on unrelated `person`-named constraints later.
- Response schema bumped from `Comment#` (entity) to `ApiComment#` on POST/PATCH so the FE gets a consistent payload. **Verified safe**: the only known consumer (`useCreateComment` / `useUpdateComment` in fe#537) reads only `{ message }` and re-fetches via the invalidated query key.
- `GET /comment` loads `commentPerson`; `addComments2Entity` (used by opportunity/agent/volunteer detail pages) does too — so existing list/detail responses pick up the new field automatically.

### DTO

`commentSerializer` adds `taggedPersonIds: comment.commentPerson?.map(cp => cp.personId).filter(Boolean) ?? []` — empty array when the relation isn't loaded or no tags exist.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test:run` — **227/227** (was 219, +8 new: 6 `syncCommentTags`, 2 `dto-comment` extensions)
- [x] Migration applied on dev DB; `comment_person` table + unique index + FKs verified via `\d`
- [x] FE-side grep confirms POST/PATCH response-shape change is safe (only `{message}` is consumed)
- [ ] After merge: FE PR fe#537 exercises the round-trip; confirm POST/PATCH/GET return `taggedPersonIds` correctly.

## Cross-PR caveat for fe#537

The FE PR currently stores `<@user.id>` markers (user id), but the SDK + this PR expect `taggedPersonIds` (person id), and `ApiUserGet` doesn't expose `personId`. FE will need either (a) switch the marker to person id + extend `ApiUserGet` with `personId`, or (b) have the BE translate user->person on its end. Not addressed here.

## Out of scope (acknowledged follow-ups)

- Pre-validate `personIds` upfront instead of relying on PG FK violation — cheap-enough today, revisit if batched tagging becomes a thing.
- Add the same `@Unique` constraint retroactively to `AgentPerson` — separate ticket; not introduced or worsened by this PR.

Closes the BE half of fe#537 (issue need4deed-org/fe#503).

Generated with [Claude Code](https://claude.com/claude-code)
