### PR TITLE
chore(sdk): upgrade to 0.0.99; add communication to GET /opportunity/:id/volunteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.98",
+    "need4deed-sdk": "0.0.99",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -533,6 +533,7 @@
             "name": { "type": "string" },
             "volunteeringType": { "$ref": "VolunteerStateTypeType#" },
             "engagement": { "$ref": "VolunteerStateEngagementType#" },
+            "communication": { "$ref": "VolunteerStateCommunicationType#" },
             "avatarUrl": { "type": "string" },
             "activities": {
               "type": "array",
@@ -563,6 +564,7 @@
         "name",
         "volunteeringType",
         "engagement",
+        "communication",
         "avatarUrl"
       ]
     },

--- a/src/services/dto/dto-opportunity-volunteer.ts
+++ b/src/services/dto/dto-opportunity-volunteer.ts
@@ -38,6 +38,7 @@ export function opportunityOpportunityVolunteerDTO(
     avatarUrl: opportunityVolunteer.volunteer.person.avatarUrl,
     volunteeringType: opportunityVolunteer.volunteer.statusType,
     engagement: opportunityVolunteer.volunteer.statusEngagement,
+    communication: opportunityVolunteer.volunteer.statusCommunication,
     activities: getOptionItems(
       opportunityVolunteer.volunteer.deal.dealActivity,
       "activity",

--- a/src/test/services/dto/dto-opportunity-volunteer.test.ts
+++ b/src/test/services/dto/dto-opportunity-volunteer.test.ts
@@ -27,6 +27,7 @@ function makeOV(
     volunteer: {
       statusType: "regular",
       statusEngagement: "active",
+      statusCommunication: "called",
       person: { name: "Jane Doe", avatarUrl: "https://cdn.example.com/a.png" },
       deal: {
         dealActivity: [],
@@ -73,6 +74,7 @@ describe("opportunityOpportunityVolunteerDTO", () => {
     expect(result.avatarUrl).toBe("https://cdn.example.com/a.png");
     expect(result.volunteeringType).toBe("regular");
     expect(result.engagement).toBe("active");
+    expect(result.communication).toBe("called");
     expect(result.activities).toBeDefined();
     expect(result.languages).toBeDefined();
     expect(result.availability).toBeDefined();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.98:
-  version "0.0.98"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.98.tgz#e2d7fcf58b1506b5d6814c0b580af18f079678ef"
-  integrity sha512-f0RT21+TcFNSSEKuoXmIBkIt7R0Fj7PprQBDy6c7W7CUhNTf1W4FNMNz8qxfTCjxOh3RBIplsHx4+tS84HRO0w==
+need4deed-sdk@0.0.99:
+  version "0.0.99"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.99.tgz#dfef959872d390ae187e07ce3c4b9d7a3b1bdf29"
+  integrity sha512-OUnQs+cL2ROLuj+NSpUFMJWKXv9XYPWgqQ/3MPaXSv4lUiCuAm6NDnMdXHDZtZLakPAlykvRzm17xssn1VjuZA==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## What

- Upgrade `need4deed-sdk` 0.0.98 → **0.0.99**.
- 0.0.99's `ApiVolunteerOpportunityGet` adds a **`communication: VolunteerStateCommunicationType`** field (the only contract change affecting us — full-project `typecheck` stays green otherwise).
- Sync `GET /opportunity/{id}/volunteer`:
  - **DTO** `opportunityOpportunityVolunteerDTO` → map `communication` from `volunteer.statusCommunication`.
  - **Response schema** `ApiOpportunityVolunteerGet` → add `"communication": { "$ref": "VolunteerStateCommunicationType#" }` (schema already registered) and add it to `required`, matching the non-optional, non-null entity field.

## Tests

`dto-opportunity-volunteer.test.ts` updated to provide `statusCommunication` and assert it maps to `communication`. 4/4 pass; `typecheck` + lint clean; schema JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)