### PR TITLE
fix(user): default timezone to "CET" on registration

### DIFF
--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -336,6 +336,10 @@ export default async function userRoutes(
         role,
         isActive: false,
         language: language ?? Lang.EN,
+        // Server-controlled (not in ApiUserPost). Set explicitly to the entity
+        // default so class-validator's @IsString passes (the DB default only
+        // applies at INSERT, not to the in-memory entity being validated).
+        timezone: "CET",
         person: request.resolvedPerson,
       });
 


### PR DESCRIPTION
## Bug

`POST /user` failed with `timezone must be a string` (class-validator `@IsString()`). The `ApiUserPost` refactor (#647) dropped `timezone` from the body/handler, but the `User` entity validates `timezone` as a required string — and `validate(newUser)` runs on the in-memory object **before** save, where the `@Column({ default: "CET" })` DB default hasn't applied yet.

## Fix

Set `timezone: "CET"` explicitly when constructing the user (server-controlled, mirrors the entity default). One line.

`yarn typecheck` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)