### PR TITLE
refactor: Deal ↔ Skill m2m (drop Profile indirection)

### DIFF
--- a/src/data/data-source.ts
+++ b/src/data/data-source.ts
@@ -20,6 +20,7 @@ import AgentPerson from "./entity/m2m/agent-person";
 import AgentPostcode from "./entity/m2m/agent-postcode";
 import CommentPerson from "./entity/m2m/comment-person";
 import DealActivity from "./entity/m2m/deal-activity";
+import DealSkill from "./entity/m2m/deal-skill";
 import DistrictPostcode from "./entity/m2m/district-postcode";
 import LocationAddress from "./entity/m2m/location-address";
 import LocationDistrict from "./entity/m2m/location-district";
@@ -77,6 +78,7 @@ export const dataSource = new DataSource({
     Config,
     Deal,
     DealActivity,
+    DealSkill,
     District,
     DistrictPostcode,
     Document,

--- a/src/data/entity/deal.entity.ts
+++ b/src/data/entity/deal.entity.ts
@@ -11,6 +11,7 @@ import { DealType } from "../types";
 import Location from "./location/location.entity";
 import Postcode from "./location/postcode.entity";
 import DealActivity from "./m2m/deal-activity";
+import DealSkill from "./m2m/deal-skill";
 import Opportunity from "./opportunity/opportunity.entity";
 import Profile from "./profile/profile.entity";
 import Time from "./time/time.entity";
@@ -70,6 +71,9 @@ export default class Deal {
 
   @OneToMany(() => DealActivity, (dealActivity) => dealActivity.deal)
   dealActivity: DealActivity[];
+
+  @OneToMany(() => DealSkill, (dealSkill) => dealSkill.deal)
+  dealSkill: DealSkill[];
 
   @OneToMany(() => Opportunity, (opportunity) => opportunity.deal)
   opportunity: Opportunity[];

--- a/src/data/entity/m2m/deal-skill.ts
+++ b/src/data/entity/m2m/deal-skill.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from "typeorm";
+import Deal from "../deal.entity";
+import Skill from "../profile/skill.entity";
+
+@Entity()
+@Unique(["dealId", "skillId"])
+export default class DealSkill {
+  constructor(dealSkill?: Partial<DealSkill>) {
+    if (dealSkill) {
+      Object.assign(this, dealSkill);
+    }
+  }
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Deal, (deal) => deal.dealSkill, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "deal_id" })
+  deal: Deal;
+
+  @Column()
+  dealId: number;
+
+  @ManyToOne(() => Skill, (skill) => skill.dealSkill, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "skill_id" })
+  skill: Skill;
+
+  @Column()
+  skillId: number;
+}

--- a/src/data/entity/profile/skill.entity.ts
+++ b/src/data/entity/profile/skill.entity.ts
@@ -1,5 +1,6 @@
 import { IsNotEmpty, IsString, Length } from "class-validator";
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import DealSkill from "../m2m/deal-skill";
 import ProfileSkill from "../m2m/profile-skill";
 
 @Entity()
@@ -21,6 +22,9 @@ export default class Skill {
 
   @OneToMany(() => ProfileSkill, (profileSkill) => profileSkill.skill)
   profileSkill: ProfileSkill[];
+
+  @OneToMany(() => DealSkill, (dealSkill) => dealSkill.skill)
+  dealSkill: DealSkill[];
 
   translation: string;
 }

--- a/src/data/migrations/1780488457577-add-deal-skill.ts
+++ b/src/data/migrations/1780488457577-add-deal-skill.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDealSkill1780488457577 implements MigrationInterface {
+  name = "AddDealSkill1780488457577";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "deal_skill" ("id" SERIAL NOT NULL, "deal_id" integer NOT NULL, "skill_id" integer NOT NULL, CONSTRAINT "UQ_cf0a989e58c03a76911ea044fa5" UNIQUE ("deal_id", "skill_id"), CONSTRAINT "PK_791b2c5c3ae4db034fef8999c35" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "deal_skill" ADD CONSTRAINT "FK_407bd56cbfa76cc7d99fb29f01a" FOREIGN KEY ("deal_id") REFERENCES "deal"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "deal_skill" ADD CONSTRAINT "FK_8d6f46ceb923a37da3891ace9ac" FOREIGN KEY ("skill_id") REFERENCES "skill"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    // Backfill: copy existing Profile<->Skill rows onto the Deal directly,
+    // mapping profile_id -> deal_id through the deal table. DISTINCT guards
+    // the (deal_id, skill_id) unique constraint against any duplicate source rows.
+    await queryRunner.query(
+      `INSERT INTO "deal_skill" ("deal_id", "skill_id") SELECT DISTINCT "deal"."id", "profile_skill"."skill_id" FROM "profile_skill" INNER JOIN "deal" ON "deal"."profile_id" = "profile_skill"."profile_id"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "deal_skill" DROP CONSTRAINT "FK_8d6f46ceb923a37da3891ace9ac"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "deal_skill" DROP CONSTRAINT "FK_407bd56cbfa76cc7d99fb29f01a"`,
+    );
+    await queryRunner.query(`DROP TABLE "deal_skill"`);
+  }
+}

--- a/src/data/seeds/utils.ts
+++ b/src/data/seeds/utils.ts
@@ -28,9 +28,9 @@ import Location from "../entity/location/location.entity";
 import Postcode from "../entity/location/postcode.entity";
 import AgentPerson from "../entity/m2m/agent-person";
 import DealActivity from "../entity/m2m/deal-activity";
+import DealSkill from "../entity/m2m/deal-skill";
 import LocationDistrict from "../entity/m2m/location-district";
 import ProfileLanguage from "../entity/m2m/profile-language";
-import ProfileSkill from "../entity/m2m/profile-skill";
 import TimeTimeslot from "../entity/m2m/time-timeslot";
 import NotionRelation from "../entity/notion-relation.entity";
 import Agent from "../entity/opportunity/agent.entity";
@@ -325,7 +325,7 @@ export async function createDeal(
   const profileRepository = getRepository(dataSource, Profile);
   const dealActivityRepository = getRepository(dataSource, DealActivity);
   const skillRepository = getRepository(dataSource, Skill);
-  const profileSkillRepository = getRepository(dataSource, ProfileSkill);
+  const dealSkillRepository = getRepository(dataSource, DealSkill);
   const languageRepository = getRepository(dataSource, Language);
   const profileLanguageRepository = getRepository(dataSource, ProfileLanguage);
   const locationRepository = getRepository(dataSource, Location);
@@ -359,14 +359,15 @@ export async function createDeal(
     activities.push(activity);
   }
 
+  const skills: Skill[] = [];
   for (const title of dealData.profile.skills ?? []) {
     const skill = await skillRepository.findOne({ where: { title } });
     if (!skill) {
       // logger.warn(`Skill ${title} not found. Skipping.`);
       continue;
     }
-    const profileSkill = new ProfileSkill({ profile, skill });
-    await profileSkillRepository.save(profileSkill);
+    // DealSkill rows are created after the deal is saved (need dealId).
+    skills.push(skill);
   }
 
   for (const [title, level] of dealData.profile.languages ?? []) {
@@ -414,6 +415,11 @@ export async function createDeal(
   for (const activity of activities) {
     const dealActivity = new DealActivity({ deal, activity });
     await dealActivityRepository.save(dealActivity);
+  }
+
+  for (const skill of skills) {
+    const dealSkill = new DealSkill({ deal, skill });
+    await dealSkillRepository.save(dealSkill);
   }
 
   return deal;

--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -261,7 +261,7 @@ export default async function opportunityLegacyRoutes(
             .map((pl) => pl.language?.title ?? null)
             .filter(Boolean);
 
-          const skills = (profile.profileSkill ?? [])
+          const skills = (deal.dealSkill ?? [])
             .map((ps) => ps.skill?.title ?? null)
             .filter(Boolean);
 
@@ -313,7 +313,7 @@ export default async function opportunityLegacyRoutes(
         relations: [
           "deal.profile.profileLanguage.language",
           "deal.dealActivity.activity",
-          "deal.profile.profileSkill.skill",
+          "deal.dealSkill.skill",
           "deal.time.timeTimeslot.timeslot",
           "deal.location.locationDistrict.district",
           "accompanying",

--- a/src/server/routes/opportunity/opportunity-volunteer.routes.ts
+++ b/src/server/routes/opportunity/opportunity-volunteer.routes.ts
@@ -37,7 +37,7 @@ export default function opportunityOpportunityVolunteerRoutes(
         relations: [
           "volunteer.person",
           "volunteer.deal.dealActivity.activity",
-          "volunteer.deal.profile.profileSkill.skill",
+          "volunteer.deal.dealSkill.skill",
           "volunteer.deal.profile.profileLanguage.language",
           "volunteer.deal.time.timeTimeslot.timeslot",
           "volunteer.deal.location.locationDistrict.district",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -9,8 +9,8 @@ import {
 import { BadRequestError, NotFoundError } from "../../../config";
 import Comment from "../../../data/entity/comment.entity";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
+import DealSkill from "../../../data/entity/m2m/deal-skill";
 import ProfileLanguage from "../../../data/entity/m2m/profile-language";
-import ProfileSkill from "../../../data/entity/m2m/profile-skill";
 import TimeTimeslot from "../../../data/entity/m2m/time-timeslot";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
@@ -83,7 +83,7 @@ export default async function opportunityRoutes(
         "accompanying.postcode",
         "deal.profile.profileLanguage.language",
         "deal.dealActivity.activity",
-        "deal.profile.profileSkill.skill",
+        "deal.dealSkill.skill",
         "deal.location.locationDistrict.district",
         "deal.time.timeTimeslot.timeslot",
         "agent.agentPerson.person.address.postcode",
@@ -394,7 +394,7 @@ export default async function opportunityRoutes(
       }
 
       if (skills) {
-        const success = await updateOptionList(dealId, ProfileSkill, skills);
+        const success = await updateOptionList(dealId, DealSkill, skills);
         if (!success) {
           throw new BadRequestError(
             `Skills for opportunity (deal_id:${dealId}) not updated.`,

--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -11,9 +11,9 @@ import {
 } from "need4deed-sdk";
 import { FindOptionsWhere } from "typeorm";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
+import DealSkill from "../../../data/entity/m2m/deal-skill";
 import LocationDistrict from "../../../data/entity/m2m/location-district";
 import ProfileLanguage from "../../../data/entity/m2m/profile-language";
-import ProfileSkill from "../../../data/entity/m2m/profile-skill";
 import TimeTimeslot from "../../../data/entity/m2m/time-timeslot";
 import Person from "../../../data/entity/person.entity";
 import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
@@ -61,7 +61,7 @@ export default async function volunteerRoutes(
     "deal",
     "deal.postcode",
     "deal.dealActivity.activity",
-    "deal.profile.profileSkill.skill",
+    "deal.dealSkill.skill",
     "deal.profile.profileLanguage.language",
     "deal.time.timeTimeslot.timeslot",
     "deal.location.locationPostcode.postcode",
@@ -328,7 +328,7 @@ export default async function volunteerRoutes(
         }
 
         if (skills) {
-          const success = await updateOptionList(dealId, ProfileSkill, skills);
+          const success = await updateOptionList(dealId, DealSkill, skills);
           if (!success) {
             return reply.status(400).send({
               message: `Skills for volunteer (deal_id:${dealId}) not updated.`,

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -166,7 +166,7 @@ export async function addTranslatedFields(
           ? translation?.translation
           : pa.activity.translation;
       }
-      for (const ps of volunteer.deal.profile.profileSkill) {
+      for (const ps of volunteer.deal.dealSkill) {
         const translation = await fieldTranslationRepository.findOne({
           where: {
             language,
@@ -440,9 +440,11 @@ function getDealRelationsAndIdFieldName(m2mEntityName: string) {
       idFieldNames: ["deal", "dealId", "activity", "activityId"],
       relations: [],
     },
-    ProfileSkill: {
-      idFieldNames: ["profile", "profileId", "skill", "skillId"],
-      relations: ["profile.profileSkill"],
+    DealSkill: {
+      // m2m hangs directly off the deal (the root), so no nested relation
+      // needs loading to resolve the host id.
+      idFieldNames: ["deal", "dealId", "skill", "skillId"],
+      relations: [],
     },
     LocationDistrict: {
       idFieldNames: ["location", "locationId", "district", "districtId"],

--- a/src/server/utils/data/get-volunteer-where.ts
+++ b/src/server/utils/data/get-volunteer-where.ts
@@ -6,16 +6,11 @@ export function getVolunteerWhere(
   filter: QuerystringVolunteerFiltering["filter"],
 ) {
   // Build deal.profile sub-filter to avoid overwriting when multiple profile
-  // relations are active (language, skill all share the same deal key).
+  // relations are active (language shares the same deal key).
   const profileFilter: Record<string, unknown> = {};
   if (filter?.language) {
     profileFilter.profileLanguage = {
       language: { id: normalizeStringArrayInput(filter.language) },
-    };
-  }
-  if (filter?.skill) {
-    profileFilter.profileSkill = {
-      skill: { id: normalizeStringArrayInput(filter.skill) },
     };
   }
 
@@ -26,6 +21,11 @@ export function getVolunteerWhere(
   if (filter?.activity) {
     dealFilter.dealActivity = {
       activity: { id: normalizeStringArrayInput(filter.activity) },
+    };
+  }
+  if (filter?.skill) {
+    dealFilter.dealSkill = {
+      skill: { id: normalizeStringArrayInput(filter.skill) },
     };
   }
   if (filter?.district) {

--- a/src/server/utils/data/write-opportunity-legacy.ts
+++ b/src/server/utils/data/write-opportunity-legacy.ts
@@ -2,9 +2,9 @@ import { dataSource } from "../../../data/data-source";
 import Deal from "../../../data/entity/deal.entity";
 import Location from "../../../data/entity/location/location.entity";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
+import DealSkill from "../../../data/entity/m2m/deal-skill";
 import LocationDistrict from "../../../data/entity/m2m/location-district";
 import ProfileLanguage from "../../../data/entity/m2m/profile-language";
-import ProfileSkill from "../../../data/entity/m2m/profile-skill";
 import TimeTimeslot from "../../../data/entity/m2m/time-timeslot";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
@@ -21,8 +21,8 @@ export async function writeOpportunityLegacy(
     const profileRepository = transactionalEntityManager.getRepository(Profile);
     const dealActivityRepository =
       transactionalEntityManager.getRepository(DealActivity);
-    const profileSkillRepository =
-      transactionalEntityManager.getRepository(ProfileSkill);
+    const dealSkillRepository =
+      transactionalEntityManager.getRepository(DealSkill);
     const profileLanguageRepository =
       transactionalEntityManager.getRepository(ProfileLanguage);
     const timeRepository = transactionalEntityManager.getRepository(Time);
@@ -36,11 +36,6 @@ export async function writeOpportunityLegacy(
       transactionalEntityManager.getRepository(Accompanying);
 
     await profileRepository.save(opportunity.deal.profile);
-
-    for (const profileSkill of opportunity.deal.profile.profileSkill) {
-      profileSkill.profileId = opportunity.deal.profile.id;
-      await profileSkillRepository.save(profileSkill);
-    }
 
     for (const profileLanguage of opportunity.deal.profile.profileLanguage) {
       profileLanguage.profileId = opportunity.deal.profile.id;
@@ -61,11 +56,17 @@ export async function writeOpportunityLegacy(
 
     await dealRepository.save(opportunity.deal);
 
-    // Deal m2m relations (activities) — saved after the deal so dealId exists
+    // Deal m2m relations (activities, skills) — saved after the deal so
+    // dealId exists
     for (const dealActivity of opportunity.deal.dealActivity) {
       dealActivity.dealId = opportunity.deal.id;
     }
     await dealActivityRepository.save(opportunity.deal.dealActivity);
+
+    for (const dealSkill of opportunity.deal.dealSkill) {
+      dealSkill.dealId = opportunity.deal.id;
+    }
+    await dealSkillRepository.save(opportunity.deal.dealSkill);
 
     if (opportunity.accompanying) {
       await accompanyingRepository.save(opportunity.accompanying);

--- a/src/server/utils/data/write-volunteer-legacy.ts
+++ b/src/server/utils/data/write-volunteer-legacy.ts
@@ -3,9 +3,9 @@ import Deal from "../../../data/entity/deal.entity";
 import Address from "../../../data/entity/location/address.entity";
 import Location from "../../../data/entity/location/location.entity";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
+import DealSkill from "../../../data/entity/m2m/deal-skill";
 import LocationDistrict from "../../../data/entity/m2m/location-district";
 import ProfileLanguage from "../../../data/entity/m2m/profile-language";
-import ProfileSkill from "../../../data/entity/m2m/profile-skill";
 import TimeTimeslot from "../../../data/entity/m2m/time-timeslot";
 import Person from "../../../data/entity/person.entity";
 import Profile from "../../../data/entity/profile/profile.entity";
@@ -23,8 +23,8 @@ export async function writeVolunteerLegacy(
     const profileRepository = transactionalEntityManager.getRepository(Profile);
     const dealActivityRepository =
       transactionalEntityManager.getRepository(DealActivity);
-    const profileSkillRepository =
-      transactionalEntityManager.getRepository(ProfileSkill);
+    const dealSkillRepository =
+      transactionalEntityManager.getRepository(DealSkill);
     const profileLanguageRepository =
       transactionalEntityManager.getRepository(ProfileLanguage);
     const timeRepository = transactionalEntityManager.getRepository(Time);
@@ -49,12 +49,7 @@ export async function writeVolunteerLegacy(
     await profileRepository.save(volunteer.deal.profile);
     const profileId = volunteer.deal.profile.id;
 
-    // Profile m2m relations (skills, languages)
-    for (const profileSkill of volunteer.deal.profile.profileSkill) {
-      profileSkill.profileId = profileId;
-    }
-    await profileSkillRepository.save(volunteer.deal.profile.profileSkill);
-
+    // Profile m2m relations (languages)
     for (const profileLanguage of volunteer.deal.profile.profileLanguage) {
       profileLanguage.profileId = profileId;
     }
@@ -88,11 +83,17 @@ export async function writeVolunteerLegacy(
     await dealRepository.save(volunteer.deal);
     const dealId = volunteer.deal.id;
 
-    // Deal m2m relations (activities) — saved after the deal so dealId exists
+    // Deal m2m relations (activities, skills) — saved after the deal so
+    // dealId exists
     for (const dealActivity of volunteer.deal.dealActivity) {
       dealActivity.dealId = dealId;
     }
     await dealActivityRepository.save(volunteer.deal.dealActivity);
+
+    for (const dealSkill of volunteer.deal.dealSkill) {
+      dealSkill.dealId = dealId;
+    }
+    await dealSkillRepository.save(volunteer.deal.dealSkill);
 
     // Volunteer
     await volunteerRepository.save(volunteer);

--- a/src/services/dto/dto-opportunity-volunteer.ts
+++ b/src/services/dto/dto-opportunity-volunteer.ts
@@ -43,7 +43,7 @@ export function opportunityOpportunityVolunteerDTO(
       "activity",
     ),
     skills: getOptionItems(
-      opportunityVolunteer.volunteer.deal.profile?.profileSkill,
+      opportunityVolunteer.volunteer.deal.dealSkill,
       "skill",
     ),
     languages: getLanguages(

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -155,11 +155,9 @@ export function dtoOpportunityGet(
       .map((pa) => ({
         id: pa.activity.id,
       })),
-    skills: opportunityComments.deal.profile.profileSkill
-      .filter(Boolean)
-      .map((ps) => ({
-        id: ps.skill.id,
-      })),
+    skills: opportunityComments.deal.dealSkill.filter(Boolean).map((ps) => ({
+      id: ps.skill.id,
+    })),
     location: opportunityComments.deal.location.locationDistrict
       .filter(Boolean)
       .map((ld) => ({

--- a/src/services/dto/dto-volunteer.ts
+++ b/src/services/dto/dto-volunteer.ts
@@ -26,7 +26,7 @@ export function volunteerListSerializer(
     const languages = getLanguages(volunteer.deal.profile.profileLanguage);
     const availability = getAvailability(volunteer.deal.time?.timeTimeslot);
     const activities = getOptionItems(volunteer.deal.dealActivity, "activity");
-    const skills = getOptionItems(volunteer.deal.profile.profileSkill, "skill");
+    const skills = getOptionItems(volunteer.deal.dealSkill, "skill");
     const locations = getOptionItems(
       volunteer.deal.location?.locationDistrict,
       "district",
@@ -115,7 +115,7 @@ export function volunteerSerializer(
   const createdAt = volunteer.createdAt;
   const updatedAt = volunteer.updatedAt;
   const activities = getOptionItems(volunteer.deal.dealActivity, "activity");
-  const skills = getOptionItems(volunteer.deal.profile.profileSkill, "skill");
+  const skills = getOptionItems(volunteer.deal.dealSkill, "skill");
   const locations = getOptionItems(
     volunteer.deal.location.locationDistrict,
     "district",

--- a/src/services/dto/parser-deal-opportunity.ts
+++ b/src/services/dto/parser-deal-opportunity.ts
@@ -11,9 +11,9 @@ import Deal from "../../data/entity/deal.entity";
 import District from "../../data/entity/location/district.entity";
 import Location from "../../data/entity/location/location.entity";
 import DealActivity from "../../data/entity/m2m/deal-activity";
+import DealSkill from "../../data/entity/m2m/deal-skill";
 import LocationDistrict from "../../data/entity/m2m/location-district";
 import ProfileLanguage from "../../data/entity/m2m/profile-language";
-import ProfileSkill from "../../data/entity/m2m/profile-skill";
 import TimeTimeslot from "../../data/entity/m2m/time-timeslot";
 import Activity from "../../data/entity/profile/activity.entity";
 import Language from "../../data/entity/profile/language.entity";
@@ -56,17 +56,17 @@ export async function dealParserOpportunity(
   }
 
   // skills
-  const profileSkill: ProfileSkill[] = [];
+  const dealSkill: DealSkill[] = [];
   const opportunitySkills = (formData.skills || []) as string[];
   for (const opportunitySkill of opportunitySkills) {
     const profileEntity = await getProfileEntityByTitle(
       opportunitySkill,
       EntityTableName.SKILL,
       Skill,
-      ProfileSkill,
+      DealSkill,
     );
     if (profileEntity) {
-      profileSkill.push(profileEntity);
+      dealSkill.push(profileEntity);
     }
   }
 
@@ -100,7 +100,6 @@ export async function dealParserOpportunity(
   const category = null;
   const profile = new Profile({
     category,
-    profileSkill,
     profileLanguage,
   });
 
@@ -174,6 +173,7 @@ export async function dealParserOpportunity(
     type,
     profile,
     dealActivity,
+    dealSkill,
     postcode,
     time,
     location,

--- a/src/services/dto/parser-deal-volunteer.ts
+++ b/src/services/dto/parser-deal-volunteer.ts
@@ -9,9 +9,9 @@ import Deal from "../../data/entity/deal.entity";
 import District from "../../data/entity/location/district.entity";
 import Location from "../../data/entity/location/location.entity";
 import DealActivity from "../../data/entity/m2m/deal-activity";
+import DealSkill from "../../data/entity/m2m/deal-skill";
 import LocationDistrict from "../../data/entity/m2m/location-district";
 import ProfileLanguage from "../../data/entity/m2m/profile-language";
-import ProfileSkill from "../../data/entity/m2m/profile-skill";
 import TimeTimeslot from "../../data/entity/m2m/time-timeslot";
 import Activity from "../../data/entity/profile/activity.entity";
 import Language from "../../data/entity/profile/language.entity";
@@ -41,17 +41,17 @@ export async function dealParser(formData: VolunteerFormData): Promise<Deal> {
   }
 
   // skills
-  const profileSkill: ProfileSkill[] = [];
+  const dealSkill: DealSkill[] = [];
   const volunteerSkills = (formData.skills || []) as string[];
   for (const volunteerSkill of volunteerSkills) {
     const profileEntity = await getProfileEntityByTitle(
       volunteerSkill,
       EntityTableName.SKILL,
       Skill,
-      ProfileSkill,
+      DealSkill,
     );
     if (profileEntity) {
-      profileSkill.push(profileEntity);
+      dealSkill.push(profileEntity);
     }
   }
 
@@ -77,7 +77,6 @@ export async function dealParser(formData: VolunteerFormData): Promise<Deal> {
   const category = null;
   const profile = new Profile({
     category,
-    profileSkill,
     profileLanguage,
   });
 
@@ -135,6 +134,7 @@ export async function dealParser(formData: VolunteerFormData): Promise<Deal> {
     type,
     profile,
     dealActivity,
+    dealSkill,
     postcode,
     time,
     location,

--- a/src/test/server/utils/write-volunteer.test.ts
+++ b/src/test/server/utils/write-volunteer.test.ts
@@ -3,9 +3,9 @@ import Deal from "../../../data/entity/deal.entity";
 import Address from "../../../data/entity/location/address.entity";
 import Location from "../../../data/entity/location/location.entity";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
+import DealSkill from "../../../data/entity/m2m/deal-skill";
 import LocationDistrict from "../../../data/entity/m2m/location-district";
 import ProfileLanguage from "../../../data/entity/m2m/profile-language";
-import ProfileSkill from "../../../data/entity/m2m/profile-skill";
 import TimeTimeslot from "../../../data/entity/m2m/time-timeslot";
 import Person from "../../../data/entity/person.entity";
 import Profile from "../../../data/entity/profile/profile.entity";
@@ -28,7 +28,7 @@ describe("writeVolunteer", () => {
   const personSave = vi.fn();
   const profileSave = vi.fn();
   const dealActivitySave = vi.fn();
-  const profileSkillSave = vi.fn();
+  const dealSkillSave = vi.fn();
   const profileLanguageSave = vi.fn();
   const timeSave = vi.fn();
   const timeTimeslotSave = vi.fn();
@@ -50,8 +50,8 @@ describe("writeVolunteer", () => {
           return { save: profileSave };
         case DealActivity:
           return { save: dealActivitySave };
-        case ProfileSkill:
-          return { save: profileSkillSave };
+        case DealSkill:
+          return { save: dealSkillSave };
         case ProfileLanguage:
           return { save: profileLanguageSave };
         case Time:
@@ -78,7 +78,7 @@ describe("writeVolunteer", () => {
       arr.forEach((it, i) => (it.id = 100 + i));
       return arr;
     });
-    profileSkillSave.mockImplementation(async (arr: any[]) => {
+    dealSkillSave.mockImplementation(async (arr: any[]) => {
       arr.forEach((it, i) => (it.id = 200 + i));
       return arr;
     });
@@ -108,10 +108,10 @@ describe("writeVolunteer", () => {
         id: undefined,
         profile: {
           id: undefined,
-          profileSkill: [{}, {}],
           profileLanguage: [{}, {}],
         },
         dealActivity: [{}, {}],
+        dealSkill: [{}, {}],
         time: { id: undefined, timeTimeslot: [{}, {}] },
         location: { id: undefined, locationDistrict: [{}, {}] },
       },
@@ -123,9 +123,7 @@ describe("writeVolunteer", () => {
     expect(personSave).toHaveBeenCalledWith(volunteer.person);
     expect(profileSave).toHaveBeenCalledWith(volunteer.deal.profile);
     expect(dealActivitySave).toHaveBeenCalledWith(volunteer.deal.dealActivity);
-    expect(profileSkillSave).toHaveBeenCalledWith(
-      volunteer.deal.profile.profileSkill,
-    );
+    expect(dealSkillSave).toHaveBeenCalledWith(volunteer.deal.dealSkill);
     expect(profileLanguageSave).toHaveBeenCalledWith(
       volunteer.deal.profile.profileLanguage,
     );
@@ -143,8 +141,9 @@ describe("writeVolunteer", () => {
     expect(result).toBe(77);
     expect(volunteer.id).toBe(77);
 
-    // ensure m2m propagation happened — activities now key off the deal id
+    // ensure m2m propagation happened — activities/skills now key off the deal id
     expect(volunteer.deal.dealActivity[0].dealId).toBe(66);
+    expect(volunteer.deal.dealSkill[0].dealId).toBe(66);
     expect(volunteer.deal.time.timeTimeslot[0].timeId).toBe(44);
     expect(volunteer.deal.location.locationDistrict[0].locationId).toBe(55);
   });
@@ -160,10 +159,10 @@ describe("writeVolunteer", () => {
         id: undefined,
         profile: {
           id: undefined,
-          profileSkill: [],
           profileLanguage: [],
         },
         dealActivity: [{}],
+        dealSkill: [],
         time: { id: undefined, timeTimeslot: [] },
         location: { id: undefined, locationDistrict: [] },
       },

--- a/src/test/services/dto/dto-opportunity-volunteer.test.ts
+++ b/src/test/services/dto/dto-opportunity-volunteer.test.ts
@@ -29,8 +29,9 @@ function makeOV(
       statusEngagement: "active",
       person: { name: "Jane Doe", avatarUrl: "https://cdn.example.com/a.png" },
       deal: {
-        profile: { profileSkill: [], profileLanguage: [] },
+        profile: { profileLanguage: [] },
         dealActivity: [],
+        dealSkill: [],
         time: { timeTimeslot: [] },
         location: { locationDistrict: [] },
       },

--- a/src/test/services/dto/dto-volunteer.test.ts
+++ b/src/test/services/dto/dto-volunteer.test.ts
@@ -48,9 +48,9 @@ function makeVolunteer(overrides = {}) {
     deal: {
       profile: {
         profileLanguage: [],
-        profileSkill: [],
       },
       dealActivity: [],
+      dealSkill: [],
       time: { timeTimeslot: [] },
       location: { locationDistrict: [] },
     },


### PR DESCRIPTION
Part of #611 (Phase 1 — Profile flattening). Closes #613.

Replaces the `Profile ─< ProfileSkill >─ Skill` chain with a direct `Deal ─< DealSkill >─ Skill` m2m. Mirrors the merged Deal↔Activity work (#612 / #619), and folds in the unique constraint + input-dedup from the start rather than as a follow-up.

## Changes

**Schema**
- New `DealSkill` entity with `@Unique(["dealId","skillId"])` + inverse relations on `Deal`/`Skill`; registered in `data-source.ts`.
- Migration `add-deal-skill`: creates `deal_skill` (incl. the unique constraint), then backfills from `profile_skill` mapping `profile_id → deal_id` via the `deal` table — using `SELECT DISTINCT` so the backfill can't violate the new constraint.

**Writes** — `parser-deal-volunteer`, `parser-deal-opportunity`, `write-volunteer-legacy`, `write-opportunity-legacy`, seeds now build/persist `deal.dealSkill`, saved after the deal (needs `dealId`).

**Reads** — `deal.profile.profileSkill` → `deal.dealSkill` across `dto-volunteer`, `dto-opportunity` (GET-by-id skills), `dto-opportunity-volunteer`, the skill where-filter, the translation loop in `for-routes.ts`, and all route relation strings.

**Misc** — `updateOptionList` routes `DealSkill` through the root-hosted path (`relations: []`); the generic input-dedup added in #619 already protects the new unique constraint.

## Not in scope
`ProfileSkill` entity + table are intentionally **kept** — dropped in #614's Profile teardown.

## Verification
- Migration applied; backfill inserted 2306 rows (= distinct deal-attached `profile_skill` rows; the 1-row gap is an orphaned profile).
- `yarn typecheck` ✓ · `yarn test:run` → 229 passed ✓ · lint clean for changed files.
- API response shapes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
