### PR TITLE
fix(#659): always enforce number consistency in fuzzy agent match

### DIFF
--- a/src/server/utils/data/get-agent-by-postcode.ts
+++ b/src/server/utils/data/get-agent-by-postcode.ts
@@ -48,31 +48,24 @@ export function getAgentByAddress(
 
   // 2. Fuzzy fallback for legacy agents: street name (no number) found as a
   //    whole word in agent title + PLZ from either address.postcode or agentPostcode.
+  //    Number consistency: if the agent title contains a number it must match the
+  //    form's number — prevents "Heerstr 10" matching form input "Heerstr 110".
+  //    Agents with no number in title (e.g. "Refugium Hausvaterweg") match on
+  //    street name alone.
   const streetName = extractStreetName(street);
   if (!streetName) return undefined;
   const streetRegex = streetNameWordRegex(streetName);
-  const fuzzyMatches = agents.filter(
-    (a) =>
-      agentHasPlz(a, plz) &&
-      streetRegex.test(normalizeStreet(a.title ?? "")),
-  );
+  const houseNumber = extractHouseNumber(street);
 
-  if (fuzzyMatches.length === 1) return fuzzyMatches[0];
+  const fuzzyMatches = agents.filter((a) => {
+    if (!agentHasPlz(a, plz)) return false;
+    if (!streetRegex.test(normalizeStreet(a.title ?? ""))) return false;
+    const titleNumber = extractHouseNumber(a.title ?? "");
+    if (titleNumber && houseNumber && titleNumber !== houseNumber) return false;
+    return true;
+  });
 
-  // Multiple agents on the same street — narrow by house number in title
-  // (~70% of agents include the number in their title, e.g. "Refugium Staukowerstrase 5")
-  if (fuzzyMatches.length > 1) {
-    const houseNumber = extractHouseNumber(street);
-    if (houseNumber) {
-      const numberRegex = streetNameWordRegex(houseNumber);
-      const byNumber = fuzzyMatches.filter((a) =>
-        numberRegex.test(normalizeStreet(a.title ?? "")),
-      );
-      if (byNumber.length === 1) return byNumber[0];
-    }
-  }
-
-  return undefined;
+  return fuzzyMatches.length === 1 ? fuzzyMatches[0] : undefined;
 }
 
 export function getAgentByPostcode(

--- a/src/test/server/utils/data/get-agent-by-postcode.test.ts
+++ b/src/test/server/utils/data/get-agent-by-postcode.test.ts
@@ -102,6 +102,32 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
     expect(getAgentByAddress([legacyAgent, second], "Hausvaterweg 21", plz)).toBeUndefined();
   });
 
+  it("does not match 'Heerstr 10' when form submits 'Heerstr 110' (number prefix false positive)", () => {
+    const heerstr10 = {
+      id: 6,
+      title: "Heerstr 10",
+      address: null,
+      agentPostcode: [{ postcode: { value: "13353" } }],
+    } as any;
+    expect(getAgentByAddress([heerstr10], "Heerstr 110", "13353")).toBeUndefined();
+  });
+
+  it("matches 'Heerstr 110' agent when form submits 'Heerstr 110'", () => {
+    const heerstr10 = {
+      id: 6,
+      title: "Heerstr 10",
+      address: null,
+      agentPostcode: [{ postcode: { value: "13353" } }],
+    } as any;
+    const heerstr110 = {
+      id: 7,
+      title: "Heerstr 110",
+      address: null,
+      agentPostcode: [{ postcode: { value: "13353" } }],
+    } as any;
+    expect(getAgentByAddress([heerstr10, heerstr110], "Heerstr 110", "13353")).toEqual(heerstr110);
+  });
+
   it("does not false-match when street name is a substring of a different street in title", () => {
     const agent = {
       id: 4,


### PR DESCRIPTION
## Summary

- Number consistency check now runs regardless of how many fuzzy candidates exist
- Prevents "Heerstr 10" from matching form input "Heerstr 110"
- Agents with no number in title (e.g. "Refugium Hausvaterweg") still match on street name alone
- Also simplifies the multi-match logic into a single filter pass

Closes https://github.com/need4deed-org/be/issues/659

## Test plan

- [ ] Submit form with `rac_address = "Heerstr 110"` — should not match existing "Heerstr 10" agent, should create new one
- [ ] Submit form with `rac_address = "Hausvaterweg 21"` — should still match "Refugium Hausvaterweg" (no number in title)
- [ ] `yarn test -- src/test/server/utils/data/get-agent-by-postcode.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)