### PR TITLE
fix(user): serve personId from GET /user/me

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -321,6 +321,9 @@
         "id": {
           "type": "number"
         },
+        "personId": {
+          "type": "number"
+        },
         "email": {
           "type": "string"
         },

--- a/src/services/dto/dto-user.ts
+++ b/src/services/dto/dto-user.ts
@@ -4,7 +4,9 @@ import User from "../../data/entity/user.entity";
 export function serializeUserToMeDTO(user: User): ApiUserGet {
   return {
     id: user.id,
-    personId: user.personId,
+    // personId is nullable (person-less users); emit undefined so the
+    // serializer omits it rather than coercing null to 0.
+    personId: user.personId ?? undefined,
     email: user.email,
     isActive: user.isActive,
     role: user.role,

--- a/src/services/dto/dto-user.ts
+++ b/src/services/dto/dto-user.ts
@@ -4,6 +4,7 @@ import User from "../../data/entity/user.entity";
 export function serializeUserToMeDTO(user: User): ApiUserGet {
   return {
     id: user.id,
+    personId: user.personId,
     email: user.email,
     isActive: user.isActive,
     role: user.role,

--- a/src/test/services/dto/dto-user.test.ts
+++ b/src/test/services/dto/dto-user.test.ts
@@ -5,6 +5,7 @@ describe("serializeUserToMeDTO", () => {
   it("maps all user fields from entity to API shape", () => {
     const user = {
       id: 1,
+      personId: 42,
       email: "test@example.com",
       isActive: true,
       role: "admin",
@@ -21,6 +22,7 @@ describe("serializeUserToMeDTO", () => {
 
     expect(result).toEqual({
       id: 1,
+      personId: 42,
       email: "test@example.com",
       isActive: true,
       role: "admin",

--- a/src/test/services/dto/dto-user.test.ts
+++ b/src/test/services/dto/dto-user.test.ts
@@ -37,6 +37,7 @@ describe("serializeUserToMeDTO", () => {
   it("falls back to empty strings when person fields are missing", () => {
     const user = {
       id: 2,
+      personId: null,
       email: "no-person@example.com",
       isActive: false,
       role: "coordinator",
@@ -50,6 +51,8 @@ describe("serializeUserToMeDTO", () => {
     expect(result.firstName).toBe("");
     expect(result.fullName).toBe("");
     expect(result.avatarUrl).toBe("");
+    // personId is nullable: a person-less user must not serialize to 0.
+    expect(result.personId).toBeUndefined();
   });
 
   it("falls back to default isoCode 'en' and timezone 'CET' when not set", () => {


### PR DESCRIPTION
## Problem

`ApiUserGet` (SDK contract) declares `personId`, but `GET /user/me` never returned it:
- `serializeUserToMeDTO` didn't set `personId`, and
- the `ApiUserMe` response schema (`sdk-types.json`) didn't list it, so Fastify's serializer stripped it even when present.

(The `GET /user` list shares the same DTO + schema, so it was missing `personId` too.)

## Fix

- Add `personId: user.personId` to `serializeUserToMeDTO` (`personId` is a plain column on `User`, already loaded — no extra relation/query).
- Add `"personId": { "type": "number" }` to the `ApiUserMe` response schema.

`personId` is voidable in the contract, so it's not added to `required`. **No SDK change** — the contract already declares it; the backend just wasn't honouring it.

## Tests

Updated `dto-user.test.ts` to assert `personId` maps through. `yarn typecheck` clean, 3/3 DTO tests pass, schema JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)