### PR TITLE
chore(notify): log verification url in sendEmailVerification debug line

### DIFF
--- a/src/services/notify/events/email-verification.ts
+++ b/src/services/notify/events/email-verification.ts
@@ -121,7 +121,7 @@ export async function sendEmailVerification(
   });
   const url = `${urlEmailVerification}/${token}`;
 
-  logger.debug(`sendEmailVerification: ${user.email}`);
+  logger.debug(`sendEmailVerification: ${user.email}, url: ${url}`);
 
   const content = resolveContent(
     await loadManifest(),


### PR DESCRIPTION
## What

Adds the verification `url` to the `sendEmailVerification` debug log line, so the verification link can be grabbed from logs during local development of the signup/verify flow.

```diff
- logger.debug(`sendEmailVerification: ${user.email}`);
+ logger.debug(`sendEmailVerification: ${user.email}, url: ${url}`);
```

## Note

This is `logger.debug` (off at normal log levels). The line logs `user.email` (already present before this change) and the verification `url`, which embeds the `verify` JWT token. Intended for local debugging only — ensure debug logging is **not** enabled in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
