### PR TITLE
fix(migration): drop legacy volunteer_list_mv before dropping deal.profile_id

### DIFF
--- a/src/data/migrations/1780492917105-flatten-deal-language-drop-profile.ts
+++ b/src/data/migrations/1780492917105-flatten-deal-language-drop-profile.ts
@@ -41,6 +41,13 @@ export class FlattenDealLanguageDropProfile1780492917105
     );
 
     // 4. Drop the Deal->Profile link and the Profile graph entirely.
+    //    The legacy volunteer_list_mv materialized view (present in prod/staging
+    //    snapshots, never created by repo code) reads deal.profile_id and blocks
+    //    the DROP COLUMN below. It is already deprecated, so drop it first;
+    //    IF EXISTS keeps this a no-op on databases that never had it.
+    await queryRunner.query(
+      `DROP MATERIALIZED VIEW IF EXISTS volunteer_list_mv`,
+    );
     await queryRunner.query(
       `ALTER TABLE "deal" DROP CONSTRAINT "FK_9f36d6cf04687b811690d82a3c1"`,
     );


### PR DESCRIPTION
## Problem

Staging deploy fails on migration `FlattenDealLanguageDropProfile1780492917105`:

```
error: cannot drop column profile_id of table deal because other objects depend on it
detail: materialized view volunteer_list_mv depends on column profile_id of table deal
query: ALTER TABLE "deal" DROP COLUMN "profile_id"
```

The whole migration runs in one transaction, so it rolled back cleanly — staging still has `profile_id`, still has the view, and the migration is **not** recorded as applied.

## Why it happens

- `volunteer_list_mv` is **never created by repo code** (the only reference is a `DROP` in `1763036250587`). It lives in the prod/staging DB **snapshots**.
- The earlier `DROP MATERIALIZED VIEW IF EXISTS` in `1763036250587` never executed on staging/prod — that migration was already recorded as applied there before the DROP line was added (edit-after-apply).
- A *new, later* migration can't fix this: migrations abort at the first failure (`1780492917105`), so nothing after it runs.

## Fix

Drop the deprecated MV at the start of step 4, before `DROP COLUMN profile_id`. `IF EXISTS` makes it a no-op on databases that never had the view (local/dev) — where this migration has already applied and so won't re-run anyway.

## Risk / scope

- The MV is already deprecated (an earlier migration intended to drop it) and nothing in the codebase reads it.
- ⚠️ **Production likely has the same MV** in its snapshot, so this also pre-empts the identical failure on the prod deploy.
- If any out-of-repo consumer (BI/reporting) still reads `volunteer_list_mv`, dropping it would affect them — not aware of any, flagging for confirmation.

## Note on editing an existing migration

This intentionally edits an already-merged migration rather than adding a new one, because (a) a later migration is unreachable past the failing one, and (b) the edit is safe: it hasn't been recorded as applied on the blocked environments, and is a no-op where it already succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)