### PR TITLE
feat(user): mirror account email onto person on registration

### DIFF
--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -299,12 +299,19 @@ export default async function userRoutes(
               `Person with ID ${personData.id} not found.`,
             );
           }
+          // Backfill the account email onto the person when it has none
+          // (cascade-saved with the user); never overwrite an existing value.
+          if (!resolvedPerson.email) {
+            resolvedPerson.email = email;
+          }
           request.resolvedPerson = resolvedPerson;
           return;
         }
 
-        // New person.
+        // New person. Mirror the account email onto the person so the person
+        // record carries the same email the user registered with.
         const newPerson = new Person(personData);
+        newPerson.email = email;
         const errors = await validate(newPerson);
         if (errors.length > 0) {
           logger.error(


### PR DESCRIPTION
## What

On `POST /user` registration, mirror the account email onto the linked `Person`:

- **New person** (no `id`): `person.email` is set to the registering `user.email`.
- **Existing person** (resolved by `id`): `person.email` is **backfilled** from `user.email` only when it's currently empty — an existing value is never overwritten.

## Why

Keeps the person record carrying the same email the user registered with, so person-side lookups/notifications have an address without depending on the linked `User`.

## Notes

- The existing-person update persists through the `cascade: true` on `User.person` when the new user is saved.
- `person.email` has `@IsEmail()` (optional) and validates fine since the body email is already a valid address; there's no unique constraint on `person.email`, so no collision risk.
- Behavioral shift: the existing-person path now may write to a person record that registration previously only read (only when its email was empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
