### PR TITLE
Fix: ApiLanguage.proficiency optional (unblocks agent languages)

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -288,7 +288,7 @@
         },
         "additionalProperties": false
       },
-      "required": ["title", "proficiency"]
+      "required": ["title"]
     },
     "ApiAvailability": {
       "$id": "ApiAvailability",


### PR DESCRIPTION
## Problem
After agent self-registration (#601) started writing `agent_language` rows, `GET /agent/:id` 500s during serialization:
```
ERROR: "proficiency" is required!  (fast-json-stringify, GET /agent/:id)
```
`agent_language` has no proficiency (it's a center's *supported* languages, not a person's skill level), so the serialized `ApiAgentGet.languages[]` items have no `proficiency` — but the registered `ApiLanguage` schema marked it `required`.

## Fix
Drop `proficiency` from `ApiLanguage`'s `required` in `sdk-types.json`. The SDK type already declares `proficiency?` optional, so this just aligns the serialization schema. Volunteer responses (which *do* carry proficiency) are unaffected — optional still serializes when present.

## Validation
Live: create an agent with `languages:[1,2]` via `POST /agent/register`, then `GET /agent/:id` → **200** with `languages: [{title}, …]` (was 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)