### PR TITLE
perf(volunteer): two-step list query + listType-driven relations

### DIFF
--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -9,7 +9,7 @@ import {
   VolunteerFormData,
   VolunteerPatchBodyData,
 } from "need4deed-sdk";
-import { FindOptionsWhere } from "typeorm";
+import { FindOptionsOrder, FindOptionsWhere, In } from "typeorm";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
 import DealDistrict from "../../../data/entity/m2m/deal-district";
 import DealLanguage from "../../../data/entity/m2m/deal-language";
@@ -30,7 +30,11 @@ import {
   responseSchema,
   volunteerListQuerySchema,
 } from "../../schema";
-import { QuerystringVolunteerGetList, RoutePrefix } from "../../types";
+import {
+  QuerystringVolunteerGetList,
+  RoutePrefix,
+  VolunteerListType,
+} from "../../types";
 import {
   fetchVolunteerById,
   getLanguageCode,
@@ -66,6 +70,26 @@ export default async function volunteerRoutes(
     "deal.dealTimeslot.timeslot",
     "deal.dealDistrict.district",
   ];
+
+  // Relations the list view actually serializes (volunteerListSerializer):
+  // neither person.address.postcode nor deal.postcode are used, so they are
+  // omitted. The table view renders only languages + locations; the card view
+  // additionally renders activities, skills and availability.
+  const listRelationsCommon = [
+    "person",
+    "deal",
+    "deal.dealLanguage.language",
+    "deal.dealDistrict.district",
+  ];
+  const listRelationsCardExtra = [
+    "deal.dealActivity.activity",
+    "deal.dealSkill.skill",
+    "deal.dealTimeslot.timeslot",
+  ];
+  const getListRelations = (listType: VolunteerListType) =>
+    listType === "table"
+      ? listRelationsCommon
+      : [...listRelationsCommon, ...listRelationsCardExtra];
 
   fastify.addHook(
     "onRequest",
@@ -173,21 +197,40 @@ export default async function volunteerRoutes(
         return query;
       }
 
-      const { page, limit, sortOrder, filter } = filterWorkaround(
+      const { page, limit, sortOrder, filter, listType } = filterWorkaround(
         request.query,
       );
       const [skip, take] = getSkipTake({ page, limit });
 
+      const where = getVolunteerWhere(filter) as FindOptionsWhere<Volunteer>;
+      const order: FindOptionsOrder<Volunteer> = {
+        id: sortOrder === SortOrder.OldToNew ? "ASC" : "DESC",
+      };
+
       const volunteerRepository = fastify.db.volunteerRepository;
-      const [volunteers, count] = await volunteerRepository.findAndCount({
-        where: getVolunteerWhere(filter) as FindOptionsWhere<Volunteer>,
-        relations,
+
+      // Step 1: page the volunteer ids + total count without hydrating any
+      // collection. TypeORM auto-joins only the relations the filter touches,
+      // so the COUNT no longer runs over a 5-way cartesian join.
+      const [idRows, count] = await volunteerRepository.findAndCount({
+        where,
+        select: { id: true },
         skip,
         take,
-        order: {
-          id: sortOrder === SortOrder.OldToNew ? "ASC" : "DESC",
-        },
+        order,
       });
+      const ids = idRows.map((v) => v.id);
+
+      // Step 2: load just this page's entities, fetching collections via the
+      // "query" strategy (one query per relation) to avoid a cartesian blow-up.
+      const volunteers = ids.length
+        ? await volunteerRepository.find({
+            where: { id: In(ids) },
+            relations: getListRelations(listType ?? "card"),
+            relationLoadStrategy: "query",
+            order,
+          })
+        : [];
 
       const data = volunteers.map(volunteerListSerializer).filter(Boolean);
 

--- a/src/server/schema/querystring.ts
+++ b/src/server/schema/querystring.ts
@@ -67,6 +67,10 @@ export const volunteerListQuerySchema = {
     ...paginationProps,
     ...langProp,
     ...sortOrderProps,
+    // Selects which relations the list loads: "table" loads only what the
+    // table view renders (languages + locations); "card" (default) loads all
+    // collections. Lets the table view skip activities/skills/availability.
+    listType: { type: "string", enum: ["card", "table"] },
     filter: {
       type: "object",
       properties: {

--- a/src/server/types/endpoint-handlers.ts
+++ b/src/server/types/endpoint-handlers.ts
@@ -84,8 +84,10 @@ export interface QuerystringVolunteerFiltering {
     match?: string | string[];
   };
 }
+export type VolunteerListType = "card" | "table";
+
 export type QuerystringVolunteerGetList = QuerystringPaginationLanguage &
-  QuerystringVolunteerFiltering;
+  QuerystringVolunteerFiltering & { listType?: VolunteerListType };
 
 export interface QuerystringUserList extends QuerystringPagination {
   search?: string;

--- a/src/services/dto/dto-volunteer.ts
+++ b/src/services/dto/dto-volunteer.ts
@@ -23,11 +23,16 @@ export function volunteerListSerializer(
     const name = volunteer.person.name;
     const email = volunteer.person.email;
     const avatarUrl = volunteer.person?.avatarUrl || null;
-    const languages = getLanguages(volunteer.deal.dealLanguage);
-    const availability = getAvailability(volunteer.deal.dealTimeslot);
-    const activities = getOptionItems(volunteer.deal.dealActivity, "activity");
-    const skills = getOptionItems(volunteer.deal.dealSkill, "skill");
-    const locations = getOptionItems(volunteer.deal.dealDistrict, "district");
+    // Collections may be absent when the list loads a reduced relation set
+    // (listType "table" skips activities/skills/availability) — default to []
+    // so the response shape stays stable.
+    const languages = getLanguages(volunteer.deal.dealLanguage) ?? [];
+    const availability = getAvailability(volunteer.deal.dealTimeslot) ?? [];
+    const activities =
+      getOptionItems(volunteer.deal.dealActivity, "activity") ?? [];
+    const skills = getOptionItems(volunteer.deal.dealSkill, "skill") ?? [];
+    const locations =
+      getOptionItems(volunteer.deal.dealDistrict, "district") ?? [];
 
     return {
       id,


### PR DESCRIPTION
## Problem

`GET /volunteer` took **~18-20s on every call** in production (half a day after deploy, and reproduced from a second client against the already-warm DB — so **not** a cache/snapshot-lazy-load effect; the query is genuinely expensive every time).

**Cause:** the handler loaded five one-to-many `deal_*` collections (`dealLanguage`, `dealDistrict`, `dealActivity`, `dealSkill`, `dealTimeslot`) in a single `findAndCount`. So the **COUNT ran over a 5-way cartesian join across the whole `volunteer` table** (unbounded by page size), and the page itself hydrated a cartesian product.

## Changes (backend only)

1. **Two-step pagination**
   - *Step 1* — page volunteer **ids + count** with no collection hydration. TypeORM auto-joins only the relations the `where` filter actually touches, so the COUNT is cheap and the filter joins become **dynamic** (none when unfiltered).
   - *Step 2* — load the page's entities via `relationLoadStrategy: "query"` (one query per relation, **no cartesian**).
2. **`listType` query param** (`"card" | "table"`, default `"card"`) selects the relation set, matching what each FE view renders:
   - `table` → `person` + `languages` + `locations`
   - `card` → the above + `activities` + `skills` + `availability`
   - `person.address.postcode` and `deal.postcode` dropped from the list entirely (the list serializer never used them).
3. `volunteerListSerializer` defaults absent collections to `[]` so the response shape stays stable.

## Contract / SDK

`QuerystringVolunteerGetList` is local to `be` and the response shape is unchanged (table returns `[]` for the collections it doesn't render), so **no SDK change**. The request param is added to `volunteerListQuerySchema` + the local type.

## ⚠️ Deploy ordering

`volunteerListQuerySchema` has `additionalProperties: false`, so a FE sending `listType` to an **old** backend would 400. **Merge/deploy this BEFORE the FE PR** (FleetView fe: pass `listType`). `listType` defaults to `card`, so this backend is fully backward-compatible with the current FE.

## Verification

`yarn typecheck` clean, `dto-volunteer` tests pass, lint clean on touched files. Recommend a local `EXPLAIN (ANALYZE, BUFFERS)` before/after on the count query to quantify (the count no longer joins the collections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)