### PR TITLE
Mask PII on GET /opportunity, /volunteer, /agent by role

### DIFF
--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -56,6 +56,11 @@ async function jwtPlugin(
           throw new Error("User not found.");
         }
 
+        // Expose the already-loaded user (carries personId + DB-authoritative
+        // role) for downstream hooks (PII masking, self-auth) — avoids a second
+        // lookup and a JWT claim.
+        request.authUser = user;
+
         if (user.role === UserRole.ADMIN) {
           logger.debug(
             `Admin user ${userId} authenticated, bypassing further checks.`,

--- a/src/server/routes/agent/agent-communication.routes.ts
+++ b/src/server/routes/agent/agent-communication.routes.ts
@@ -1,8 +1,13 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiCommunicationGet, ApiCommunicationPost } from "need4deed-sdk";
+import {
+  ApiCommunicationGet,
+  ApiCommunicationPost,
+  UserRole,
+} from "need4deed-sdk";
 import { dtoCommunication } from "../../../services";
 import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyDataCount } from "../../types";
+import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 
 export default function agentCommunicationRoutes(
   fastify: FastifyInstance,
@@ -18,6 +23,7 @@ export default function agentCommunicationRoutes(
         params: idParamSchema,
         response: responseSchema("ApiCommunicationGet#", true),
       },
+      preSerialization: makePiiSerialization(dtoCommunication),
     },
     async (request, reply) => {
       const { id } = request.params;
@@ -28,11 +34,10 @@ export default function agentCommunicationRoutes(
           where: { agentId: id },
         });
 
-      const data = communications.map(dtoCommunication);
-
+      // DTO runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Agent (id:${id}) communications fetched successfully`,
-        data,
+        data: communications as unknown as ApiCommunicationGet[],
         count,
       });
     },
@@ -41,6 +46,7 @@ export default function agentCommunicationRoutes(
   fastify.post<{ Params: ParamsId; Body: ApiCommunicationPost }>(
     "/",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiCommunicationPost#" },

--- a/src/server/routes/agent/agent-communication.routes.ts
+++ b/src/server/routes/agent/agent-communication.routes.ts
@@ -1,9 +1,6 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import {
-  ApiCommunicationGet,
-  ApiCommunicationPost,
-  UserRole,
-} from "need4deed-sdk";
+import { ApiCommunicationPost, UserRole } from "need4deed-sdk";
+import Communication from "../../../data/entity/communication.entity";
 import { dtoCommunication } from "../../../services";
 import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyDataCount } from "../../types";
@@ -15,7 +12,9 @@ export default function agentCommunicationRoutes(
 ) {
   fastify.get<{
     Params: ParamsId;
-    Reply: ReplyDataCount<ApiCommunicationGet[]>;
+    // Handler sends entities; the DTO (ApiCommunicationGet) runs in the
+    // preSerialization hook.
+    Reply: ReplyDataCount<Communication[]>;
   }>(
     `/`,
     {
@@ -37,7 +36,7 @@ export default function agentCommunicationRoutes(
       // DTO runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Agent (id:${id}) communications fetched successfully`,
-        data: communications as unknown as ApiCommunicationGet[],
+        data: communications,
         count,
       });
     },

--- a/src/server/routes/agent/agent-opportunity.routes.ts
+++ b/src/server/routes/agent/agent-opportunity.routes.ts
@@ -3,6 +3,7 @@ import { NotFoundError } from "../../../config";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import { idParamSchema } from "../../schema";
 import { ParamsId, ReplyData } from "../../types";
+import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 
 export default async function agentOpportunityRoutes(
   fastify: FastifyInstance,
@@ -15,6 +16,9 @@ export default async function agentOpportunityRoutes(
         params: idParamSchema,
         // TODO: add response schema!
       },
+      // No DTO yet (sends raw entities) — masking still applies to nested
+      // volunteer persons; identity passthrough keeps the shape.
+      preSerialization: makePiiSerialization((o: Opportunity) => o),
     },
     async (request, reply) => {
       const { id } = request.params;

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -1,11 +1,5 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import {
-  ApiAgentGet,
-  ApiAgentGetList,
-  ApiAgentPatch,
-  SortOrder,
-  UserRole,
-} from "need4deed-sdk";
+import { ApiAgentPatch, SortOrder, UserRole } from "need4deed-sdk";
 import { BadRequestError, NotFoundError } from "../../../config";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import logger from "../../../logger";
@@ -65,7 +59,9 @@ export default async function agentRoutes(
 
   fastify.get<{
     Querystring: QuerystringAgentGetList;
-    Reply: ReplyDataCount<ApiAgentGetList[]>;
+    // Handler sends entities; the DTO (ApiAgentGetList) runs in the
+    // preSerialization hook, so the send is typed as the entity.
+    Reply: ReplyDataCount<Agent[]>;
   }>(
     "/",
     {
@@ -110,17 +106,16 @@ export default async function agentRoutes(
         await agentRepository.save(updates);
       }
 
-      // DTO (dtoAgentGetList) runs in the preSerialization hook after PII
-      // masking, so the wire shape is ApiAgentGetList[] despite sending entities.
+      // DTO (dtoAgentGetList) runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Agents page:${page || 1} fetched successfully`,
-        data: agentsDistrict as unknown as ApiAgentGetList[],
+        data: agentsDistrict,
         count,
       });
     },
   );
 
-  fastify.get<{ Params: ParamsId; Reply: ReplyData<ApiAgentGet> }>(
+  fastify.get<{ Params: ParamsId; Reply: ReplyData<Agent> }>(
     "/:id",
     {
       schema: {
@@ -157,7 +152,7 @@ export default async function agentRoutes(
       // DTO (dtoAgentGet) runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Agent (id:${id}) fetched successfully`,
-        data: agentComments as unknown as ApiAgentGet,
+        data: agentComments,
       });
     },
   );

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -36,6 +36,7 @@ import {
   patchAddress,
   updateAgentLanguages,
 } from "../../utils";
+import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 import agentCommunicationRoutes from "./agent-communication.routes";
 import agentOpportunityRoutes from "./agent-opportunity.routes";
 import agentMembershipRoutes from "./membership.routes";
@@ -45,10 +46,10 @@ export default async function agentRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
 ) {
-  fastify.addHook(
-    "onRequest",
-    fastify.authenticate({ role: UserRole.COORDINATOR }),
-  );
+  // GETs are open to any logged-in user (PII is masked per role in the
+  // preSerialization hooks below); writes stay COORDINATOR-only (re-gated
+  // per-route).
+  fastify.addHook("onRequest", fastify.authenticate());
 
   fastify.register(agentRegisterRoutes, { prefix: RoutePrefix.REGISTER });
 
@@ -72,6 +73,7 @@ export default async function agentRoutes(
         querystring: agentListQuerySchema,
         response: responseSchema("ApiAgentGetList#", true),
       },
+      preSerialization: makePiiSerialization(dtoAgentGetList),
     },
     async (request, reply) => {
       logger.debug(`GET /agents: request.query:${Object.keys(request.query)}`);
@@ -103,15 +105,16 @@ export default async function agentRoutes(
 
       const { addDistrictToAgent, updates } = getDistrictToAgentHandler();
       const agentsDistrict = await Promise.all(agents.map(addDistrictToAgent));
-      const data = agentsDistrict.map(dtoAgentGetList);
 
       if (updates.length > 0) {
         await agentRepository.save(updates);
       }
 
+      // DTO (dtoAgentGetList) runs in the preSerialization hook after PII
+      // masking, so the wire shape is ApiAgentGetList[] despite sending entities.
       return reply.status(200).send({
         message: `Agents page:${page || 1} fetched successfully`,
-        data,
+        data: agentsDistrict as unknown as ApiAgentGetList[],
         count,
       });
     },
@@ -124,6 +127,7 @@ export default async function agentRoutes(
         params: idParamSchema,
         response: responseSchema("ApiAgentGet#"),
       },
+      preSerialization: makePiiSerialization(dtoAgentGet),
     },
     async (request, reply) => {
       const { id } = request.params;
@@ -145,15 +149,15 @@ export default async function agentRoutes(
       const { addDistrictToAgent, updates } = getDistrictToAgentHandler();
       const agentDistrict = await addDistrictToAgent(agent);
       const agentComments = await addComments2Entity(agentDistrict);
-      const data = dtoAgentGet(agentComments);
 
       if (updates.length > 0) {
         await agentRepository.save(updates);
       }
 
+      // DTO (dtoAgentGet) runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Agent (id:${id}) fetched successfully`,
-        data,
+        data: agentComments as unknown as ApiAgentGet,
       });
     },
   );
@@ -161,6 +165,7 @@ export default async function agentRoutes(
   fastify.patch<{ Params: ParamsId; Body: ApiAgentPatch; Reply: null }>(
     "/:id",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiAgentPatch#" },
@@ -229,6 +234,7 @@ export default async function agentRoutes(
   fastify.delete<{ Params: ParamsId; Reply: ReplyMessage }>(
     "/:id",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         response: responseSchema(""),

--- a/src/server/routes/agent/membership.routes.ts
+++ b/src/server/routes/agent/membership.routes.ts
@@ -1,5 +1,9 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { AgentMembershipStatus, ApiAgentMembership } from "need4deed-sdk";
+import {
+  AgentMembershipStatus,
+  ApiAgentMembership,
+  UserRole,
+} from "need4deed-sdk";
 import logger from "../../../logger";
 import { dtoSerializeAgentMembership } from "../../../services";
 import {
@@ -11,13 +15,18 @@ import {
 } from "../../schema";
 import { ParamsId } from "../../types";
 
-// Moderation of agent memberships. Mounted under /agent, so it inherits the
-// COORDINATOR onRequest auth hook (ADMIN bypasses). This is where joins that
-// landed PENDING (no email-domain match) get approved or rejected.
+// Moderation of agent memberships. COORDINATOR/ADMIN only — re-gated here since
+// the parent /agent onRequest hook was relaxed to logged-in for the GET PII
+// work. This is where PENDING joins get approved or rejected.
 export default async function agentMembershipRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
 ) {
+  fastify.addHook(
+    "onRequest",
+    fastify.authenticate({ role: UserRole.COORDINATOR }),
+  );
+
   // GET /agent/membership?status=pending — list memberships to moderate.
   fastify.get<{ Querystring: { status?: AgentMembershipStatus } }>(
     "/",

--- a/src/server/routes/opportunity/opportunity-volunteer.routes.ts
+++ b/src/server/routes/opportunity/opportunity-volunteer.routes.ts
@@ -3,6 +3,7 @@ import { ApiVolunteerOpportunityGet } from "need4deed-sdk";
 import { BadRequestError } from "../../../config/error/fastify";
 import { opportunityOpportunityVolunteerDTO } from "../../../services";
 import { idParamSchema, responseSchema } from "../../schema";
+import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 
 const msg400 = "URL param must ba a positive number";
 
@@ -20,6 +21,9 @@ export default function opportunityOpportunityVolunteerRoutes(
         params: idParamSchema,
         response: responseSchema("ApiOpportunityVolunteerGet#", true, false),
       },
+      preSerialization: makePiiSerialization(
+        opportunityOpportunityVolunteerDTO,
+      ),
     },
     async (request, reply) => {
       const opportunityId = request.params.id;
@@ -44,11 +48,10 @@ export default function opportunityOpportunityVolunteerRoutes(
         ],
       });
 
-      const data = volunteers.map(opportunityOpportunityVolunteerDTO);
-
+      // DTO runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Volunteers for opportunity id:${opportunityId}.`,
-        data,
+        data: volunteers as unknown as ApiVolunteerOpportunityGet[],
       });
     },
   );

--- a/src/server/routes/opportunity/opportunity-volunteer.routes.ts
+++ b/src/server/routes/opportunity/opportunity-volunteer.routes.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiVolunteerOpportunityGet } from "need4deed-sdk";
 import { BadRequestError } from "../../../config/error/fastify";
+import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
 import { opportunityOpportunityVolunteerDTO } from "../../../services";
 import { idParamSchema, responseSchema } from "../../schema";
 import { makePiiSerialization } from "../../utils/pii/pre-serialization";
@@ -13,7 +13,8 @@ export default function opportunityOpportunityVolunteerRoutes(
 ) {
   fastify.get<{
     Params: { id: number };
-    Reply: { message: string; data: ApiVolunteerOpportunityGet[] };
+    // Handler sends entities; the DTO runs in the preSerialization hook.
+    Reply: { message: string; data: OpportunityVolunteer[] };
   }>(
     "/",
     {
@@ -51,7 +52,7 @@ export default function opportunityOpportunityVolunteerRoutes(
       // DTO runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Volunteers for opportunity id:${opportunityId}.`,
-        data: volunteers as unknown as ApiVolunteerOpportunityGet[],
+        data: volunteers,
       });
     },
   );

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -48,6 +48,10 @@ import {
   patchEntity,
   updateOptionList,
 } from "../../utils";
+import {
+  makePiiSerialization,
+  maskForCaller,
+} from "../../utils/pii/pre-serialization";
 import opportunityLegacyRoutes from "./legacy.routes";
 import opportunityOpportunityVolunteerRoutes from "./opportunity-volunteer.routes";
 
@@ -55,10 +59,9 @@ export default async function opportunityRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
 ) {
-  fastify.addHook(
-    "onRequest",
-    fastify.authenticate({ role: UserRole.COORDINATOR }),
-  );
+  // GETs open to any logged-in user (PII masked per role); writes stay
+  // COORDINATOR-only (re-gated per-route).
+  fastify.addHook("onRequest", fastify.authenticate());
 
   await fastify.register(opportunityLegacyRoutes, {
     prefix: RoutePrefix.LEGACY,
@@ -143,6 +146,9 @@ export default async function opportunityRoutes(
           )
         : null;
 
+      // dtoOpportunityGet takes a handler-computed arg, so mask inline (rather
+      // than via the makePiiSerialization hook) before serializing.
+      await maskForCaller(request, opportunityComments);
       const data = dtoOpportunityGet(opportunityComments, accompanyingDistrict);
 
       return reply.status(200).send({ message: `Opportunity id:${id}`, data });
@@ -159,6 +165,7 @@ export default async function opportunityRoutes(
         querystring: opportunityListQuerySchema,
         response: responseSchema("ApiOpportunityGetList#", true),
       },
+      preSerialization: makePiiSerialization(dtoOpportunityGetList),
     },
     async (request, reply) => {
       const [skip, take] = getSkipTake({
@@ -225,11 +232,10 @@ export default async function opportunityRoutes(
         `Saving category updates: ${dealUpdates.length}, opportunity updates: ${opportunityUpdates.length}`,
       );
 
-      const data = opportunitiesCategoryDistrict.map(dtoOpportunityGetList);
-
+      // DTO (dtoOpportunityGetList) runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Opportunities page:${request.query.page}.`,
-        data,
+        data: opportunitiesCategoryDistrict as unknown as ApiOpportunityGetList[],
         count,
       });
     },
@@ -242,6 +248,7 @@ export default async function opportunityRoutes(
   }>(
     "/:id",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiVolunteerOpportunityPatch#" },

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -1,7 +1,6 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
   ApiOpportunityGet,
-  ApiOpportunityGetList,
   ApiOpportunityPatch,
   SortOrder,
   UserRole,
@@ -157,7 +156,9 @@ export default async function opportunityRoutes(
 
   fastify.get<{
     Querystring: QuerystringOpportunityList;
-    Reply: ReplyDataCount<ApiOpportunityGetList[]>;
+    // Handler sends entities; the DTO (ApiOpportunityGetList) runs in the
+    // preSerialization hook.
+    Reply: ReplyDataCount<Opportunity[]>;
   }>(
     "/",
     {
@@ -235,7 +236,7 @@ export default async function opportunityRoutes(
       // DTO (dtoOpportunityGetList) runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Opportunities page:${request.query.page}.`,
-        data: opportunitiesCategoryDistrict as unknown as ApiOpportunityGetList[],
+        data: opportunitiesCategoryDistrict,
         count,
       });
     },

--- a/src/server/routes/volunteer/appreciation.routes.ts
+++ b/src/server/routes/volunteer/appreciation.routes.ts
@@ -1,7 +1,12 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiAppreciationGet, ApiAppreciationPost } from "need4deed-sdk";
+import {
+  ApiAppreciationGet,
+  ApiAppreciationPost,
+  UserRole,
+} from "need4deed-sdk";
 import { dtoAppreciation } from "../../../services/dto/dto-appreciation";
 import { idParamSchema, responseErrors } from "../../schema";
+import { maskForCaller } from "../../utils/pii/pre-serialization";
 
 export default function volunteerAppreciationRoutes(
   fastify: FastifyInstance,
@@ -41,6 +46,7 @@ export default function volunteerAppreciationRoutes(
         },
       });
 
+      await maskForCaller(request, appreciations);
       const data = appreciations.map(dtoAppreciation);
 
       return reply.status(200).send({
@@ -53,6 +59,7 @@ export default function volunteerAppreciationRoutes(
   fastify.post<{ Params: { id: number }; Body: ApiAppreciationPost }>(
     "/",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiAppreciationPost#" },

--- a/src/server/routes/volunteer/communication.routes.ts
+++ b/src/server/routes/volunteer/communication.routes.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiVolunteerCommunicationPost } from "need4deed-sdk";
+import { ApiVolunteerCommunicationPost, UserRole } from "need4deed-sdk";
 import { idParamSchema } from "../../schema";
+import { maskForCaller } from "../../utils/pii/pre-serialization";
 
 export default function volunteerCommunicationRoutes(
   fastify: FastifyInstance,
@@ -33,6 +34,7 @@ export default function volunteerCommunicationRoutes(
         },
       });
 
+      await maskForCaller(request, communications);
       return reply.status(200).send({
         message: `List of communications for volunteer_id:${volunteerId}`,
         data: communications,
@@ -43,6 +45,7 @@ export default function volunteerCommunicationRoutes(
   fastify.post<{ Params: { id: number }; Body: ApiVolunteerCommunicationPost }>(
     "/",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiCommunicationPost#" },

--- a/src/server/routes/volunteer/doc.routes.ts
+++ b/src/server/routes/volunteer/doc.routes.ts
@@ -18,9 +18,13 @@ export default async function volunteerDocRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
 ) {
+  // Documents can't be PII-masked (they're files/metadata), so these GETs stay
+  // COORDINATOR-only — the parent /volunteer hook was relaxed to logged-in for
+  // the masked GET work, which would otherwise expose them to any user.
   fastify.get<{ Params: { id: number } }>(
     "/",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         response: {
@@ -39,27 +43,31 @@ export default async function volunteerDocRoutes(
     },
   );
 
-  fastify.get("/download", async (request, reply) => {
-    const { url } = request.query as { url: string };
-    const fileName = "test_pdf.pdf";
+  fastify.get(
+    "/download",
+    { onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }) },
+    async (request, reply) => {
+      const { url } = request.query as { url: string };
+      const fileName = "test_pdf.pdf";
 
-    const [urlObj, error] = await tryCatch(fetch(url));
+      const [urlObj, error] = await tryCatch(fetch(url));
 
-    if (error) {
-      logger.error(`Error fetching document from URL ${url}: ${error}`);
-      return reply.status(400).send({
-        message: `Error fetching document from URL: ${error}`,
+      if (error) {
+        logger.error(`Error fetching document from URL ${url}: ${error}`);
+        return reply.status(400).send({
+          message: `Error fetching document from URL: ${error}`,
+        });
+      }
+
+      reply.raw.writeHead(200, {
+        "Content-Disposition": `attachment; filename="${fileName}"`,
+        "Content-Type": "application/pdf",
+        "Content-Length": urlObj.headers.get("Content-Length") || "",
       });
-    }
 
-    reply.raw.writeHead(200, {
-      "Content-Disposition": `attachment; filename="${fileName}"`,
-      "Content-Type": "application/pdf",
-      "Content-Length": urlObj.headers.get("Content-Length") || "",
-    });
-
-    Readable.fromWeb(urlObj.body).pipe(reply.raw);
-  });
+      Readable.fromWeb(urlObj.body).pipe(reply.raw);
+    },
+  );
 
   fastify.get<{
     Params: { id: number };
@@ -67,6 +75,7 @@ export default async function volunteerDocRoutes(
   }>(
     "/upload-meta",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         querystring: volunteerDocSchemaUploadMeta,

--- a/src/server/routes/volunteer/doc.routes.ts
+++ b/src/server/routes/volunteer/doc.routes.ts
@@ -1,6 +1,6 @@
 import { Readable } from "stream";
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { DocumentType } from "need4deed-sdk";
+import { DocumentType, UserRole } from "need4deed-sdk";
 import Document from "../../../data/entity/document.entity";
 import logger from "../../../logger";
 import { tryCatch } from "../../../services/utils";
@@ -109,59 +109,64 @@ export default async function volunteerDocRoutes(
       id: number;
       Body: {};
     };
-  }>("/s3-upload-mock", async (request, reply) => {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }>(
+    "/s3-upload-mock",
+    { onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }) },
+    async (request, reply) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    const {
-      "x-amz-meta-original-name": originalName,
-      "x-amz-meta-mime-type": mimeType,
-      "x-amz-meta-document-type": type,
-      "x-amz-meta-volunteer-id": volunteerId,
-      "x-amz-meta-s3-key": s3Key,
-    } = request.body as {
-      "x-amz-meta-volunteer-id": string;
-      "x-amz-meta-original-name": string;
-      "x-amz-meta-document-type": DocumentType;
-      "x-amz-meta-mime-type": string;
-      "x-amz-meta-s3-key": string;
-    };
-    const document = new Document({
-      volunteerId: Number(volunteerId),
-      originalName,
-      mimeType,
-      s3Key,
-      type,
-    });
-    const [, error] = await tryCatch(
-      fastify.db.documentRepository.save(document),
-    );
-
-    if (error) {
-      logger.error(
-        `Error saving document for volunteer ${volunteerId}: ${error}`,
-      );
-      return reply.status(400).send({
-        message: `Error saving document: ${error}`,
+      const {
+        "x-amz-meta-original-name": originalName,
+        "x-amz-meta-mime-type": mimeType,
+        "x-amz-meta-document-type": type,
+        "x-amz-meta-volunteer-id": volunteerId,
+        "x-amz-meta-s3-key": s3Key,
+      } = request.body as {
+        "x-amz-meta-volunteer-id": string;
+        "x-amz-meta-original-name": string;
+        "x-amz-meta-document-type": DocumentType;
+        "x-amz-meta-mime-type": string;
+        "x-amz-meta-s3-key": string;
+      };
+      const document = new Document({
+        volunteerId: Number(volunteerId),
+        originalName,
+        mimeType,
+        s3Key,
+        type,
       });
-    }
+      const [, error] = await tryCatch(
+        fastify.db.documentRepository.save(document),
+      );
 
-    return reply
-      .code(201)
-      .type("application/xml")
-      .send(
-        `<?xml version="1.0" encoding="UTF-8"?>
+      if (error) {
+        logger.error(
+          `Error saving document for volunteer ${volunteerId}: ${error}`,
+        );
+        return reply.status(400).send({
+          message: `Error saving document: ${error}`,
+        });
+      }
+
+      return reply
+        .code(201)
+        .type("application/xml")
+        .send(
+          `<?xml version="1.0" encoding="UTF-8"?>
         <PostResponse>
           <Location>http://vmpub:5000/uploads/test.png</Location>
           <Bucket>mock-bucket</Bucket>
           <Key>test.png</Key>
           <ETag>"mock-etag-123"</ETag>
         </PostResponse>`,
-      );
-  });
+        );
+    },
+  );
 
   fastify.delete<{ Params: { id: number } }>(
     "/",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         response: {
@@ -206,6 +211,7 @@ export default async function volunteerDocRoutes(
   fastify.delete<{ Params: { id: number; type: DocumentType } }>(
     "/:type",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idTypeParamSchema,
         response: {

--- a/src/server/routes/volunteer/opportunity-volunteer.routes.ts
+++ b/src/server/routes/volunteer/opportunity-volunteer.routes.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
   ApiOpportunityVolunteerGet,
   OpportunityVolunteerStatusType,
+  UserRole,
 } from "need4deed-sdk";
 import { BadRequestError, NotFoundError } from "../../../config/error/fastify";
 import { volunteerOpportunityVolunteerDTO } from "../../../services";
@@ -11,6 +12,7 @@ import {
   responseErrors,
   responseSchema,
 } from "../../schema";
+import { maskForCaller } from "../../utils/pii/pre-serialization";
 
 const msg400 = "URL param must ba a positive number";
 
@@ -55,6 +57,7 @@ export default function volunteerOpportunityVolunteerRoutes(
         relations: ["opportunity"],
       });
 
+      await maskForCaller(request, opportunities);
       const data = opportunities.map(volunteerOpportunityVolunteerDTO);
 
       return reply.status(200).send({
@@ -71,6 +74,7 @@ export default function volunteerOpportunityVolunteerRoutes(
   }>(
     "/:m2mId",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idmM2mIdParamSchema,
         body: { $ref: "ApiVolunteerOpportunityPatch#" },
@@ -112,6 +116,7 @@ export default function volunteerOpportunityVolunteerRoutes(
   }>(
     "/:m2mId",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idmM2mIdParamSchema,
         response: {

--- a/src/server/routes/volunteer/volunteer-opportunity.routes.ts
+++ b/src/server/routes/volunteer/volunteer-opportunity.routes.ts
@@ -14,6 +14,7 @@ import {
   getSkipTake,
   normalizeStringArrayInput,
 } from "../../utils";
+import { maskForCaller } from "../../utils/pii/pre-serialization";
 
 export default async function volunteerOpportunityRoutes(
   fastify: FastifyInstance,
@@ -68,6 +69,7 @@ export default async function volunteerOpportunityRoutes(
         await dealRepository.save(updates);
       }
 
+      await maskForCaller(request, opportunitiesCategory);
       const data = opportunitiesCategory.map(dtoVolunteerOpportunityGetList);
 
       return reply.status(200).send({

--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -48,6 +48,10 @@ import {
   updateOptionList,
   writeVolunteerLegacy,
 } from "../../utils";
+import {
+  maskForCaller,
+  resolveCallerMask,
+} from "../../utils/pii/pre-serialization";
 import volunteerAppreciationRoutes from "./appreciation.routes";
 import volunteerCommunicationRoutes from "./communication.routes";
 import volunteerDocRoutes from "./doc.routes";
@@ -91,10 +95,9 @@ export default async function volunteerRoutes(
       ? listRelationsCommon
       : [...listRelationsCommon, ...listRelationsCardExtra];
 
-  fastify.addHook(
-    "onRequest",
-    fastify.authenticate({ role: UserRole.COORDINATOR }),
-  );
+  // GETs open to any logged-in user (PII masked per role); writes stay
+  // COORDINATOR-only (re-gated per-route).
+  fastify.addHook("onRequest", fastify.authenticate());
 
   await fastify.register(volunteerOpportunityRoutes, {
     prefix: RoutePrefix.OPPORTUNITY,
@@ -147,7 +150,12 @@ export default async function volunteerRoutes(
       const isoCode = getLanguageCode(request.query.language) || Lang.DE;
 
       try {
-        const data = await fetchVolunteerById(id, isoCode, relations);
+        const data = await fetchVolunteerById(
+          id,
+          isoCode,
+          relations,
+          await resolveCallerMask(request),
+        );
         if (!data) {
           logger.error(`Failed fetching volunteer (id=${id}).`);
           throw new Error(`Volunteer (id=${id}) not found after patch.`);
@@ -232,6 +240,7 @@ export default async function volunteerRoutes(
           })
         : [];
 
+      await maskForCaller(request, volunteers);
       const data = volunteers.map(volunteerListSerializer).filter(Boolean);
 
       reply.status(200).send({
@@ -255,6 +264,7 @@ export default async function volunteerRoutes(
   }>(
     "/:id",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         body: { $ref: "volunteer-api-id-part#" },
@@ -397,7 +407,12 @@ export default async function volunteerRoutes(
       const isoCode = getLanguageCode(request.query.language) || Lang.DE;
 
       try {
-        const data = await fetchVolunteerById(id, isoCode, relations);
+        const data = await fetchVolunteerById(
+          id,
+          isoCode,
+          relations,
+          await resolveCallerMask(request),
+        );
         if (!data) {
           logger.error(`Failed fetching volunteer (id=${id}) after patch.`);
           throw new Error(`Volunteer (id=${id}) not found after patch.`);
@@ -425,6 +440,7 @@ export default async function volunteerRoutes(
   }>(
     "/",
     {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         body: { $ref: "volunteer-form-data" },
         response: {

--- a/src/server/types/fastify.d.ts
+++ b/src/server/types/fastify.d.ts
@@ -51,6 +51,7 @@ declare module "fastify" {
     personId?: number; // Optional foreign key ID for the Person entity
     agents?: Agent[];
     registrant?: User; // Verified user resolved from the querystring token on POST /agent/register
+    authUser?: User; // The user loaded by authenticate() (personId + DB-authoritative role)
   }
 }
 

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -612,13 +612,17 @@ export async function fetchVolunteerById(
 
   addTranslatedFields([volunteer], isoCode);
 
-  // Mask PII the caller may not see before the serializer reads it.
-  if (maskVisiblePersonIds) {
-    maskPii(volunteer, maskVisiblePersonIds);
-  }
-
   const timedEvents = await getTimedEvents(volunteer);
   const comments = await getVolunteerComments(volunteer);
+
+  // Mask PII the caller may not see before the serializer reads it. Comments are
+  // loaded separately (they aren't part of the volunteer graph), so they must be
+  // masked too — otherwise comment authors' Person PII leaks to non-privileged
+  // callers.
+  if (maskVisiblePersonIds) {
+    maskPii(volunteer, maskVisiblePersonIds);
+    maskPii(comments, maskVisiblePersonIds);
+  }
 
   const data = volunteerSerializer(volunteer, comments, timedEvents);
 

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -43,6 +43,7 @@ import { getRepository, getRRULE, getStartEnd } from "../../../data/utils";
 import logger from "../../../logger";
 import { volunteerSerializer } from "../../../services";
 import { tryCatch } from "../../../services/utils";
+import { maskPii } from "../pii/mask";
 
 export { getPostcode } from "../../../data/utils";
 
@@ -596,6 +597,7 @@ export async function fetchVolunteerById(
   id: number,
   isoCode: Lang,
   relations: string[],
+  maskVisiblePersonIds?: ReadonlySet<number> | null,
 ): Promise<ApiVolunteerGet | null> {
   const volunteerRepository = getRepository(dataSource, Volunteer);
 
@@ -609,6 +611,11 @@ export async function fetchVolunteerById(
   }
 
   addTranslatedFields([volunteer], isoCode);
+
+  // Mask PII the caller may not see before the serializer reads it.
+  if (maskVisiblePersonIds) {
+    maskPii(volunteer, maskVisiblePersonIds);
+  }
 
   const timedEvents = await getTimedEvents(volunteer);
   const comments = await getVolunteerComments(volunteer);

--- a/src/server/utils/data/get-agent-where.ts
+++ b/src/server/utils/data/get-agent-where.ts
@@ -3,6 +3,8 @@ import Agent from "../../../data/entity/opportunity/agent.entity";
 import { QuerystringAgentFiltering } from "../../types";
 import { normalizeStringArrayInput } from "./for-routes";
 
+// SECURITY (#666): `search`/`street` filter on unmasked DB columns, so a
+// non-privileged caller can infer PII masked in the response by probing matches.
 export function getAgentWhere(
   filter: QuerystringAgentFiltering["filter"],
 ): FindOptionsWhere<Agent> {

--- a/src/server/utils/data/get-opportunity-where.ts
+++ b/src/server/utils/data/get-opportunity-where.ts
@@ -3,6 +3,8 @@ import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import { QuerystringOpportunityFiltering } from "../../types";
 import { normalizeStringArrayInput } from "./for-routes";
 
+// SECURITY (#666): filters run on unmasked DB columns, so a non-privileged
+// caller can infer PII masked in the response by probing which rows match.
 export function getOpportunityWhere(
   filter: QuerystringOpportunityFiltering["filter"],
 ): FindOptionsWhere<Opportunity> {

--- a/src/server/utils/data/get-volunteer-where.ts
+++ b/src/server/utils/data/get-volunteer-where.ts
@@ -2,6 +2,8 @@ import { ILike } from "typeorm";
 import { QuerystringVolunteerFiltering } from "../../types";
 import { normalizeStringArrayInput } from "./for-routes";
 
+// SECURITY (#666): `search` filters on unmasked DB columns, so a non-privileged
+// caller can infer PII masked in the response by probing which rows match.
 export function getVolunteerWhere(
   filter: QuerystringVolunteerFiltering["filter"],
 ) {

--- a/src/server/utils/pii/mask.ts
+++ b/src/server/utils/pii/mask.ts
@@ -1,0 +1,85 @@
+import Address from "../../../data/entity/location/address.entity";
+import Person from "../../../data/entity/person.entity";
+
+// PII columns masked for callers not permitted to see the owning Person.
+const PERSON_PII_FIELDS = [
+  "firstName",
+  "middleName",
+  "lastName",
+  "email",
+  "phone",
+  "landline",
+  "avatarUrl",
+] as const;
+const ADDRESS_PII_FIELDS = ["title", "street", "city"] as const;
+
+// A single random char + "***" — hides both the original value's length and its
+// first letter (so "John" -> e.g. "x***"), unlike a fixed "****".
+export function maskString(): string {
+  const c = String.fromCharCode(97 + Math.floor(Math.random() * 26));
+  return `${c}***`;
+}
+
+function maskFields(
+  obj: Record<string, unknown>,
+  fields: readonly string[],
+): void {
+  for (const field of fields) {
+    if (typeof obj[field] === "string" && obj[field]) {
+      obj[field] = maskString();
+    }
+  }
+}
+
+/**
+ * Masks PII (Person/Address) the caller may not see, in place, on the loaded
+ * entity graph (run before the DTO). TypeORM returns class instances, so PII is
+ * identified by `instanceof` — reference objects and all non-PII entities pass
+ * through untouched (the walker still descends them to reach nested PII).
+ *
+ * A Person is visible iff its id is in `visiblePersonIds`; a Person's own
+ * Address follows that visibility, and standalone Addresses (e.g. agent.address)
+ * are masked. A WeakSet guards against the entity graph's cycles.
+ */
+export function maskPii<T>(data: T, visiblePersonIds: ReadonlySet<number>): T {
+  walk(data, visiblePersonIds, new WeakSet<object>());
+  return data;
+}
+
+function walk(
+  node: unknown,
+  visible: ReadonlySet<number>,
+  seen: WeakSet<object>,
+): void {
+  if (node === null || typeof node !== "object") {return;}
+  if (seen.has(node)) {return;}
+  seen.add(node);
+
+  if (Array.isArray(node)) {
+    for (const item of node) {walk(item, visible, seen);}
+    return;
+  }
+
+  if (node instanceof Person) {
+    const isVisible = visible.has(node.id);
+    if (!isVisible)
+      {maskFields(node as unknown as Record<string, unknown>, PERSON_PII_FIELDS);}
+    // Claim the person's own Address so the standalone-Address rule below can't
+    // re-mask a visible person's address (and don't double-mask a hidden one).
+    if (node.address && typeof node.address === "object") {
+      if (!isVisible)
+        {maskFields(
+          node.address as unknown as Record<string, unknown>,
+          ADDRESS_PII_FIELDS,
+        );}
+      seen.add(node.address);
+    }
+  } else if (node instanceof Address) {
+    // Reached not via a Person (e.g. agent.address) -> standalone PII, mask it.
+    maskFields(node as unknown as Record<string, unknown>, ADDRESS_PII_FIELDS);
+  }
+
+  for (const key of Object.keys(node)) {
+    walk((node as Record<string, unknown>)[key], visible, seen);
+  }
+}

--- a/src/server/utils/pii/pre-serialization.ts
+++ b/src/server/utils/pii/pre-serialization.ts
@@ -6,12 +6,6 @@ import { resolveVisiblePersonIds } from "./visible-persons";
 type Envelope = { message?: string; data?: unknown; count?: number };
 
 /**
- * Masks Person/Address the caller may not see, in place, on `data`. No-op for
- * COORDINATOR/ADMIN and unauthenticated requests. Use directly in handlers
- * whose DTO needs extra (handler-computed) args; otherwise prefer the
- * `makePiiSerialization` hook.
- */
-/**
  * The set of person ids this caller may see UNMASKED, or `null` when no masking
  * applies (COORDINATOR/ADMIN or unauthenticated). For routes that build DTOs in
  * helpers — pass this through and `maskPii(entity, set)` before serializing.
@@ -22,17 +16,29 @@ export async function resolveCallerMask(
   const user = request.authUser;
   const privileged =
     user?.role === UserRole.COORDINATOR || user?.role === UserRole.ADMIN;
-  if (!user || privileged) {return null;}
+  if (!user || privileged) {
+    return null;
+  }
   return resolveVisiblePersonIds(request.server, user);
 }
 
+/**
+ * Masks Person/Address the caller may not see, in place, on `data`. No-op for
+ * COORDINATOR/ADMIN and unauthenticated requests. Use directly in handlers
+ * whose DTO needs extra (handler-computed) args; otherwise prefer the
+ * `makePiiSerialization` hook.
+ */
 export async function maskForCaller(
   request: FastifyRequest,
   data: unknown,
 ): Promise<void> {
-  if (data === null || data === undefined) {return;}
+  if (data === null || data === undefined) {
+    return;
+  }
   const visible = await resolveCallerMask(request);
-  if (visible) {maskPii(data, visible);}
+  if (visible) {
+    maskPii(data, visible);
+  }
 }
 
 /**

--- a/src/server/utils/pii/pre-serialization.ts
+++ b/src/server/utils/pii/pre-serialization.ts
@@ -1,0 +1,65 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import { UserRole } from "need4deed-sdk";
+import { maskPii } from "./mask";
+import { resolveVisiblePersonIds } from "./visible-persons";
+
+type Envelope = { message?: string; data?: unknown; count?: number };
+
+/**
+ * Masks Person/Address the caller may not see, in place, on `data`. No-op for
+ * COORDINATOR/ADMIN and unauthenticated requests. Use directly in handlers
+ * whose DTO needs extra (handler-computed) args; otherwise prefer the
+ * `makePiiSerialization` hook.
+ */
+/**
+ * The set of person ids this caller may see UNMASKED, or `null` when no masking
+ * applies (COORDINATOR/ADMIN or unauthenticated). For routes that build DTOs in
+ * helpers — pass this through and `maskPii(entity, set)` before serializing.
+ */
+export async function resolveCallerMask(
+  request: FastifyRequest,
+): Promise<ReadonlySet<number> | null> {
+  const user = request.authUser;
+  const privileged =
+    user?.role === UserRole.COORDINATOR || user?.role === UserRole.ADMIN;
+  if (!user || privileged) {return null;}
+  return resolveVisiblePersonIds(request.server, user);
+}
+
+export async function maskForCaller(
+  request: FastifyRequest,
+  data: unknown,
+): Promise<void> {
+  if (data === null || data === undefined) {return;}
+  const visible = await resolveCallerMask(request);
+  if (visible) {maskPii(data, visible);}
+}
+
+/**
+ * Per-route `preSerialization` hook. The handler sends the loaded entity graph
+ * as `data`; this masks Person/Address the caller may not see, then runs the
+ * route's DTO. COORDINATOR/ADMIN (and unauthenticated/error payloads) pass
+ * through untouched. List vs single is detected from `data`.
+ */
+export function makePiiSerialization<TEntity, TDto>(
+  dto: (entity: TEntity) => TDto,
+) {
+  return async function piiPreSerialization(
+    request: FastifyRequest,
+    _reply: FastifyReply,
+    payload: Envelope,
+  ): Promise<Envelope> {
+    // Error/empty replies ({ message } with no data) — nothing to serialize.
+    if (!payload || payload.data === null || payload.data === undefined) {
+      return payload;
+    }
+
+    await maskForCaller(request, payload.data);
+
+    const data = Array.isArray(payload.data)
+      ? (payload.data as TEntity[]).map(dto)
+      : dto(payload.data as TEntity);
+
+    return { ...payload, data };
+  };
+}

--- a/src/server/utils/pii/visible-persons.ts
+++ b/src/server/utils/pii/visible-persons.ts
@@ -1,0 +1,52 @@
+import { FastifyInstance } from "fastify";
+import { UserRole } from "need4deed-sdk";
+import { In } from "typeorm";
+import User from "../../../data/entity/user.entity";
+
+/**
+ * Person ids the caller may see UNMASKED (non COORDINATOR/ADMIN):
+ *   USER      -> none
+ *   VOLUNTEER -> own person
+ *   AGENT     -> own ∪ members of their agent(s) ∪ persons of volunteers on
+ *                opportunities owned by their agent(s)
+ * Only the AGENT branch hits the DB; resolved per request, masking-side only.
+ */
+export async function resolveVisiblePersonIds(
+  fastify: FastifyInstance,
+  user: User,
+): Promise<Set<number>> {
+  const visible = new Set<number>();
+  const personId = user.personId ?? undefined;
+
+  // USER sees only reference data; a missing personId can't match anything.
+  if (user.role === UserRole.USER || !personId) {return visible;}
+
+  visible.add(personId); // VOLUNTEER + AGENT see their own person
+
+  if (user.role !== UserRole.AGENT) {return visible;}
+
+  const agentPersonRepository = fastify.db.agentPersonRepository;
+  const memberships = await agentPersonRepository.find({ where: { personId } });
+  const agentIds = memberships.map((m) => m.agentId);
+  if (agentIds.length === 0) {return visible;}
+
+  // Members of the caller's agent(s).
+  const members = await agentPersonRepository.find({
+    where: { agentId: In(agentIds) },
+  });
+  members.forEach((m) => visible.add(m.personId));
+
+  // Persons of volunteers on opportunities owned by the caller's agent(s).
+  const rows: { person_id: number }[] =
+    await agentPersonRepository.manager.query(
+      `SELECT DISTINCT v.person_id
+       FROM opportunity o
+       JOIN opportunity_volunteer ov ON ov.opportunity_id = o.id
+       JOIN volunteer v ON v.id = ov.volunteer_id
+      WHERE o.agent_id = ANY($1) AND v.person_id IS NOT NULL`,
+      [agentIds],
+    );
+  rows.forEach((r) => visible.add(Number(r.person_id)));
+
+  return visible;
+}

--- a/src/test/server/utils/pii/mask.test.ts
+++ b/src/test/server/utils/pii/mask.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import Address from "../../../../data/entity/location/address.entity";
+import Person from "../../../../data/entity/person.entity";
+import { maskPii, maskString } from "../../../../server/utils/pii/mask";
+
+const MASKED = /^[a-z]\*\*\*$/;
+
+const makePerson = (id: number): Person =>
+  Object.assign(new Person(), {
+    id,
+    firstName: "John",
+    lastName: "Doe",
+    email: "john@example.de",
+  });
+
+const makeAddress = (street: string): Address =>
+  Object.assign(new Address(), { street, city: "Berlin" });
+
+describe("maskString", () => {
+  it("returns a random char + '***' (hides length and first letter)", () => {
+    expect(maskString()).toMatch(MASKED);
+  });
+});
+
+describe("maskPii", () => {
+  it("masks a Person not in the visible set", () => {
+    const p = makePerson(2);
+    maskPii(p, new Set([1]));
+    expect(p.firstName).toMatch(MASKED);
+    expect(p.lastName).toMatch(MASKED);
+    expect(p.email).toMatch(MASKED);
+  });
+
+  it("leaves a visible Person untouched", () => {
+    const p = makePerson(1);
+    maskPii(p, new Set([1]));
+    expect(p.firstName).toBe("John");
+    expect(p.email).toBe("john@example.de");
+  });
+
+  it("masks a hidden Person's address but keeps a visible Person's address", () => {
+    const hidden = makePerson(2);
+    hidden.address = makeAddress("Main 1");
+    const visible = makePerson(1);
+    visible.address = makeAddress("Side 2");
+
+    maskPii([hidden, visible], new Set([1]));
+
+    expect(hidden.address.street).toMatch(MASKED);
+    expect(visible.address.street).toBe("Side 2");
+  });
+
+  it("masks a standalone Address (not under a Person) and leaves non-PII fields", () => {
+    const agentLike = {
+      id: 5,
+      title: "Center",
+      address: makeAddress("Haupt 3"),
+    };
+    maskPii(agentLike, new Set([1]));
+    expect(agentLike.address.street).toMatch(MASKED);
+    expect(agentLike.title).toBe("Center");
+  });
+
+  it("leaves reference-like objects untouched and recurses to nested PII", () => {
+    const graph = {
+      id: 7,
+      district: { id: 3, title: "Mitte" },
+      volunteers: [{ id: 9, person: makePerson(2) }],
+    };
+    maskPii(graph, new Set());
+    expect(graph.district.title).toBe("Mitte");
+    expect(graph.volunteers[0].person.firstName).toMatch(MASKED);
+  });
+
+  it("is cycle-safe", () => {
+    const p = makePerson(2);
+    const wrapper: { person: Person; self?: unknown } = { person: p };
+    (p as unknown as { back: unknown }).back = wrapper; // introduce a cycle
+    expect(() => maskPii(wrapper, new Set([1]))).not.toThrow();
+    expect(p.firstName).toMatch(MASKED);
+  });
+});

--- a/src/test/server/utils/pii/visible-persons.test.ts
+++ b/src/test/server/utils/pii/visible-persons.test.ts
@@ -1,0 +1,109 @@
+import type { FastifyInstance } from "fastify";
+import { UserRole } from "need4deed-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type User from "../../../../data/entity/user.entity";
+import { resolveVisiblePersonIds } from "../../../../server/utils/pii/visible-persons";
+
+const find = vi.fn();
+const query = vi.fn();
+
+const fastify = {
+  db: { agentPersonRepository: { find, manager: { query } } },
+} as unknown as FastifyInstance;
+
+const makeUser = (role: UserRole, personId: number | null = 1): User =>
+  ({ id: 100, role, personId }) as unknown as User;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("resolveVisiblePersonIds", () => {
+  it("returns an empty set for USER (reference data only), no DB calls", async () => {
+    const visible = await resolveVisiblePersonIds(
+      fastify,
+      makeUser(UserRole.USER),
+    );
+    expect([...visible]).toEqual([]);
+    expect(find).not.toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty set when the caller has no personId", async () => {
+    const visible = await resolveVisiblePersonIds(
+      fastify,
+      makeUser(UserRole.VOLUNTEER, null),
+    );
+    expect([...visible]).toEqual([]);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("returns only the own person for VOLUNTEER, no DB calls", async () => {
+    const visible = await resolveVisiblePersonIds(
+      fastify,
+      makeUser(UserRole.VOLUNTEER, 7),
+    );
+    expect([...visible]).toEqual([7]);
+    expect(find).not.toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  describe("AGENT branch", () => {
+    it("returns own ∪ members ∪ volunteers on the agent's opportunities", async () => {
+      // 1st find: caller's memberships -> agent ids
+      find.mockResolvedValueOnce([
+        { agentId: 42, personId: 1 },
+        { agentId: 43, personId: 1 },
+      ]);
+      // 2nd find: members of those agents
+      find.mockResolvedValueOnce([
+        { agentId: 42, personId: 1 },
+        { agentId: 42, personId: 2 },
+        { agentId: 43, personId: 3 },
+      ]);
+      // raw SQL: persons of volunteers on the agents' opportunities
+      query.mockResolvedValueOnce([{ person_id: 8 }, { person_id: 9 }]);
+
+      const visible = await resolveVisiblePersonIds(
+        fastify,
+        makeUser(UserRole.AGENT, 1),
+      );
+
+      expect([...visible].sort((a, b) => a - b)).toEqual([1, 2, 3, 8, 9]);
+
+      // member lookup is scoped to the caller's agent ids
+      expect(find).toHaveBeenNthCalledWith(2, {
+        where: { agentId: expect.anything() },
+      });
+      // raw SQL receives the agent ids array as its only parameter
+      expect(query.mock.calls[0][1]).toEqual([[42, 43]]);
+    });
+
+    it("returns only the own person when the AGENT has no memberships", async () => {
+      find.mockResolvedValueOnce([]); // no memberships
+
+      const visible = await resolveVisiblePersonIds(
+        fastify,
+        makeUser(UserRole.AGENT, 5),
+      );
+
+      expect([...visible]).toEqual([5]);
+      expect(find).toHaveBeenCalledTimes(1); // no member lookup
+      expect(query).not.toHaveBeenCalled(); // no raw SQL
+    });
+
+    it("coerces raw SQL person_id values to numbers", async () => {
+      find.mockResolvedValueOnce([{ agentId: 42, personId: 1 }]);
+      find.mockResolvedValueOnce([{ agentId: 42, personId: 1 }]);
+      query.mockResolvedValueOnce([{ person_id: "8" }]); // string from pg
+
+      const visible = await resolveVisiblePersonIds(
+        fastify,
+        makeUser(UserRole.AGENT, 1),
+      );
+
+      expect(visible.has(8)).toBe(true);
+      expect(visible.has("8" as unknown as number)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Opens the GET endpoints under `/opportunity/*`, `/volunteer/*`, `/agent/*` to any logged-in user and **masks PII (`Person`/`Address`)** the caller isn't permitted to see. COORDINATOR/ADMIN are unaffected; writes stay COORDINATOR-only.

## Auth
- The blanket `authenticate({ role: COORDINATOR })` `onRequest` hook on the three route groups is relaxed to `authenticate()` (logged-in only).
- Every POST/PATCH/DELETE is **re-gated** per-route to `authenticate({ role: COORDINATOR })`. `/agent/membership` stays COORDINATOR; `/agent/register/search` stays public.

## Masking
- New `src/server/utils/pii/`: `maskString` (random char + `***`, e.g. `John` → `x***`), `maskPii` (entity-graph walker using `instanceof Person/Address`, cycle-safe), `resolveVisiblePersonIds`, and a `makePiiSerialization` `preSerialization` hook + `maskForCaller`/`resolveCallerMask` helpers for routes whose DTO is built in a helper.
- The hook masks the loaded **entity graph** then runs the DTO, so masked values stay strings — **no response-schema changes**.
- Caller identity reuses the user `authenticate()` already loads (exposed as `request.authUser`) — no JWT change, role stays DB-authoritative.

### Who sees an unmasked Person
| Role | Unmasked |
|---|---|
| USER | none |
| VOLUNTEER | own (`id === personId`) |
| AGENT | own ∪ their agent's members ∪ volunteers on their agent's opportunities |
| COORDINATOR/ADMIN | all |

## Validation
- 7 new unit tests for `maskString`/`maskPii`; all 291 existing tests still pass; typecheck + lint clean.
- Live smoke (role-specific access cookies): ADMIN/COORDINATOR see real names/emails; AGENT sees `Sarah`→`g***`, emails→`y***` on both the hook path (`GET /agent/:id`, `/agent`) and the inline path (`GET /volunteer/:id`, `/volunteer`); AGENT `PATCH` → 403.

## Known limitation (flagged)
Search filters run on **unmasked DB columns**, so a non-privileged caller can infer a masked value by probing matches; free-text PII (legacy `<|>` comments) isn't reached. `// SECURITY:` markers added at the filter sites; tracked in #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)