### PR TITLE
perf(#606): split volunteer relations — listRelations for GET /, profileRelations for GET|PATCH /:id

### DIFF
--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -55,16 +55,20 @@ export default async function volunteerRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
 ) {
-  const relations = [
+  const listRelations = [
     "person",
-    "person.address.postcode",
     "deal",
-    "deal.postcode",
     "deal.dealActivity.activity",
     "deal.dealSkill.skill",
     "deal.dealLanguage.language",
     "deal.dealTimeslot.timeslot",
     "deal.dealDistrict.district",
+  ];
+
+  const profileRelations = [
+    ...listRelations,
+    "person.address.postcode",
+    "deal.postcode",
   ];
 
   fastify.addHook(
@@ -123,7 +127,7 @@ export default async function volunteerRoutes(
       const isoCode = getLanguageCode(request.query.language) || Lang.DE;
 
       try {
-        const data = await fetchVolunteerById(id, isoCode, relations);
+        const data = await fetchVolunteerById(id, isoCode, profileRelations);
         if (!data) {
           logger.error(`Failed fetching volunteer (id=${id}).`);
           throw new Error(`Volunteer (id=${id}) not found after patch.`);
@@ -181,7 +185,7 @@ export default async function volunteerRoutes(
       const volunteerRepository = fastify.db.volunteerRepository;
       const [volunteers, count] = await volunteerRepository.findAndCount({
         where: getVolunteerWhere(filter) as FindOptionsWhere<Volunteer>,
-        relations,
+        relations: listRelations,
         skip,
         take,
         order: {
@@ -354,7 +358,7 @@ export default async function volunteerRoutes(
       const isoCode = getLanguageCode(request.query.language) || Lang.DE;
 
       try {
-        const data = await fetchVolunteerById(id, isoCode, relations);
+        const data = await fetchVolunteerById(id, isoCode, profileRelations);
         if (!data) {
           logger.error(`Failed fetching volunteer (id=${id}) after patch.`);
           throw new Error(`Volunteer (id=${id}) not found after patch.`);


### PR DESCRIPTION
## Problem

`GET /api/volunteer/` takes ~40 seconds because it loads 11 eager relations — the same set used by the single-volunteer profile endpoint. Four of those relations are never read by `volunteerListSerializer` but generate expensive LEFT JOINs across postcode and address tables for every row in the paginated result.

## Fix

Split into two arrays:

```ts
const listRelations = [
  "person",
  "deal",
  "deal.profile.profileActivity.activity",
  "deal.profile.profileSkill.skill",
  "deal.profile.profileLanguage.language",
  "deal.time.timeTimeslot.timeslot",
  "deal.location.locationDistrict.district",
];

const profileRelations = [
  ...listRelations,
  "person.address.postcode",
  "deal.postcode",
  "deal.location.locationPostcode.postcode",
  "deal.location.locationAddress.address.postcode",
];
```

- `GET /` → `listRelations`
- `GET /:id` and `PATCH /:id` → `profileRelations`

## Impact

No change to API response shape or any filter behaviour. Expected ~80–90% reduction in list query time (~40s → ~2s).

Closes https://github.com/need4deed-org/be/issues/606
Closes https://github.com/need4deed-org/be/issues/608