### PR TITLE
fix(opportunity): refresh submitter Person fields from rac_* on resubmit

### DIFF
--- a/src/server/utils/data/get-or-create-submitter-person.ts
+++ b/src/server/utils/data/get-or-create-submitter-person.ts
@@ -79,11 +79,15 @@ export async function getOrCreateSubmitterPerson(
     if (fullName) {
       const { firstName, lastName } = splitName(fullName, email);
       person.firstName = firstName;
-      person.lastName = lastName;
+      // Use null (not undefined) when the new name has no last token: TypeORM
+      // skips undefined on update, which would leave a stale last name behind
+      // (e.g. resubmitting "Cher" over "Mary van der Berg" -> "Cher van der Berg").
+      person.lastName = lastName ?? (null as unknown as undefined);
       dirty = true;
     }
-    if (body.rac_phone) {
-      person.phone = body.rac_phone;
+    const phone = (body.rac_phone ?? "").trim();
+    if (phone) {
+      person.phone = phone;
       dirty = true;
     }
     if (dirty) {

--- a/src/server/utils/data/get-or-create-submitter-person.ts
+++ b/src/server/utils/data/get-or-create-submitter-person.ts
@@ -30,11 +30,14 @@ function splitName(
  * opportunity:
  *
  *   1. Empty/missing rac_email -> return null (no Person manufactured).
- *   2. Lookup by email (case-insensitive). If found + AgentPerson row already
- *      exists for (person, agentId), no-op.
- *   3. Found + no link -> upsert AgentPerson with VOLUNTEER_COORDINATOR role.
- *   4. Not found -> create Person from rac_*; upsert AgentPerson with same
- *      role.
+ *   2. Lookup by email (case-insensitive).
+ *        - Found     -> overwrite the rac_* fields (name/phone) from this
+ *                       submission so blank/stale records get corrected. Only
+ *                       fields the form actually provides are touched, so a
+ *                       later submission omitting one does not wipe good data.
+ *        - Not found -> create Person from rac_*.
+ *   3. Either way, upsert an AgentPerson link (VOLUNTEER_COORDINATOR) for
+ *      (person, agentId) when one does not already exist.
  *
  * `manager` defaults to the global dataSource; pass a transactional
  * EntityManager (or a migration's QueryRunner.manager) to make the writes
@@ -67,6 +70,25 @@ export async function getOrCreateSubmitterPerson(
         phone: body.rac_phone || undefined,
       }),
     );
+  } else {
+    // Refresh the rac_* fields from this submission so blank/stale records get
+    // corrected. Only overwrite a field the form actually provides — an empty
+    // rac_full_name / rac_phone must not wipe an existing good value.
+    let dirty = false;
+    const fullName = (body.rac_full_name ?? "").trim();
+    if (fullName) {
+      const { firstName, lastName } = splitName(fullName, email);
+      person.firstName = firstName;
+      person.lastName = lastName;
+      dirty = true;
+    }
+    if (body.rac_phone) {
+      person.phone = body.rac_phone;
+      dirty = true;
+    }
+    if (dirty) {
+      person = await personRepository.save(person);
+    }
   }
 
   const existingLink = await agentPersonRepository.findOne({

--- a/src/test/server/utils/data/get-or-create-submitter-person.test.ts
+++ b/src/test/server/utils/data/get-or-create-submitter-person.test.ts
@@ -145,6 +145,55 @@ describe("getOrCreateSubmitterPerson", () => {
     });
   });
 
+  it("clears a stale lastName — single-token resubmit over a multi-token name sets lastName to null", async () => {
+    personFind.mockResolvedValueOnce({
+      id: 7,
+      email: "sam@center.de",
+      firstName: "Mary",
+      lastName: "van der Berg",
+    });
+    personSave.mockImplementation(async (p: any) => p);
+    agentPersonFind.mockResolvedValueOnce({
+      id: 100,
+      agentId: 42,
+      personId: 7,
+    });
+
+    await getOrCreateSubmitterPerson(
+      { ...baseBody, rac_full_name: "Cher" },
+      42,
+      fakeManager,
+    );
+
+    expect(personSave).toHaveBeenCalledTimes(1);
+    const saved = personSave.mock.calls[0][0];
+    expect(saved).toMatchObject({ id: 7, firstName: "Cher" });
+    // null (not undefined) so TypeORM actually clears the column on update.
+    expect(saved.lastName).toBeNull();
+  });
+
+  it("ignores a whitespace-only rac_phone — does not overwrite or mark dirty", async () => {
+    personFind.mockResolvedValueOnce({
+      id: 7,
+      email: "sam@center.de",
+      firstName: "Sam",
+      phone: "+49-30-1111111",
+    });
+    agentPersonFind.mockResolvedValueOnce({
+      id: 100,
+      agentId: 42,
+      personId: 7,
+    });
+
+    await getOrCreateSubmitterPerson(
+      { ...baseBody, rac_full_name: "  ", rac_phone: "   " },
+      42,
+      fakeManager,
+    );
+
+    expect(personSave).not.toHaveBeenCalled();
+  });
+
   it("branch 4 — person not found: creates Person from rac_*, then upserts AgentPerson", async () => {
     personFind.mockResolvedValueOnce(null);
     personSave.mockImplementation(async (p: any) => ({ ...p, id: 55 }));

--- a/src/test/server/utils/data/get-or-create-submitter-person.test.ts
+++ b/src/test/server/utils/data/get-or-create-submitter-person.test.ts
@@ -47,8 +47,9 @@ describe("getOrCreateSubmitterPerson", () => {
     expect(agentPersonSave).not.toHaveBeenCalled();
   });
 
-  it("branch 2 — person found and AgentPerson link already exists: no upsert", async () => {
+  it("branch 2 — person found and AgentPerson link already exists: overwrites rac_* fields, no link upsert", async () => {
     personFind.mockResolvedValueOnce({ id: 7, email: "sam@center.de" });
+    personSave.mockImplementation(async (p: any) => p);
     agentPersonFind.mockResolvedValueOnce({
       id: 100,
       agentId: 42,
@@ -57,25 +58,90 @@ describe("getOrCreateSubmitterPerson", () => {
 
     const result = await getOrCreateSubmitterPerson(baseBody, 42, fakeManager);
 
-    expect(result).toEqual({ id: 7, email: "sam@center.de" });
-    expect(personSave).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ id: 7, email: "sam@center.de" });
+    // Existing record refreshed from this submission's rac_* fields.
+    expect(personSave).toHaveBeenCalledTimes(1);
+    expect(personSave.mock.calls[0][0]).toMatchObject({
+      id: 7,
+      firstName: "Sam",
+      lastName: "Submitter",
+      phone: "+49-30-2222222",
+    });
     expect(agentPersonSave).not.toHaveBeenCalled();
   });
 
-  it("branch 3 — person found without link: upserts AgentPerson with VOLUNTEER_COORDINATOR role", async () => {
+  it("branch 3 — person found without link: overwrites rac_* fields and upserts AgentPerson with VOLUNTEER_COORDINATOR role", async () => {
     personFind.mockResolvedValueOnce({ id: 7, email: "sam@center.de" });
+    personSave.mockImplementation(async (p: any) => p);
     agentPersonFind.mockResolvedValueOnce(null);
     agentPersonSave.mockImplementation(async (ap: any) => ({ ...ap, id: 999 }));
 
     const result = await getOrCreateSubmitterPerson(baseBody, 42, fakeManager);
 
     expect(result?.id).toBe(7);
-    expect(personSave).not.toHaveBeenCalled();
+    expect(personSave).toHaveBeenCalledTimes(1);
+    expect(personSave.mock.calls[0][0]).toMatchObject({
+      id: 7,
+      firstName: "Sam",
+      lastName: "Submitter",
+      phone: "+49-30-2222222",
+    });
     expect(agentPersonSave).toHaveBeenCalledTimes(1);
     expect(agentPersonSave.mock.calls[0][0]).toMatchObject({
       agentId: 42,
       personId: 7,
       role: AgentRoleType.VOLUNTEER_COORDINATOR,
+    });
+  });
+
+  it("branch 2 (no incoming values) — leaves an existing record untouched when rac_full_name and rac_phone are empty", async () => {
+    personFind.mockResolvedValueOnce({
+      id: 7,
+      email: "sam@center.de",
+      firstName: "Sam",
+    });
+    agentPersonFind.mockResolvedValueOnce({
+      id: 100,
+      agentId: 42,
+      personId: 7,
+    });
+
+    await getOrCreateSubmitterPerson(
+      { ...baseBody, rac_full_name: "  ", rac_phone: "" },
+      42,
+      fakeManager,
+    );
+
+    expect(personSave).not.toHaveBeenCalled();
+    expect(agentPersonSave).not.toHaveBeenCalled();
+  });
+
+  it("overwrite is selective — fills only the provided field (phone) without clobbering the name", async () => {
+    personFind.mockResolvedValueOnce({
+      id: 7,
+      email: "sam@center.de",
+      firstName: "Existing",
+      lastName: "Name",
+    });
+    personSave.mockImplementation(async (p: any) => p);
+    agentPersonFind.mockResolvedValueOnce({
+      id: 100,
+      agentId: 42,
+      personId: 7,
+    });
+
+    await getOrCreateSubmitterPerson(
+      { ...baseBody, rac_full_name: "  ", rac_phone: "+49-30-9999999" },
+      42,
+      fakeManager,
+    );
+
+    expect(personSave).toHaveBeenCalledTimes(1);
+    expect(personSave.mock.calls[0][0]).toMatchObject({
+      id: 7,
+      firstName: "Existing",
+      lastName: "Name",
+      phone: "+49-30-9999999",
     });
   });
 


### PR DESCRIPTION
## Problem

`POST /opportunity` resolves the submitter via `getOrCreateSubmitterPerson(body, agentId)`, which looks the Person up by `rac_email`. When the Person **already exists**, the helper left its fields untouched. So a record with a blank `first_name` (or missing phone) was never corrected on resubmission — and `ApiOpportunityGet.contact` surfaced an empty `name` even though the form carried a real `rac_full_name` (observed on prod opp #876, contact person id 63).

## Change

When the Person exists, overwrite the `rac_*`-backed fields from the current submission:

- `rac_full_name` → `firstName` / `lastName`
- `rac_phone` → `phone`

**Selective by design:** a field is written only when the form actually provides a value, so a later submission that omits `rac_full_name` / `rac_phone` cannot wipe an existing good value (i.e. it can't reintroduce the empty-name bug in reverse). `rac_email` remains the identity key and is not overwritten. A `dirty` flag skips the save when nothing changed.

The `AgentPerson` link upsert is unchanged and still covers both the found and created cases (an existing person submitting for a new agent still gets linked).

## Requirements covered

1. Identify person by `rac_email` — existing
2. Not found → create + link to the figured agent — existing
3. **Found → overwrite corresponding `rac_*` fields — added**

## Tests

`get-or-create-submitter-person.test.ts`: updated branches 2 & 3 to assert the refresh, added a "no incoming values → record untouched" case and a selective-overwrite (phone-only, name preserved) case. 9/9 pass; `yarn typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)