### PR TITLE
docs: remove duplicate runtime-contract line in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,6 @@ Any changes in entities that are registered in `src/data/data-source.ts` must be
 yarn migration:generate src/data/migrations/<short-description-in-kebab=case>
 ```
 
-The runtime contract is at https://app.need4deed.org/swagger/json
-
 ---
 
 ## Handling throws in endpoint handlers


### PR DESCRIPTION
Follow-up to #639, which inadvertently introduced a second `The runtime contract is at https://app.need4deed.org/swagger/json` line (under "TypeORM entities sync to DDL"), duplicating the one in `## API contract`.

Removes the duplicate; keeps the `## Handling throws in endpoint handlers` section. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)