### PR TITLE
chore: upgrade need4deed-sdk to 0.0.98

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.97",
+    "need4deed-sdk": "0.0.98",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/data/seeds/types.ts
+++ b/src/data/seeds/types.ts
@@ -1,10 +1,10 @@
 import {
-  DealType,
   DocumentStatusType,
   LangProficiency,
   OpportunityType,
   VolunteerStateType,
 } from "need4deed-sdk";
+import { DealType } from "../types";
 
 export interface ProfileJSON {
   info: string;

--- a/src/services/dto/parser-deal-opportunity.ts
+++ b/src/services/dto/parser-deal-opportunity.ts
@@ -1,6 +1,5 @@
 import {
   ApiLanguage,
-  DealType,
   EntityTableName,
   LangPurpose,
   OccasionalType,
@@ -18,6 +17,7 @@ import Activity from "../../data/entity/profile/activity.entity";
 import Language from "../../data/entity/profile/language.entity";
 import Skill from "../../data/entity/profile/skill.entity";
 import Timeslot from "../../data/entity/time/timeslot.entity";
+import { DealType } from "../../data/types";
 import {
   getPostcode,
   getRepository,

--- a/src/services/dto/parser-deal-volunteer.ts
+++ b/src/services/dto/parser-deal-volunteer.ts
@@ -1,6 +1,5 @@
 import {
   ApiLanguage,
-  DealType,
   EntityTableName,
   OccasionalType,
   VolunteerFormData,
@@ -15,6 +14,7 @@ import DealTimeslot from "../../data/entity/m2m/deal-timeslot";
 import Activity from "../../data/entity/profile/activity.entity";
 import Language from "../../data/entity/profile/language.entity";
 import Skill from "../../data/entity/profile/skill.entity";
+import { DealType } from "../../data/types";
 import { getPostcode, getRRULE, getStartEnd } from "../../data/utils";
 import { getProfileEntityByTitle, getTimeslot } from "../../server/utils";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,10 +3813,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.97:
-  version "0.0.97"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.97.tgz#242bdec085b414e3ec70f246538fb7115b4f7a1d"
-  integrity sha512-0oxgjasJTgZ+cnWD0AZAQMh73huA+OZ83sWBaqAKXOnu723ZtSocFesVtp1kikftCpQ4rQNotJooD+bIahCwsQ==
+need4deed-sdk@0.0.98:
+  version "0.0.98"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.98.tgz#e2d7fcf58b1506b5d6814c0b580af18f079678ef"
+  integrity sha512-f0RT21+TcFNSSEKuoXmIBkIt7R0Fj7PprQBDy6c7W7CUhNTf1W4FNMNz8qxfTCjxOh3RBIplsHx4+tS84HRO0w==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Upgrade `need4deed-sdk` 0.0.97 → 0.0.98.

0.0.98 removes the leftover `new_api.ts` (need4deed-org/sdk#121) that wrongly modeled `Deal` as part of the API contract. That file also held the `DealType` enum, which a few BE files were importing **from the SDK** — so the bump alone broke `yarn typecheck`.

`DealType` is internal (Deal is storage, not contract), so this repoints those imports to the **local** `data/types` enum that `deal.entity.ts` already uses for the `deal_type` DB column:
- `services/dto/parser-deal-volunteer.ts`
- `services/dto/parser-deal-opportunity.ts`
- `data/seeds/types.ts`

No behavior change — same enum values (`volunteer`/`opportunity`).

## Verification
`yarn typecheck` ✓ · `yarn test:run` → 229 passed ✓ · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
