### PR TITLE
feat(opportunity): back up RAC contact as a piped comment on submission

### DIFF
--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -25,6 +25,7 @@ import {
   getOpportunityNotificationText,
   getOpportunityOrphanageAgent,
   getOrCreateSubmitterPerson,
+  writeOpportunityContactComment,
   writeOpportunityLegacy,
 } from "../../utils";
 
@@ -99,6 +100,15 @@ export default async function opportunityLegacyRoutes(
       }
 
       const id = await writeOpportunityLegacy(opportunity);
+
+      // Durable backup of the submitter's contact as a piped <|> comment, in
+      // addition to the Person-based contact set above. Best-effort: never
+      // blocks the submission.
+      await writeOpportunityContactComment(
+        id,
+        opportunity.agent?.id,
+        request.body,
+      );
 
       fastify.notify.opsAlert(
         getOpportunityNotificationText(opportunity.title),

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -16,5 +16,6 @@ export * from "./get-volunteer-patch-data";
 export * from "./get-volunteer-where";
 export * from "./sync-comment-tags";
 export * from "./update-leads";
+export * from "./write-opportunity-contact-comment";
 export * from "./write-opportunity-legacy";
 export * from "./write-volunteer-legacy";

--- a/src/server/utils/data/write-opportunity-contact-comment.ts
+++ b/src/server/utils/data/write-opportunity-contact-comment.ts
@@ -1,0 +1,83 @@
+import { EntityTableName, OpportunityLegacyFormData } from "need4deed-sdk";
+import { DataSource, EntityManager } from "typeorm";
+import { dataSource } from "../../../data/data-source";
+import Comment from "../../../data/entity/comment.entity";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import User from "../../../data/entity/user.entity";
+import { getRepository } from "../../../data/utils";
+import logger from "../../../logger";
+
+type ContactFields = Pick<
+  OpportunityLegacyFormData,
+  "rac_email" | "rac_full_name" | "rac_phone" | "rac_address" | "rac_plz"
+>;
+
+/**
+ * Persist the RAC contact details as a piped `<|>` comment on the opportunity —
+ * a durable backup of the submitter's contact, written *alongside* (not instead
+ * of) the Person-based contact (`submittedByPerson` -> `getOpportunityContact`
+ * -> `ApiOpportunityGet.contact`). The dashboard also reads it as a fallback for
+ * opportunities that predate the contact API.
+ *
+ * Format (matches the legacy/public-form blob): `email<|>name<|>address<|>plz<|>phone`
+ *
+ * Best-effort: swallows its own errors and no-ops when there is nothing to
+ * store, so it can never block or fail an opportunity submission.
+ */
+export async function writeOpportunityContactComment(
+  opportunityId: number,
+  agentId: number | undefined,
+  body: ContactFields,
+  manager: DataSource | EntityManager = dataSource,
+): Promise<void> {
+  const { rac_email, rac_full_name, rac_phone, rac_address, rac_plz } = body;
+  if (!rac_email && !rac_full_name && !rac_phone) {
+    return;
+  }
+
+  try {
+    const userRepository = getRepository(manager, User);
+
+    // A comment needs an author (user_id NOT NULL). Prefer a User linked to the
+    // agent; fall back to any user. The author is not shown for piped comments,
+    // so this only satisfies the constraint.
+    let author: User | null = null;
+    if (agentId) {
+      const link = await getRepository(manager, AgentPerson).findOne({
+        where: { agentId },
+      });
+      if (link) {
+        author = await userRepository.findOne({
+          where: { personId: link.personId },
+        });
+      }
+    }
+    if (!author) {
+      author = await userRepository.findOne({
+        where: {},
+        order: { id: "ASC" },
+      });
+    }
+    if (!author) {
+      logger.warn(
+        `No user available to author contact comment for opportunity ${opportunityId}`,
+      );
+      return;
+    }
+
+    const text = `${rac_email ?? ""}<|>${rac_full_name ?? ""}<|>${rac_address ?? ""}<|>${rac_plz ?? ""}<|>${rac_phone ?? ""}`;
+    const commentRepository = getRepository(manager, Comment);
+    await commentRepository.save(
+      commentRepository.create({
+        text,
+        entityType: EntityTableName.OPPORTUNITY,
+        entityId: opportunityId,
+        userId: author.id,
+      }),
+    );
+  } catch (err) {
+    logger.error(
+      `Failed to write contact backup comment for opportunity ${opportunityId}: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}

--- a/src/test/server/utils/data/write-opportunity-contact-comment.test.ts
+++ b/src/test/server/utils/data/write-opportunity-contact-comment.test.ts
@@ -1,0 +1,107 @@
+import { EntityTableName } from "need4deed-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Comment from "../../../../data/entity/comment.entity";
+import AgentPerson from "../../../../data/entity/m2m/agent-person";
+import User from "../../../../data/entity/user.entity";
+import { writeOpportunityContactComment } from "../../../../server/utils/data/write-opportunity-contact-comment";
+
+const userFindOne = vi.fn();
+const agentPersonFindOne = vi.fn();
+const commentCreate = vi.fn((c: any) => c);
+const commentSave = vi.fn();
+
+const fakeManager: any = {
+  getRepository: (entity: any) => {
+    switch (entity) {
+      case User:
+        return { findOne: userFindOne };
+      case AgentPerson:
+        return { findOne: agentPersonFindOne };
+      case Comment:
+        return { create: commentCreate, save: commentSave };
+      default:
+        throw new Error(`unexpected repo: ${entity?.name}`);
+    }
+  },
+};
+
+const body = {
+  rac_email: "sam@center.de",
+  rac_full_name: "Sam Submitter",
+  rac_phone: "+49-30-2222222",
+  rac_address: "Musterstr. 1",
+  rac_plz: "12345",
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("writeOpportunityContactComment", () => {
+  it("writes a piped comment authored by the agent's linked user", async () => {
+    agentPersonFindOne.mockResolvedValueOnce({
+      id: 5,
+      agentId: 42,
+      personId: 9,
+    });
+    userFindOne.mockResolvedValueOnce({ id: 7, personId: 9 }); // by personId
+
+    await writeOpportunityContactComment(876, 42, body, fakeManager);
+
+    expect(commentSave).toHaveBeenCalledTimes(1);
+    expect(commentCreate.mock.calls[0][0]).toEqual({
+      text: "sam@center.de<|>Sam Submitter<|>Musterstr. 1<|>12345<|>+49-30-2222222",
+      entityType: EntityTableName.OPPORTUNITY,
+      entityId: 876,
+      userId: 7,
+    });
+  });
+
+  it("falls back to the first user when the agent has no linked user", async () => {
+    agentPersonFindOne.mockResolvedValueOnce(null);
+    userFindOne.mockResolvedValueOnce({ id: 1 }); // fallback first user
+
+    await writeOpportunityContactComment(876, 42, body, fakeManager);
+
+    expect(userFindOne).toHaveBeenLastCalledWith({
+      where: {},
+      order: { id: "ASC" },
+    });
+    expect(commentCreate.mock.calls[0][0]).toMatchObject({
+      userId: 1,
+      entityId: 876,
+    });
+  });
+
+  it("no-ops when no contact fields are present (no author lookup, no write)", async () => {
+    await writeOpportunityContactComment(
+      876,
+      42,
+      { ...body, rac_email: "", rac_full_name: "", rac_phone: "" },
+      fakeManager,
+    );
+
+    expect(agentPersonFindOne).not.toHaveBeenCalled();
+    expect(userFindOne).not.toHaveBeenCalled();
+    expect(commentSave).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when no user exists to author the comment", async () => {
+    agentPersonFindOne.mockResolvedValueOnce(null);
+    userFindOne.mockResolvedValueOnce(null);
+
+    await writeOpportunityContactComment(876, 42, body, fakeManager);
+
+    expect(commentSave).not.toHaveBeenCalled();
+  });
+
+  it("never throws — a save failure is swallowed", async () => {
+    agentPersonFindOne.mockResolvedValueOnce(null);
+    userFindOne.mockResolvedValueOnce({ id: 1 });
+    commentSave.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(
+      writeOpportunityContactComment(876, 42, body, fakeManager),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

On `POST /opportunity` (public form), persist the submitter's RAC contact as a piped `<|>` comment — **in addition to** the existing Person-based flow, not instead of it.

- `getOrCreateSubmitterPerson` → `submittedByPerson` → `getOpportunityContact` → `ApiOpportunityGet.contact` stays the primary source (unchanged).
- New `writeOpportunityContactComment` also stores `email<|>name<|>address<|>plz<|>phone` as a durable backup, so submitted contact data can't be lost if something goes wrong with the Person path — and it's the fallback the dashboard already reads for opportunities without `.contact`.

## Why

Belt-and-suspenders for contact data (re: #636). The current FE reads `.contact` primarily and piped comments only as a legacy fallback, so this is a safety net, not the display path.

## Design

- **Additive** — the submitter-setting workflow is untouched.
- **Best-effort** — `writeOpportunityContactComment` swallows its own errors and no-ops when no contact fields are present, so it can never block or fail a submission.
- Author: a User linked to the agent if found, else any user (author isn't shown for piped comments; just satisfies `comment.user_id` NOT NULL).

## Tests

New `write-opportunity-contact-comment.test.ts`: piped format + agent-linked author, fallback author, no-op when empty, no-op when no user, and the swallow-on-failure guarantee. 5/5 pass; typecheck + lint clean.

## Relationship to #637
This reimplements #637's useful half (the submission-time contact write) cleanly, without #637's `volunteer.routes.ts` change (which conflicts with the merged #634 two-step) and without the comment-PATCH ownership relaxation (moot — the FE edits contact via `PATCH /opportunity/:id`, not the comment). **#637 can be closed in favour of this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)