### PR TITLE
feat(agent): real DTO + schema for GET agent opportunity-linked

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.103",
+    "need4deed-sdk": "0.0.104",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/server/routes/agent/agent-opportunity.routes.ts
+++ b/src/server/routes/agent/agent-opportunity.routes.ts
@@ -1,7 +1,8 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { NotFoundError } from "../../../config";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
-import { idParamSchema } from "../../schema";
+import { dtoAgentOpportunity } from "../../../services";
+import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyData } from "../../types";
 import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 
@@ -9,16 +10,19 @@ export default async function agentOpportunityRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
 ) {
-  fastify.get<{ Params: ParamsId; Reply: ReplyData<Opportunity[]> }>(
+  fastify.get<{
+    Params: ParamsId;
+    // Handler sends entities; the DTO (ApiAgentOpportunity) runs in the
+    // preSerialization hook after PII masking.
+    Reply: ReplyData<Opportunity[]>;
+  }>(
     "/",
     {
       schema: {
         params: idParamSchema,
-        // TODO: add response schema!
+        response: responseSchema("ApiAgentOpportunity#", true, false),
       },
-      // No DTO yet (sends raw entities) — masking still applies to nested
-      // volunteer persons; identity passthrough keeps the shape.
-      preSerialization: makePiiSerialization((o: Opportunity) => o),
+      preSerialization: makePiiSerialization(dtoAgentOpportunity),
     },
     async (request, reply) => {
       const { id } = request.params;
@@ -30,8 +34,8 @@ export default async function agentOpportunityRoutes(
         throw new NotFoundError(`Agent (id:${id}) not found.`);
       }
 
-      // TODO: add DTO for agent profile
-
+      // DTO (dtoAgentOpportunity) runs in the preSerialization hook after PII
+      // masking of the nested volunteer persons.
       return reply.status(200).send({
         message: `Opportunities of the agent (id:${id})`,
         data: agent.opportunity,

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -740,6 +740,43 @@
         }
       ]
     },
+    "ApiAgentOpportunityVolunteer": {
+      "$id": "ApiAgentOpportunityVolunteer",
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "volunteerId": { "type": "integer" },
+        "status": { "$ref": "OpportunityVolunteerStatusType#" },
+        "name": { "type": "string" },
+        "avatarUrl": { "type": "string" }
+      },
+      "required": ["id", "volunteerId", "status"]
+    },
+    "ApiAgentOpportunity": {
+      "$id": "ApiAgentOpportunity",
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "title": { "type": "string" },
+        "statusOpportunity": { "$ref": "OpportunityStatusType#" },
+        "statusMatch": { "$ref": "OpportunityMatchStatusType#" },
+        "numberOfVolunteers": { "type": "integer" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "volunteers": {
+          "type": "array",
+          "items": { "$ref": "ApiAgentOpportunityVolunteer#" }
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "statusOpportunity",
+        "statusMatch",
+        "numberOfVolunteers",
+        "createdAt",
+        "volunteers"
+      ]
+    },
     "AgentType": {
       "$id": "AgentType",
       "type": "string",

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -3,11 +3,13 @@ import {
   ApiAgentGet,
   ApiAgentGetList,
   ApiAgentMembership,
+  ApiAgentOpportunity,
   ApiOpportunityAgent,
 } from "need4deed-sdk";
 import Comment from "../../data/entity/comment.entity";
 import AgentPerson from "../../data/entity/m2m/agent-person";
 import Agent from "../../data/entity/opportunity/agent.entity";
+import Opportunity from "../../data/entity/opportunity/opportunity.entity";
 import { serializeAddress } from "./dto-address";
 import { commentSerializer } from "./dto-comment";
 import { dtoSerializePerson } from "./dto-person";
@@ -93,5 +95,33 @@ function dtoAgentDetails(agent: Agent): AgentDetails {
         id: al.languageId,
         title: al.language?.title,
       })) || [],
+  };
+}
+
+/**
+ * One of an agent's opportunities plus the volunteers linked to it. Response
+ * item of GET /agent/:id/opportunity-linked. Expects the
+ * `opportunityVolunteer.volunteer.person` relation loaded; person PII is masked
+ * upstream by the route's preSerialization hook, so masked values pass through.
+ */
+export function dtoAgentOpportunity(
+  opportunity: Opportunity,
+): ApiAgentOpportunity {
+  return {
+    id: opportunity.id,
+    title: opportunity.title,
+    statusOpportunity: opportunity.status,
+    statusMatch: opportunity.statusMatch,
+    numberOfVolunteers: opportunity.numberVolunteers,
+    createdAt: opportunity.createdAt,
+    volunteers: (opportunity.opportunityVolunteer ?? [])
+      .filter(Boolean)
+      .map((ov) => ({
+        id: ov.id,
+        volunteerId: ov.volunteerId,
+        status: ov.status,
+        name: ov.volunteer?.person?.name,
+        avatarUrl: ov.volunteer?.person?.avatarUrl,
+      })),
   };
 }

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -4,6 +4,7 @@ import Agent from "../../../data/entity/opportunity/agent.entity";
 import {
   dtoAgentGet,
   dtoAgentGetList,
+  dtoAgentOpportunity,
   dtoOpportunityAgent,
 } from "../../../services";
 
@@ -179,5 +180,89 @@ describe("dtoAgentGetList", () => {
     // Ensure the mapping from agent.searchStatus to volunteerSearch is correct
     const result = dtoAgentGetList({ ...mockAgentBase } as any);
     expect(result.volunteerSearch).toBe(AgentVolunteerSearchType.SEARCHING);
+  });
+});
+
+describe("dtoAgentOpportunity", () => {
+  const baseOpportunity = {
+    id: 42,
+    title: "German tutoring",
+    status: "opp-active",
+    statusMatch: "opp-vol-matched",
+    numberVolunteers: 3,
+    createdAt: new Date("2026-01-15"),
+  };
+
+  it("maps the opportunity scalars and its linked volunteers", () => {
+    const opportunity = {
+      ...baseOpportunity,
+      opportunityVolunteer: [
+        {
+          id: 5,
+          volunteerId: 9,
+          status: "opp-matched",
+          volunteer: { person: { name: "Jane Doe", avatarUrl: "a.png" } },
+        },
+      ],
+    };
+
+    expect(dtoAgentOpportunity(opportunity as any)).toEqual({
+      id: 42,
+      title: "German tutoring",
+      statusOpportunity: "opp-active",
+      statusMatch: "opp-vol-matched",
+      numberOfVolunteers: 3,
+      createdAt: new Date("2026-01-15"),
+      volunteers: [
+        {
+          id: 5,
+          volunteerId: 9,
+          status: "opp-matched",
+          name: "Jane Doe",
+          avatarUrl: "a.png",
+        },
+      ],
+    });
+  });
+
+  it("passes through masked person fields verbatim", () => {
+    // The route masks person PII upstream; the DTO must not un-mask or drop it.
+    const opportunity = {
+      ...baseOpportunity,
+      opportunityVolunteer: [
+        {
+          id: 5,
+          volunteerId: 9,
+          status: "opp-matched",
+          volunteer: { person: { name: "x*** y***", avatarUrl: "z***" } },
+        },
+      ],
+    };
+
+    const { volunteers } = dtoAgentOpportunity(opportunity as any);
+    expect(volunteers[0].name).toBe("x*** y***");
+    expect(volunteers[0].avatarUrl).toBe("z***");
+  });
+
+  it("yields an empty volunteers array when none are linked", () => {
+    const result = dtoAgentOpportunity({
+      ...baseOpportunity,
+      opportunityVolunteer: undefined,
+    } as any);
+    expect(result.volunteers).toEqual([]);
+  });
+
+  it("tolerates a linked volunteer with no person loaded", () => {
+    const result = dtoAgentOpportunity({
+      ...baseOpportunity,
+      opportunityVolunteer: [{ id: 5, volunteerId: 9, status: "opp-pending" }],
+    } as any);
+    expect(result.volunteers[0]).toEqual({
+      id: 5,
+      volunteerId: 9,
+      status: "opp-pending",
+      name: undefined,
+      avatarUrl: undefined,
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.103:
-  version "0.0.103"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.103.tgz#836fa46e8cfe03288c7536f4e7b9c0b6a2f7a713"
-  integrity sha512-MdYk9AMWD0X5sOVYShQSRgwkbZm+GvoGi37O7xuwFkY+BQ6MbkuNK77wgFKm1x53sr62O4MWZQr6W+zrTDgr/Q==
+need4deed-sdk@0.0.104:
+  version "0.0.104"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.104.tgz#dc40993f8a47c38620669b4ada63bd3fe287327c"
+  integrity sha512-0aNx67Q91mTeL4Q0+kqpxYago7O+Zd7diBkOmWhL6yBa0MzJVCwAoEA5CfV3BsybRxPNw7lbyC8u4Qek3cAULA==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## What

Replaces the identity-passthrough on `GET /agent/:id/opportunity-linked` with a real DTO + response schema.

- `makePiiSerialization((o) => o)` → `makePiiSerialization(dtoAgentOpportunity)`
- adds `response: responseSchema("ApiAgentOpportunity#", true, false)`
- bumps `need4deed-sdk` 0.0.103 → 0.0.104 (the new `ApiAgentOpportunity` contract — need4deed-org/sdk#124)
- adds the `ApiAgentOpportunity` / `ApiAgentOpportunityVolunteer` defs to `sdk-types.json`
- `dtoAgentOpportunity` in `dto-agent.ts` + unit tests

## Why

Closes finding #2 from the #667 review: the endpoint previously had `// TODO: add response schema!` and sent the raw TypeORM entity. With no response schema, Fastify serialized the entire entity graph and relied solely on PII masking (which only scrubs Person/Address) — any other nested field was un-whitelisted. Now the wire shape is a defined, masked-aware contract.

## Behaviour

Unchanged data, narrower contract: each opportunity returns `id`, `title`, `statusOpportunity`, `statusMatch`, `numberOfVolunteers`, `createdAt`, and `volunteers[]` (`id`, `volunteerId`, `status`, masked `name`/`avatarUrl`). The relations already loaded (`opportunityVolunteer.volunteer.person`) are exactly what the DTO needs — no new queries. Masking still runs first in the hook, so the DTO reads already-masked persons.

## Tests

`dtoAgentOpportunity` unit tests (mapping, masked-passthrough, no-volunteers, no-person-loaded). Full suite green (304 + 4); server-boot tests confirm the new schema `$ref` registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
