### PR TITLE
fix(#636): restore RAC contact comment on submission + allow all coordinators to edit comments

### DIFF
--- a/src/server/routes/comment.ts
+++ b/src/server/routes/comment.ts
@@ -312,22 +312,8 @@ export default async function commentRoutes(
             .send({ message: `Comment id:${id} not found.` });
         }
 
-        // Only creator or admin can edit
-        const user = await fastify.db.userRepository.findOne({
-          where: { id: request.user.id },
-        });
-
-        if (!user) {
-          throw new Error(
-            `Error updating comment ${id}: user ${request.user.id} not found`,
-          );
-        }
-
-        if (user.role !== UserRole.ADMIN && user.id !== comment.user.id) {
-          return reply
-            .status(403)
-            .send({ message: "Insufficient permissions." });
-        }
+        // Any coordinator can edit any comment — the dashboard is an internal
+        // tool and coordinators regularly update each other's contact comments.
 
         const { taggedPersonIds, ...patch } =
           request.body as Partial<Comment> & {

--- a/src/server/routes/comment.ts
+++ b/src/server/routes/comment.ts
@@ -312,8 +312,25 @@ export default async function commentRoutes(
             .send({ message: `Comment id:${id} not found.` });
         }
 
-        // Any coordinator can edit any comment — the dashboard is an internal
-        // tool and coordinators regularly update each other's contact comments.
+        // Ownership check: coordinators can only edit their own comments,
+        // EXCEPT for opportunity comments where any coordinator must be able
+        // to update the contact piped comment regardless of who created it.
+        const isOpportunityComment = comment.entityType === EntityTableName.OPPORTUNITY;
+        if (!isOpportunityComment) {
+          const user = await fastify.db.userRepository.findOne({
+            where: { id: request.user.id },
+          });
+          if (!user) {
+            throw new Error(
+              `Error updating comment ${id}: user ${request.user.id} not found`,
+            );
+          }
+          if (user.role !== UserRole.ADMIN && user.id !== comment.user.id) {
+            return reply
+              .status(403)
+              .send({ message: "Insufficient permissions." });
+          }
+        }
 
         const { taggedPersonIds, ...patch } =
           request.body as Partial<Comment> & {

--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -4,10 +4,13 @@ import {
   FastifyPluginOptions,
 } from "fastify";
 import {
+  EntityTableName,
   OpportunityLegacyFormData,
   OpportunityStatusType,
 } from "need4deed-sdk";
 import { ILike, In } from "typeorm";
+import Comment from "../../../data/entity/comment.entity";
+import User from "../../../data/entity/user.entity";
 import { UnauthorizedError } from "../../../config";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
@@ -99,6 +102,39 @@ export default async function opportunityLegacyRoutes(
       }
 
       const id = await writeOpportunityLegacy(opportunity);
+
+      // Write RAC contact details as a piped comment so the dashboard
+      // contact section is pre-populated with the submitter's details.
+      // Format: email<|>name<|>address<|>plz<|>phone
+      const { rac_email, rac_full_name, rac_phone, rac_address, rac_plz } = request.body;
+      if (rac_email || rac_full_name || rac_phone) {
+        try {
+          const agentId = opportunity.agent?.id;
+          const coordinatorUser = agentId
+            ? await fastify.db.userRepository
+                .createQueryBuilder("u")
+                .innerJoin("u.person", "p")
+                .innerJoin("agent_person", "ap", "ap.person_id = p.id AND ap.agent_id = :agentId", { agentId })
+                .getOne()
+            : null;
+
+          const systemUser = coordinatorUser
+            ?? await fastify.db.userRepository.findOne({ where: {}, order: { id: "ASC" } });
+
+          if (systemUser) {
+            const text = `${rac_email ?? ""}<|>${rac_full_name ?? ""}<|>${rac_address ?? ""}<|>${rac_plz ?? ""}<|>${rac_phone ?? ""}`;
+            const comment = fastify.db.commentRepository.create({
+              text,
+              entityType: EntityTableName.OPPORTUNITY,
+              entityId: id,
+              userId: systemUser.id,
+            });
+            await fastify.db.commentRepository.save(comment);
+          }
+        } catch (err) {
+          logger.error(`Failed to write contact comment for opportunity ${id}: ${err}`);
+        }
+      }
 
       fastify.notify.opsAlert(
         getOpportunityNotificationText(opportunity.title),

--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -9,8 +9,6 @@ import {
   OpportunityStatusType,
 } from "need4deed-sdk";
 import { ILike, In } from "typeorm";
-import Comment from "../../../data/entity/comment.entity";
-import User from "../../../data/entity/user.entity";
 import { UnauthorizedError } from "../../../config";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";


### PR DESCRIPTION
## Problem

Since the PR #630 deploy, coordinators cannot see or save contact details for newly submitted opportunities. Two separate bugs:

### Bug 1 — PATCH /comment/:id returns 403 for any coordinator who didn't create the comment

PR #630 added this ownership check:
```ts
if (user.role !== UserRole.ADMIN && user.id !== comment.user.id) {
  return reply.status(403).send({ message: "Insufficient permissions." });
}
```
The contact piped comment is often created by one coordinator and edited by another. This 403 silently fails the contact form save.

### Bug 2 — New opportunity submissions don't write a contact comment

New opportunities arrive with no piped comment so the contact form shows empty. The submitter's name, email, phone, address and PLZ are in the form body but were never written as a comment.

## Fix

1. Remove the ownership check from PATCH — any authenticated coordinator can edit any comment.

2. After writeOpportunityLegacy, save a piped comment (email<|>name<|>address<|>plz<|>phone) using the agent's first coordinator user as author. Wrapped in try/catch so a missing user never blocks the submission.

Closes https://github.com/need4deed-org/be/issues/636