### PR TITLE
feat: GET /comment supports taggedPersonId filter (#609)

### DIFF
--- a/src/data/entity/m2m/comment-person.ts
+++ b/src/data/entity/m2m/comment-person.ts
@@ -11,6 +11,9 @@ import Person from "../person.entity";
 
 @Entity()
 @Index(["commentId", "personId"], { unique: true })
+// Reverse-lookup index: "give me every comment where this person is tagged."
+// The composite unique above can seek on commentId-first only.
+@Index(["personId"])
 export default class CommentPerson {
   constructor(commentPerson?: Partial<CommentPerson>) {
     if (commentPerson) {

--- a/src/data/migrations/1780432006040-add-index-comment-person-person-id.ts
+++ b/src/data/migrations/1780432006040-add-index-comment-person-person-id.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIndexCommentPersonPersonId1780432006040
+  implements MigrationInterface
+{
+  name = "AddIndexCommentPersonPersonId1780432006040";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_81d4ae770167ca1c3196b3c3b5" ON "comment_person" ("person_id") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_81d4ae770167ca1c3196b3c3b5"`,
+    );
+  }
+}

--- a/src/server/routes/comment.ts
+++ b/src/server/routes/comment.ts
@@ -1,8 +1,10 @@
 import { validate } from "class-validator";
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { ApiComment, EntityTableName, UserRole } from "need4deed-sdk";
+import { In } from "typeorm";
 import { BadRequestError } from "../../config";
 import Comment from "../../data/entity/comment.entity";
+import CommentPerson from "../../data/entity/m2m/comment-person";
 import logger from "../../logger";
 import { commentSerializer } from "../../services";
 import { responseErrors } from "../schema";
@@ -20,6 +22,7 @@ export default async function commentRoutes(
       userId?: number;
       entityId?: number;
       entityType?: EntityTableName;
+      taggedPersonId?: number;
     };
     Reply: {
       message: string;
@@ -36,6 +39,7 @@ export default async function commentRoutes(
             userId: { type: "number" },
             entityId: { type: "number" },
             entityType: { type: "string" },
+            taggedPersonId: { type: "number" },
           },
         },
         response: {
@@ -55,11 +59,37 @@ export default async function commentRoutes(
     },
     async (request, reply) => {
       try {
-        const { userId, entityId, entityType } = request.query;
+        const { userId, entityId, entityType, taggedPersonId } = request.query;
 
         const commentRepository = fastify.db.commentRepository;
+
+        // Two-step lookup for the tag filter: a relation-filtered findAndCount
+        // would constrain the loaded commentPerson array to only the matching
+        // row, which would lie to the DTO about how many people the comment
+        // actually tags. Resolve the comment ids first, then load fully.
+        let commentIdFilter: number[] | undefined;
+        if (taggedPersonId !== undefined) {
+          const tagRows = await commentRepository.manager
+            .getRepository(CommentPerson)
+            .find({
+              where: { personId: taggedPersonId },
+              select: ["commentId"],
+            });
+          commentIdFilter = tagRows.map((r) => r.commentId);
+          if (commentIdFilter.length === 0) {
+            return reply
+              .status(200)
+              .send({ message: "Comments", data: [], count: 0 });
+          }
+        }
+
         const [comments, count] = await commentRepository.findAndCount({
-          where: { userId, entityId, entityType },
+          where: {
+            userId,
+            entityId,
+            entityType,
+            ...(commentIdFilter ? { id: In(commentIdFilter) } : {}),
+          },
           relations: ["user", "user.person", "language", "commentPerson"],
         });
 
@@ -197,7 +227,9 @@ export default async function commentRoutes(
       } catch (error) {
         // Let BadRequestError (e.g. pre-validation in syncCommentTags) flow
         // to the global handler so it surfaces as 400 with its own message.
-        if (error instanceof BadRequestError) {throw error;}
+        if (error instanceof BadRequestError) {
+          throw error;
+        }
         // Safety net: pre-validation should have caught this, but if a
         // concurrent delete removed the Person between the check and the
         // INSERT, a 23503 still slips through. Match on the failing table
@@ -323,7 +355,9 @@ export default async function commentRoutes(
       } catch (error) {
         // Let BadRequestError (e.g. pre-validation in syncCommentTags) flow
         // to the global handler so it surfaces as 400 with its own message.
-        if (error instanceof BadRequestError) {throw error;}
+        if (error instanceof BadRequestError) {
+          throw error;
+        }
         // Safety net: pre-validation should have caught this, but if a
         // concurrent delete removed the Person between the check and the
         // INSERT, a 23503 still slips through. Match on the failing table


### PR DESCRIPTION
## Summary

Adds the reverse-lookup that PR #607 left open: *"give me every comment where person X is tagged."* New optional `taggedPersonId` query param on `GET /comment`, composable with the existing `userId` (comment **author**), `entityId`, and `entityType` filters.

Closes #609.

## What it does

- **`GET /comment?taggedPersonId=7`** → returns every comment where person 7 appears in `comment_person`.
- **Composable** — `?taggedPersonId=7&userId=12&entityType=volunteer&entityId=42` narrows to "comments authored by user 12 on volunteer 42 where person 7 is tagged."
- **Person id, not user id** — matches the m2m column and the SDK's `taggedPersonIds: number[]`. No `userId` alias for tag lookups (would re-introduce the user/person ambiguity that fe#537 is still untangling).

## Two-step lookup (why not relation filter)

The natural `where: { commentPerson: { personId } }` approach has a subtle bug: TypeORM's relation filter *also* constrains the relation load, so `comment.commentPerson` in the result only contains the matching tag — the serializer would then report `taggedPersonIds: [X]` and hide every other tag on the comment.

Two-step query keeps the DTO honest:

1. Find `comment_person.comment_id` where `person_id = taggedPersonId`.
2. Load comments with `id IN (...)` and full relations.

Empty match short-circuits with a 200 + `data: []` before the second query (also avoids the `id: In([])` antipattern).

## Index

Adds `@Index(["personId"])` on `CommentPerson` (non-unique). The composite `(comment_id, person_id)` unique from #607 can only seek on `comment_id` first; this gives the reverse lookup its own seek path. Migration `add-index-comment-person-person-id` generated cleanly.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test:run` — **229/229**
- [x] Migration applied locally; `comment_person` shows the new btree on `person_id` in `\d`
- [ ] After merge: the FE side can call `GET /comment?taggedPersonId=N` once it has a person id to query with (cross-PR caveat from fe#537 still applies — `ApiUserGet` doesn't yet expose `personId`).

## Out of scope

- No handler-level integration test added; consistent with the existing comment route which has no route-test coverage. Helper-level coverage (`syncCommentTags`) remains.
- No backfill — this is read-side only.

Generated with [Claude Code](https://claude.com/claude-code)
