### PR TITLE
feat(notify): configurable verification email from CDN manifest (#645)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 # verified sender/domain in Brevo.
 EMAIL_FROM=no-reply@need4deed.org
 BREVO_API_KEY=fake-string
+# Verification email content is read from a per-locale CDN manifest
+# (${AWS_S3_BASE}emails/verification.json), cached in-memory; falls back to
+# built-in copy. Optional tuning:
+EMAIL_TEMPLATE_TTL_MS=600000
+EMAIL_TEMPLATE_FETCH_TIMEOUT_MS=5000
 
 CORS_ORIGINS=http://localhost:3000,http://localhost:3100,http://localhost:3200
 CORS_CREDENTIALS=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ Copy `.env.example` to `.env` and fill in real values. Key variables:
 - `NODE_ENV` — `development` | `test` | `production`
 - `RUN_MIGRATIONS` — when truthy, auto-run pending migrations on server startup (always on in prod regardless of this flag); see Commands section
 - `EMAIL_FROM`, `BREVO_API_KEY` — transactional email via Brevo (verified sender + API key)
+- `EMAIL_TEMPLATE_TTL_MS`, `EMAIL_TEMPLATE_FETCH_TIMEOUT_MS` — optional; cache TTL + fetch timeout for the verification-email CDN manifest (`${AWS_S3_BASE}emails/verification.json`); falls back to built-in copy
 - `CORS_ORIGINS` — comma-separated list of allowed origins
 
 ---

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -82,6 +82,16 @@ export const urlEmailVerification =
   process.env.URL_EMAIL_VERIFICATION ||
   "https://app.need4deed.org/verify-email";
 
+// CDN manifest (per-locale subject + html/text) for the verification email.
+export const emailVerificationManifestUrl =
+  awsS3BaseUrl + "emails/verification.json";
+// How long a fetched email manifest is cached in-memory (default 10 min).
+export const emailTemplateTtlMs =
+  Number(process.env.EMAIL_TEMPLATE_TTL_MS) || 10 * 60 * 1000;
+// Timeout for fetching the email manifest from the CDN (default 5s).
+export const emailTemplateFetchTimeoutMs =
+  Number(process.env.EMAIL_TEMPLATE_FETCH_TIMEOUT_MS) || 5000;
+
 export const REFRESH_LIFESPAN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
 export const ACCESS_LIFESPAN_MS = 15 * 60 * 1000; // 15 minutes in milliseconds
 export const VERIFY_LIFESPAN_MS = 24 * 60 * 60 * 1000; // 24h in milliseconds

--- a/src/services/notify/events/email-verification.ts
+++ b/src/services/notify/events/email-verification.ts
@@ -1,12 +1,109 @@
 import type { JWT, TokenType } from "@fastify/jwt";
-import { urlEmailVerification } from "../../../config/constants";
+import { Lang } from "need4deed-sdk";
+import {
+  emailTemplateFetchTimeoutMs,
+  emailTemplateTtlMs,
+  emailVerificationManifestUrl,
+  urlEmailVerification,
+} from "../../../config/constants";
 import type User from "../../../data/entity/user.entity";
+import { fetchJsonFromUrl } from "../../../data/utils";
 import logger from "../../../logger";
-import type { EmailTransport } from "../types";
+import type { EmailMessage, EmailTransport } from "../types";
 
 export interface EmailVerificationDeps {
   email: EmailTransport;
   jwt: JWT;
+}
+
+interface LocaleContent {
+  subject: string;
+  html?: string;
+  text?: string;
+}
+type VerificationManifest = Partial<Record<Lang, LocaleContent>>;
+
+const URL_PLACEHOLDER = "{{verificationUrl}}";
+const DEFAULT_LOCALE = Lang.EN;
+
+// Built-in fallback used when the CDN manifest is missing/invalid, so a
+// verification email always sends (and in the user's language where possible).
+const BUILTIN: Record<Lang, LocaleContent> = {
+  [Lang.EN]: {
+    subject: "Account Created",
+    text: `Your account has been created successfully. Please verify your email:\n${URL_PLACEHOLDER}`,
+    html: `<p>Your account has been created successfully. Please verify your email:</p><p><a href="${URL_PLACEHOLDER}">${URL_PLACEHOLDER}</a></p>`,
+  },
+  [Lang.DE]: {
+    subject: "Konto erstellt",
+    text: `Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail:\n${URL_PLACEHOLDER}`,
+    html: `<p>Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail:</p><p><a href="${URL_PLACEHOLDER}">${URL_PLACEHOLDER}</a></p>`,
+  },
+};
+
+let manifestCache: { value: VerificationManifest; expires: number } | null =
+  null;
+
+/** Test-only: drop the cached manifest so each test fetches fresh. */
+export function resetVerificationTemplateCache(): void {
+  manifestCache = null;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+/**
+ * Load the email manifest from the CDN, cached in-memory for emailTemplateTtlMs.
+ * On any failure, serve the last good value if we have one, else null (→ the
+ * caller falls back to BUILTIN). Never throws.
+ */
+async function loadManifest(): Promise<VerificationManifest | null> {
+  const now = Date.now();
+  if (manifestCache && now < manifestCache.expires) {
+    return manifestCache.value;
+  }
+  try {
+    const value = (await withTimeout(
+      fetchJsonFromUrl(emailVerificationManifestUrl),
+      emailTemplateFetchTimeoutMs,
+    )) as VerificationManifest;
+    manifestCache = { value, expires: now + emailTemplateTtlMs };
+    return value;
+  } catch (err) {
+    logger.warn(
+      `email verification manifest fetch failed: ${err instanceof Error ? err.message : err}`,
+    );
+    return manifestCache?.value ?? null; // last-good (stale) or built-in
+  }
+}
+
+function resolveLocale(language: string | undefined): Lang {
+  return language === Lang.DE
+    ? Lang.DE
+    : language === Lang.EN
+      ? Lang.EN
+      : DEFAULT_LOCALE;
+}
+
+function isValid(content: LocaleContent | undefined): content is LocaleContent {
+  return Boolean(content?.subject && (content.html || content.text));
+}
+
+function resolveContent(
+  manifest: VerificationManifest | null,
+  locale: Lang,
+): LocaleContent {
+  const candidates = [manifest?.[locale], manifest?.[DEFAULT_LOCALE]];
+  return candidates.find(isValid) ?? BUILTIN[locale] ?? BUILTIN[DEFAULT_LOCALE];
 }
 
 export async function sendEmailVerification(
@@ -23,15 +120,21 @@ export async function sendEmailVerification(
     type: "verify" as TokenType,
   });
   const url = `${urlEmailVerification}/${token}`;
-  const copy =
-    "Your account has been created successfully. Please verify your email:";
 
   logger.debug(`sendEmailVerification: ${user.email}`);
 
-  await email.send({
+  const content = resolveContent(
+    await loadManifest(),
+    resolveLocale(user.language),
+  );
+  const fill = (s?: string) => s?.split(URL_PLACEHOLDER).join(url);
+
+  const message: EmailMessage = {
     to: user.email,
-    subject: "Account Created",
-    text: `${copy}\n${url}`,
-    html: `<p>${copy}</p><p><a href="${url}">${url}</a></p>`,
-  });
+    subject: content.subject,
+    ...(content.text ? { text: fill(content.text) } : {}),
+    ...(content.html ? { html: fill(content.html) } : {}),
+  };
+
+  await email.send(message);
 }

--- a/src/test/services/notify/email-verification.test.ts
+++ b/src/test/services/notify/email-verification.test.ts
@@ -1,0 +1,93 @@
+import { Lang } from "need4deed-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { urlEmailVerification } from "../../../config/constants";
+import { fetchJsonFromUrl } from "../../../data/utils";
+import {
+  resetVerificationTemplateCache,
+  sendEmailVerification,
+} from "../../../services/notify/events/email-verification";
+
+vi.mock("../../../data/utils", () => ({
+  fetchJsonFromUrl: vi.fn(),
+}));
+
+const send = vi.fn();
+const deps = { email: { send }, jwt: { sign: () => "tok" } } as any;
+const user = (over: any = {}) => ({ id: 1, email: "u@x.de", ...over });
+const expectedUrl = `${urlEmailVerification}/tok`;
+
+const manifest = {
+  en: {
+    subject: "Verify your account",
+    html: '<a href="{{verificationUrl}}">{{verificationUrl}}</a>',
+    text: "verify: {{verificationUrl}}",
+  },
+  de: {
+    subject: "Konto bestätigen",
+    html: '<a href="{{verificationUrl}}">{{verificationUrl}}</a>',
+    text: "bestätige: {{verificationUrl}}",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetVerificationTemplateCache();
+});
+
+describe("sendEmailVerification", () => {
+  it("uses the manifest entry for the user's locale and substitutes the URL", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendEmailVerification(deps, user({ language: Lang.DE }));
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.subject).toBe("Konto bestätigen");
+    expect(msg.text).toBe(`bestätige: ${expectedUrl}`);
+    expect(msg.html).toBe(`<a href="${expectedUrl}">${expectedUrl}</a>`);
+    expect(msg.html).not.toContain("{{verificationUrl}}");
+  });
+
+  it("falls back to the default locale (en) for an unsupported language", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendEmailVerification(deps, user({ language: "fr" }));
+
+    expect(send.mock.calls[0][0].subject).toBe("Verify your account");
+  });
+
+  it("caches the manifest within TTL (single fetch across two sends)", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendEmailVerification(deps, user({ language: Lang.EN }));
+    await sendEmailVerification(deps, user({ language: Lang.DE }));
+
+    expect(fetchJsonFromUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to built-in content when the manifest fetch fails, and still sends", async () => {
+    vi.mocked(fetchJsonFromUrl).mockRejectedValue(new Error("CDN down"));
+
+    await sendEmailVerification(deps, user({ language: Lang.DE }));
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.subject).toBe("Konto erstellt"); // built-in de
+    expect(msg.text).toContain(expectedUrl);
+    expect(msg.text).not.toContain("{{verificationUrl}}");
+  });
+
+  it("falls back to built-in when the manifest entry is invalid (missing body)", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue({
+      en: { subject: "no body here" },
+    });
+
+    await sendEmailVerification(deps, user({ language: Lang.EN }));
+
+    expect(send.mock.calls[0][0].subject).toBe("Account Created"); // built-in en
+  });
+
+  it("throws when the user has no email", async () => {
+    await expect(
+      sendEmailVerification(deps, user({ email: undefined })),
+    ).rejects.toThrow("User email is required");
+  });
+});


### PR DESCRIPTION
Closes #645.

## What

`sendEmailVerification` now sources the subject + html/text from a **per-locale CDN manifest** instead of hardcoded copy, so content changes don't need a deploy.

- **Manifest:** `${AWS_S3_BASE}emails/verification.json`, keyed by locale (`en`/`de`):
  ```json
  { "en": { "subject": "...", "html": "...{{verificationUrl}}...", "text": "...{{verificationUrl}}" },
    "de": { ... } }
  ```
- **Placeholder:** `{{verificationUrl}}` is replaced with the signed verify link.
- **Locale:** chosen from `user.language` (`en`/`de`), defaulting to `en`.
- **Cache:** manifest cached in-memory with a TTL (`EMAIL_TEMPLATE_TTL_MS`, default 10 min) — no CDN round-trip per signup. Reuses `fetchJsonFromUrl`.
- **Fallback chain:** `manifest[userLocale]` → `manifest[en]` → **built-in** content (provided for both en + de). Any failure (non-200 / invalid JSON / missing fields / timeout, via `EMAIL_TEMPLATE_FETCH_TIMEOUT_MS`, default 5s) → built-in. The email always sends; loading never throws.

## Config / docs

New optional env `EMAIL_TEMPLATE_TTL_MS` + `EMAIL_TEMPLATE_FETCH_TIMEOUT_MS`, documented in `.env.example` and `CLAUDE.md`. Manifest URL derived from existing `AWS_S3_BASE`.

## Tests

`email-verification.test.ts` (new): locale selection (de), default-locale fallback (unsupported lang), cache hit (single fetch across two sends), fetch-failure → built-in, invalid-entry → built-in, and the no-email guard. 6/6 pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)