### PR TITLE
fix(user): default language to "en" when omitted on POST /user

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.101",
+    "need4deed-sdk": "0.0.102",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -1,6 +1,12 @@
 import { validate } from "class-validator";
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiUserGet, ApiUserPost, SortOrder, UserRole } from "need4deed-sdk";
+import {
+  ApiUserGet,
+  ApiUserPost,
+  Lang,
+  SortOrder,
+  UserRole,
+} from "need4deed-sdk";
 import { FindOptionsWhere, ILike } from "typeorm";
 import {
   BadRequestError,
@@ -329,7 +335,7 @@ export default async function userRoutes(
         password: await hashPassword(passwordPlain),
         role,
         isActive: false,
-        language,
+        language: language ?? Lang.EN,
         person: request.resolvedPerson,
       });
 

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -1,16 +1,18 @@
 import { existingPersonSchema, newPersonSchema } from "./person.schema";
 
 // Matches the SDK ApiUserPost contract: email, password, role (UserRole),
-// language (Lang), person. (isActive is server-controlled; timezone uses the
-// entity default.)
+// optional language (Lang, defaults to "en"), person. (isActive is
+// server-controlled; timezone uses the entity default.)
 export const createUserBodySchema = {
   type: "object",
-  required: ["email", "password", "role", "language", "person"],
+  required: ["email", "password", "role", "person"],
   properties: {
     email: { type: "string", format: "email" },
     password: { type: "string", minLength: 8, maxLength: 50 },
     role: { $ref: "UserRole#" },
-    language: { $ref: "Lang#" },
+    // Optional: defaults to "en" when omitted (allOf keeps the Lang enum while
+    // allowing a sibling default, which a bare $ref would ignore in draft-07).
+    language: { allOf: [{ $ref: "Lang#" }], default: "en" },
     person: {
       oneOf: [
         // The 'person' property must match one of these schemas

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.101:
-  version "0.0.101"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.101.tgz#3c435de4fc6580b2c1a307c8ce70f4e5e9a242f1"
-  integrity sha512-Xu0XIe9UYs0zVHOd7oqTryC6ybb69YxpwfcV2GEG7T99X9VtwEl6B3JEbwYiJw/KLprkKRTdBEU1jWmXtYG0qw==
+need4deed-sdk@0.0.102:
+  version "0.0.102"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.102.tgz#6e5de50c2e9a5d00854b0e351db095a1b3dea677"
+  integrity sha512-VpyTphC5usDVbmRTuq9I9LqeXtl4mIoI4jwmWFxSfD5Dym6h1Lsd48LkoXKFwH5gwmcEM8MPAfC/tllMyK4d3Q==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
SDK **0.0.102** makes `ApiUserPost.language` optional, so registration must default a missing `language` to `"en"`.

- **SDK** bumped 0.0.101 → 0.0.102.
- **Schema** (`createUserBodySchema`): `language` dropped from `required`; now `language: { allOf: [{ $ref: "Lang#" }], default: "en" }` — `allOf` keeps the `Lang` enum (en/de) while allowing the sibling `default`, which a bare `$ref` would ignore under draft-07.
- **Handler**: `language: language ?? Lang.EN` as a backstop (and the `User` entity column also defaults to `"en"`), so an omitted language always lands on `"en"`.

`yarn typecheck` + lint clean (one pre-existing `any` warning); the server-boot test passes (validates the `allOf`/`$ref` schema registers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)