### PR TITLE
show PLZ in agent organisation details for legacy agents

### DIFF
--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -131,6 +131,7 @@ export default async function agentRoutes(
       const agentRepository = fastify.db.agentRepository;
       const relations = [
         "address.postcode",
+        "agentPostcode.postcode",
         "district",
         "opportunity.opportunityVolunteer",
         "organization.address.postcode",

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -81,9 +81,14 @@ export function dtoOpportunityAgent(agent: Agent): ApiOpportunityAgent {
 }
 
 function dtoAgentDetails(agent: Agent): AgentDetails {
+  let address = serializeAddress(agent.address);
+  if (!agent.address && agent.agentPostcode?.length) {
+    const plz = agent.agentPostcode[0].postcode?.value;
+    if (plz) address = `${plz} Berlin`;
+  }
   return {
     about: agent.info,
-    address: serializeAddress(agent.address),
+    address,
     website: agent.website,
     organizationType: agent.type,
     operator: agent?.organization?.title,


### PR DESCRIPTION
## Summary
- Adds `agentPostcode.postcode` to the relations loaded in `GET /agents/:id`
- When `agent.address` is null (legacy agents with no address entity), falls back to the first `agentPostcode` PLZ to produce e.g. `"14055 Berlin"` instead of `"Berlin"`
- Agents with a proper `address` entity continue to show the full `"Street, PLZ Berlin"` string via `serializeAddress` — no change for those

## Why
Legacy agents were created without an `Address` entity; their PLZ lives in `agentPostcode`. The org-details section was showing just "Berlin" for all such agents even when a postcode was available.

Resolves https://github.com/need4deed-org/fe/issues/627

## Test plan
- [ ] Load an agent with `address = null` and `agentPostcode` entries → `agentDetails.address` should be `"14055 Berlin"` (or whichever PLZ)
- [ ] Load an agent with a proper `address.street` + `address.postcode` → address unchanged, still `"Heerstr. 110, 14055 Berlin"`
- [ ] Load an agent with neither address nor agentPostcode → still returns `"Berlin"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)