### PR TITLE
feat(pii): mask accompanying + comments by caller visibility

### DIFF
--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -44,6 +44,7 @@ import logger from "../../../logger";
 import { volunteerSerializer } from "../../../services";
 import { tryCatch } from "../../../services/utils";
 import { maskPii } from "../pii/mask";
+import { CallerVisibility } from "../pii/visible-persons";
 
 export { getPostcode } from "../../../data/utils";
 
@@ -597,7 +598,7 @@ export async function fetchVolunteerById(
   id: number,
   isoCode: Lang,
   relations: string[],
-  maskVisiblePersonIds?: ReadonlySet<number> | null,
+  maskContext?: CallerVisibility | null,
 ): Promise<ApiVolunteerGet | null> {
   const volunteerRepository = getRepository(dataSource, Volunteer);
 
@@ -619,9 +620,9 @@ export async function fetchVolunteerById(
   // loaded separately (they aren't part of the volunteer graph), so they must be
   // masked too — otherwise comment authors' Person PII leaks to non-privileged
   // callers.
-  if (maskVisiblePersonIds) {
-    maskPii(volunteer, maskVisiblePersonIds);
-    maskPii(comments, maskVisiblePersonIds);
+  if (maskContext) {
+    maskPii(volunteer, maskContext);
+    maskPii(comments, maskContext);
   }
 
   const data = volunteerSerializer(volunteer, comments, timedEvents);

--- a/src/server/utils/pii/mask.ts
+++ b/src/server/utils/pii/mask.ts
@@ -1,5 +1,10 @@
+import { EntityTableName, UserRole } from "need4deed-sdk";
+import Comment from "../../../data/entity/comment.entity";
 import Address from "../../../data/entity/location/address.entity";
+import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
+import { CallerVisibility } from "./visible-persons";
 
 // PII columns masked for callers not permitted to see the owning Person.
 const PERSON_PII_FIELDS = [
@@ -12,6 +17,10 @@ const PERSON_PII_FIELDS = [
   "avatarUrl",
 ] as const;
 const ADDRESS_PII_FIELDS = ["title", "street", "city"] as const;
+// Refugee contact details carried as scalars on an opportunity's accompanying.
+const ACCOMPANYING_PII_FIELDS = ["name", "address", "phone", "email"] as const;
+// Free-text comment body (may name people / carry contact details).
+const COMMENT_PII_FIELDS = ["text"] as const;
 
 // A single random char + "***" — hides both the original value's length and its
 // first letter (so "John" -> e.g. "x***"), unlike a fixed "****".
@@ -31,55 +40,113 @@ function maskFields(
   }
 }
 
+// An entity whose comments/accompanying the caller may see unmasked.
+function isEntityVisible(
+  entityType: EntityTableName,
+  entityId: number,
+  ctx: CallerVisibility,
+): boolean {
+  switch (entityType) {
+    case EntityTableName.OPPORTUNITY:
+      return ctx.opportunityIds.has(entityId);
+    case EntityTableName.AGENT:
+      return ctx.agentIds.has(entityId);
+    default:
+      // VOLUNTEER and the rest: no inherited visibility (conservative).
+      return false;
+  }
+}
+
+// A comment is visible if the caller authored it, or its parent entity is
+// visible AND the author isn't a COORDINATOR/ADMIN (internal notes stay masked
+// even on an entity the caller owns).
+function isCommentVisible(comment: Comment, ctx: CallerVisibility): boolean {
+  if (comment.userId === ctx.userId) {
+    return true;
+  }
+  const authorRole = comment.user?.role;
+  if (authorRole === UserRole.COORDINATOR || authorRole === UserRole.ADMIN) {
+    return false;
+  }
+  return isEntityVisible(comment.entityType, comment.entityId, ctx);
+}
+
 /**
- * Masks PII (Person/Address) the caller may not see, in place, on the loaded
- * entity graph (run before the DTO). TypeORM returns class instances, so PII is
- * identified by `instanceof` — reference objects and all non-PII entities pass
- * through untouched (the walker still descends them to reach nested PII).
+ * Masks PII the caller may not see, in place, on the loaded entity graph (run
+ * before the DTO). TypeORM returns class instances, so PII is identified by
+ * `instanceof`; reference objects and non-PII entities pass through untouched
+ * (the walker still descends them to reach nested PII). A WeakSet guards the
+ * entity graph's cycles.
  *
- * A Person is visible iff its id is in `visiblePersonIds`; a Person's own
- * Address follows that visibility, and standalone Addresses (e.g. agent.address)
- * are masked. A WeakSet guards against the entity graph's cycles.
+ * Masked: a Person not in `personIds` (and its own Address); a standalone
+ * Address (e.g. agent.address); an Opportunity's accompanying when the
+ * opportunity isn't visible; a Comment that isn't visible (see isCommentVisible).
  */
-export function maskPii<T>(data: T, visiblePersonIds: ReadonlySet<number>): T {
-  walk(data, visiblePersonIds, new WeakSet<object>());
+export function maskPii<T>(data: T, ctx: CallerVisibility): T {
+  walk(data, ctx, new WeakSet<object>());
   return data;
 }
 
 function walk(
   node: unknown,
-  visible: ReadonlySet<number>,
+  ctx: CallerVisibility,
   seen: WeakSet<object>,
 ): void {
-  if (node === null || typeof node !== "object") {return;}
-  if (seen.has(node)) {return;}
+  if (node === null || typeof node !== "object") {
+    return;
+  }
+  if (seen.has(node)) {
+    return;
+  }
   seen.add(node);
 
   if (Array.isArray(node)) {
-    for (const item of node) {walk(item, visible, seen);}
+    for (const item of node) {
+      walk(item, ctx, seen);
+    }
     return;
   }
 
   if (node instanceof Person) {
-    const isVisible = visible.has(node.id);
-    if (!isVisible)
-      {maskFields(node as unknown as Record<string, unknown>, PERSON_PII_FIELDS);}
+    const isVisible = ctx.personIds.has(node.id);
+    if (!isVisible) {
+      maskFields(node as unknown as Record<string, unknown>, PERSON_PII_FIELDS);
+    }
     // Claim the person's own Address so the standalone-Address rule below can't
     // re-mask a visible person's address (and don't double-mask a hidden one).
     if (node.address && typeof node.address === "object") {
-      if (!isVisible)
-        {maskFields(
+      if (!isVisible) {
+        maskFields(
           node.address as unknown as Record<string, unknown>,
           ADDRESS_PII_FIELDS,
-        );}
+        );
+      }
       seen.add(node.address);
     }
   } else if (node instanceof Address) {
     // Reached not via a Person (e.g. agent.address) -> standalone PII, mask it.
     maskFields(node as unknown as Record<string, unknown>, ADDRESS_PII_FIELDS);
+  } else if (node instanceof Opportunity) {
+    // Accompanying (refugee contact) follows its opportunity's visibility.
+    if (
+      !ctx.opportunityIds.has(node.id) &&
+      node.accompanying instanceof Accompanying
+    ) {
+      maskFields(
+        node.accompanying as unknown as Record<string, unknown>,
+        ACCOMPANYING_PII_FIELDS,
+      );
+    }
+  } else if (node instanceof Comment) {
+    if (!isCommentVisible(node, ctx)) {
+      maskFields(
+        node as unknown as Record<string, unknown>,
+        COMMENT_PII_FIELDS,
+      );
+    }
   }
 
   for (const key of Object.keys(node)) {
-    walk((node as Record<string, unknown>)[key], visible, seen);
+    walk((node as Record<string, unknown>)[key], ctx, seen);
   }
 }

--- a/src/server/utils/pii/mask.ts
+++ b/src/server/utils/pii/mask.ts
@@ -64,7 +64,9 @@ function isCommentVisible(comment: Comment, ctx: CallerVisibility): boolean {
   if (comment.userId === ctx.userId) {
     return true;
   }
-  const authorRole = comment.user?.role;
+  // A missing author role defaults to USER (non-privileged) — entity visibility
+  // then decides.
+  const authorRole = comment.user?.role ?? UserRole.USER;
   if (authorRole === UserRole.COORDINATOR || authorRole === UserRole.ADMIN) {
     return false;
   }

--- a/src/server/utils/pii/pre-serialization.ts
+++ b/src/server/utils/pii/pre-serialization.ts
@@ -1,32 +1,32 @@
 import { FastifyReply, FastifyRequest } from "fastify";
 import { UserRole } from "need4deed-sdk";
 import { maskPii } from "./mask";
-import { resolveVisiblePersonIds } from "./visible-persons";
+import { CallerVisibility, resolveCallerVisibility } from "./visible-persons";
 
 type Envelope = { message?: string; data?: unknown; count?: number };
 
 /**
- * The set of person ids this caller may see UNMASKED, or `null` when no masking
- * applies (COORDINATOR/ADMIN or unauthenticated). For routes that build DTOs in
- * helpers — pass this through and `maskPii(entity, set)` before serializing.
+ * What this caller may see UNMASKED, or `null` when no masking applies
+ * (COORDINATOR/ADMIN or unauthenticated). For routes that build DTOs in
+ * helpers — pass this through and `maskPii(entity, ctx)` before serializing.
  */
 export async function resolveCallerMask(
   request: FastifyRequest,
-): Promise<ReadonlySet<number> | null> {
+): Promise<CallerVisibility | null> {
   const user = request.authUser;
   const privileged =
     user?.role === UserRole.COORDINATOR || user?.role === UserRole.ADMIN;
   if (!user || privileged) {
     return null;
   }
-  return resolveVisiblePersonIds(request.server, user);
+  return resolveCallerVisibility(request.server, user);
 }
 
 /**
- * Masks Person/Address the caller may not see, in place, on `data`. No-op for
- * COORDINATOR/ADMIN and unauthenticated requests. Use directly in handlers
- * whose DTO needs extra (handler-computed) args; otherwise prefer the
- * `makePiiSerialization` hook.
+ * Masks the PII the caller may not see (persons/addresses, an opportunity's
+ * accompanying, comments), in place, on `data`. No-op for COORDINATOR/ADMIN and
+ * unauthenticated requests. Use directly in handlers whose DTO needs extra
+ * (handler-computed) args; otherwise prefer the `makePiiSerialization` hook.
  */
 export async function maskForCaller(
   request: FastifyRequest,
@@ -35,17 +35,17 @@ export async function maskForCaller(
   if (data === null || data === undefined) {
     return;
   }
-  const visible = await resolveCallerMask(request);
-  if (visible) {
-    maskPii(data, visible);
+  const visibility = await resolveCallerMask(request);
+  if (visibility) {
+    maskPii(data, visibility);
   }
 }
 
 /**
  * Per-route `preSerialization` hook. The handler sends the loaded entity graph
- * as `data`; this masks Person/Address the caller may not see, then runs the
- * route's DTO. COORDINATOR/ADMIN (and unauthenticated/error payloads) pass
- * through untouched. List vs single is detected from `data`.
+ * as `data`; this masks the PII the caller may not see, then runs the route's
+ * DTO. COORDINATOR/ADMIN (and unauthenticated/error payloads) pass through
+ * untouched. List vs single is detected from `data`.
  */
 export function makePiiSerialization<TEntity, TDto>(
   dto: (entity: TEntity) => TDto,

--- a/src/server/utils/pii/visible-persons.ts
+++ b/src/server/utils/pii/visible-persons.ts
@@ -4,49 +4,96 @@ import { In } from "typeorm";
 import User from "../../../data/entity/user.entity";
 
 /**
- * Person ids the caller may see UNMASKED (non COORDINATOR/ADMIN):
- *   USER      -> none
- *   VOLUNTEER -> own person
- *   AGENT     -> own ∪ members of their agent(s) ∪ persons of volunteers on
- *                opportunities owned by their agent(s)
- * Only the AGENT branch hits the DB; resolved per request, masking-side only.
+ * What a non COORDINATOR/ADMIN caller may see UNMASKED, resolved per request
+ * (masking-side only). Drives PII masking of persons, an opportunity's
+ * accompanying details, and comments.
+ *
+ *   userId         the caller's user id (a comment they authored is unmasked)
+ *   personIds      Person ids whose PII is visible
+ *   opportunityIds Opportunities whose accompanying + comments are visible
+ *   agentIds       Agents whose comments are visible (caller's memberships)
+ *
+ * Per role:
+ *   USER      -> nothing
+ *   VOLUNTEER -> own person; opportunities they're matched to
+ *   AGENT     -> own person ∪ members of their agent(s) ∪ persons of volunteers
+ *                on their opportunities; their agent(s); their opportunities
  */
-export async function resolveVisiblePersonIds(
+export interface CallerVisibility {
+  userId: number;
+  personIds: Set<number>;
+  opportunityIds: Set<number>;
+  agentIds: Set<number>;
+}
+
+export async function resolveCallerVisibility(
   fastify: FastifyInstance,
   user: User,
-): Promise<Set<number>> {
-  const visible = new Set<number>();
+): Promise<CallerVisibility> {
+  const visibility: CallerVisibility = {
+    userId: user.id,
+    personIds: new Set<number>(),
+    opportunityIds: new Set<number>(),
+    agentIds: new Set<number>(),
+  };
+  const { personIds, opportunityIds, agentIds } = visibility;
   const personId = user.personId ?? undefined;
 
   // USER sees only reference data; a missing personId can't match anything.
-  if (user.role === UserRole.USER || !personId) {return visible;}
+  if (user.role === UserRole.USER || !personId) {
+    return visibility;
+  }
 
-  visible.add(personId); // VOLUNTEER + AGENT see their own person
+  personIds.add(personId); // VOLUNTEER + AGENT see their own person
 
-  if (user.role !== UserRole.AGENT) {return visible;}
+  if (user.role === UserRole.VOLUNTEER) {
+    // Opportunities the caller is matched to (own person -> volunteer -> match).
+    const rows: { opportunity_id: number }[] =
+      await fastify.db.agentPersonRepository.manager.query(
+        `SELECT ov.opportunity_id
+           FROM opportunity_volunteer ov
+           JOIN volunteer v ON v.id = ov.volunteer_id
+          WHERE v.person_id = $1`,
+        [personId],
+      );
+    rows.forEach((r) => opportunityIds.add(Number(r.opportunity_id)));
+    return visibility;
+  }
+
+  if (user.role !== UserRole.AGENT) {
+    return visibility;
+  }
 
   const agentPersonRepository = fastify.db.agentPersonRepository;
   const memberships = await agentPersonRepository.find({ where: { personId } });
-  const agentIds = memberships.map((m) => m.agentId);
-  if (agentIds.length === 0) {return visible;}
+  memberships.forEach((m) => agentIds.add(m.agentId));
+  if (agentIds.size === 0) {
+    return visibility;
+  }
 
   // Members of the caller's agent(s).
   const members = await agentPersonRepository.find({
-    where: { agentId: In(agentIds) },
+    where: { agentId: In([...agentIds]) },
   });
-  members.forEach((m) => visible.add(m.personId));
+  members.forEach((m) => personIds.add(m.personId));
 
-  // Persons of volunteers on opportunities owned by the caller's agent(s).
-  const rows: { person_id: number }[] =
+  // Opportunities owned by the caller's agent(s), plus the persons of the
+  // volunteers matched to them (an agent member sees those volunteers).
+  const rows: { id: number; person_id: number | null }[] =
     await agentPersonRepository.manager.query(
-      `SELECT DISTINCT v.person_id
-       FROM opportunity o
-       JOIN opportunity_volunteer ov ON ov.opportunity_id = o.id
-       JOIN volunteer v ON v.id = ov.volunteer_id
-      WHERE o.agent_id = ANY($1) AND v.person_id IS NOT NULL`,
-      [agentIds],
+      `SELECT o.id, v.person_id
+         FROM opportunity o
+         LEFT JOIN opportunity_volunteer ov ON ov.opportunity_id = o.id
+         LEFT JOIN volunteer v ON v.id = ov.volunteer_id
+        WHERE o.agent_id = ANY($1)`,
+      [[...agentIds]],
     );
-  rows.forEach((r) => visible.add(Number(r.person_id)));
+  rows.forEach((r) => {
+    opportunityIds.add(Number(r.id));
+    if (r.person_id !== null) {
+      personIds.add(Number(r.person_id));
+    }
+  });
 
-  return visible;
+  return visibility;
 }

--- a/src/test/server/utils/pii/mask.test.ts
+++ b/src/test/server/utils/pii/mask.test.ts
@@ -1,9 +1,29 @@
+import { EntityTableName, UserRole } from "need4deed-sdk";
 import { describe, expect, it } from "vitest";
+import Comment from "../../../../data/entity/comment.entity";
 import Address from "../../../../data/entity/location/address.entity";
+import Accompanying from "../../../../data/entity/opportunity/accompanying.entity";
+import Opportunity from "../../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../../data/entity/person.entity";
 import { maskPii, maskString } from "../../../../server/utils/pii/mask";
+import { CallerVisibility } from "../../../../server/utils/pii/visible-persons";
 
 const MASKED = /^[a-z]\*\*\*$/;
+
+// Build a CallerVisibility from the few fields a given test cares about.
+const ctx = (
+  p: Partial<{
+    userId: number;
+    personIds: number[];
+    opportunityIds: number[];
+    agentIds: number[];
+  }> = {},
+): CallerVisibility => ({
+  userId: p.userId ?? 0,
+  personIds: new Set(p.personIds ?? []),
+  opportunityIds: new Set(p.opportunityIds ?? []),
+  agentIds: new Set(p.agentIds ?? []),
+});
 
 const makePerson = (id: number): Person =>
   Object.assign(new Person(), {
@@ -16,6 +36,25 @@ const makePerson = (id: number): Person =>
 const makeAddress = (street: string): Address =>
   Object.assign(new Address(), { street, city: "Berlin" });
 
+const makeAccompanying = (): Accompanying =>
+  Object.assign(new Accompanying(), {
+    name: "Refugee Name",
+    address: "Hidden St 5",
+    phone: "+49 30 111",
+    email: "refugee@example.de",
+  });
+
+const makeComment = (over: Partial<Comment> = {}): Comment =>
+  Object.assign(new Comment(), {
+    id: 1,
+    text: "internal note about someone",
+    userId: 9,
+    entityType: EntityTableName.OPPORTUNITY,
+    entityId: 5,
+    user: { role: UserRole.AGENT },
+    ...over,
+  });
+
 describe("maskString", () => {
   it("returns a random char + '***' (hides length and first letter)", () => {
     expect(maskString()).toMatch(MASKED);
@@ -25,7 +64,7 @@ describe("maskString", () => {
 describe("maskPii", () => {
   it("masks a Person not in the visible set", () => {
     const p = makePerson(2);
-    maskPii(p, new Set([1]));
+    maskPii(p, ctx({ personIds: [1] }));
     expect(p.firstName).toMatch(MASKED);
     expect(p.lastName).toMatch(MASKED);
     expect(p.email).toMatch(MASKED);
@@ -33,7 +72,7 @@ describe("maskPii", () => {
 
   it("leaves a visible Person untouched", () => {
     const p = makePerson(1);
-    maskPii(p, new Set([1]));
+    maskPii(p, ctx({ personIds: [1] }));
     expect(p.firstName).toBe("John");
     expect(p.email).toBe("john@example.de");
   });
@@ -44,7 +83,7 @@ describe("maskPii", () => {
     const visible = makePerson(1);
     visible.address = makeAddress("Side 2");
 
-    maskPii([hidden, visible], new Set([1]));
+    maskPii([hidden, visible], ctx({ personIds: [1] }));
 
     expect(hidden.address.street).toMatch(MASKED);
     expect(visible.address.street).toBe("Side 2");
@@ -56,7 +95,7 @@ describe("maskPii", () => {
       title: "Center",
       address: makeAddress("Haupt 3"),
     };
-    maskPii(agentLike, new Set([1]));
+    maskPii(agentLike, ctx({ personIds: [1] }));
     expect(agentLike.address.street).toMatch(MASKED);
     expect(agentLike.title).toBe("Center");
   });
@@ -67,7 +106,7 @@ describe("maskPii", () => {
       district: { id: 3, title: "Mitte" },
       volunteers: [{ id: 9, person: makePerson(2) }],
     };
-    maskPii(graph, new Set());
+    maskPii(graph, ctx());
     expect(graph.district.title).toBe("Mitte");
     expect(graph.volunteers[0].person.firstName).toMatch(MASKED);
   });
@@ -76,7 +115,80 @@ describe("maskPii", () => {
     const p = makePerson(2);
     const wrapper: { person: Person; self?: unknown } = { person: p };
     (p as unknown as { back: unknown }).back = wrapper; // introduce a cycle
-    expect(() => maskPii(wrapper, new Set([1]))).not.toThrow();
+    expect(() => maskPii(wrapper, ctx({ personIds: [1] }))).not.toThrow();
     expect(p.firstName).toMatch(MASKED);
+  });
+
+  describe("accompanying", () => {
+    it("masks an opportunity's accompanying when the opportunity isn't visible", () => {
+      const opp = Object.assign(new Opportunity(), {
+        id: 5,
+        accompanying: makeAccompanying(),
+      });
+      maskPii(opp, ctx({ opportunityIds: [] }));
+      expect(opp.accompanying!.name).toMatch(MASKED);
+      expect(opp.accompanying!.address).toMatch(MASKED);
+      expect(opp.accompanying!.phone).toMatch(MASKED);
+      expect(opp.accompanying!.email).toMatch(MASKED);
+    });
+
+    it("leaves accompanying when the opportunity is visible", () => {
+      const opp = Object.assign(new Opportunity(), {
+        id: 5,
+        accompanying: makeAccompanying(),
+      });
+      maskPii(opp, ctx({ opportunityIds: [5] }));
+      expect(opp.accompanying!.name).toBe("Refugee Name");
+      expect(opp.accompanying!.address).toBe("Hidden St 5");
+    });
+  });
+
+  describe("comments", () => {
+    it("masks a comment whose parent entity isn't visible and the caller didn't author", () => {
+      const c = makeComment();
+      maskPii(c, ctx({ userId: 1, opportunityIds: [] }));
+      expect(c.text).toMatch(MASKED);
+    });
+
+    it("leaves a comment on a visible opportunity authored by a non-coordinator", () => {
+      const c = makeComment({ user: { role: UserRole.AGENT } as never });
+      maskPii(c, ctx({ userId: 1, opportunityIds: [5] }));
+      expect(c.text).toBe("internal note about someone");
+    });
+
+    it("masks a COORDINATOR-authored comment even on a visible opportunity", () => {
+      const c = makeComment({ user: { role: UserRole.COORDINATOR } as never });
+      maskPii(c, ctx({ userId: 1, opportunityIds: [5] }));
+      expect(c.text).toMatch(MASKED);
+    });
+
+    it("leaves a comment the caller authored, regardless of entity visibility", () => {
+      const c = makeComment({
+        userId: 7,
+        user: { role: UserRole.COORDINATOR } as never,
+      });
+      maskPii(c, ctx({ userId: 7, opportunityIds: [] }));
+      expect(c.text).toBe("internal note about someone");
+    });
+
+    it("leaves a comment on a visible agent entity", () => {
+      const c = makeComment({
+        entityType: EntityTableName.AGENT,
+        entityId: 3,
+        user: { role: UserRole.AGENT } as never,
+      });
+      maskPii(c, ctx({ userId: 1, agentIds: [3] }));
+      expect(c.text).toBe("internal note about someone");
+    });
+
+    it("masks a comment on a non-opportunity/agent entity (conservative)", () => {
+      const c = makeComment({
+        entityType: EntityTableName.VOLUNTEER,
+        entityId: 3,
+        user: { role: UserRole.AGENT } as never,
+      });
+      maskPii(c, ctx({ userId: 1, opportunityIds: [5], agentIds: [3] }));
+      expect(c.text).toMatch(MASKED);
+    });
   });
 });

--- a/src/test/server/utils/pii/mask.test.ts
+++ b/src/test/server/utils/pii/mask.test.ts
@@ -181,6 +181,16 @@ describe("maskPii", () => {
       expect(c.text).toBe("internal note about someone");
     });
 
+    it("defaults a missing author role to USER, so entity visibility decides", () => {
+      const visibleParent = makeComment({ user: undefined });
+      maskPii(visibleParent, ctx({ userId: 1, opportunityIds: [5] }));
+      expect(visibleParent.text).toBe("internal note about someone");
+
+      const hiddenParent = makeComment({ user: undefined });
+      maskPii(hiddenParent, ctx({ userId: 1, opportunityIds: [] }));
+      expect(hiddenParent.text).toMatch(MASKED);
+    });
+
     it("masks a comment on a non-opportunity/agent entity (conservative)", () => {
       const c = makeComment({
         entityType: EntityTableName.VOLUNTEER,

--- a/src/test/server/utils/pii/visible-persons.test.ts
+++ b/src/test/server/utils/pii/visible-persons.test.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { UserRole } from "need4deed-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type User from "../../../../data/entity/user.entity";
-import { resolveVisiblePersonIds } from "../../../../server/utils/pii/visible-persons";
+import { resolveCallerVisibility } from "../../../../server/utils/pii/visible-persons";
 
 const find = vi.fn();
 const query = vi.fn();
@@ -11,99 +11,96 @@ const fastify = {
   db: { agentPersonRepository: { find, manager: { query } } },
 } as unknown as FastifyInstance;
 
-const makeUser = (role: UserRole, personId: number | null = 1): User =>
-  ({ id: 100, role, personId }) as unknown as User;
+const makeUser = (
+  role: UserRole,
+  personId: number | null = 1,
+  id = 100,
+): User => ({ id, role, personId }) as unknown as User;
+
+const sorted = (s: Set<number>) => [...s].sort((a, b) => a - b);
 
 beforeEach(() => {
   vi.resetAllMocks();
 });
 
-describe("resolveVisiblePersonIds", () => {
-  it("returns an empty set for USER (reference data only), no DB calls", async () => {
-    const visible = await resolveVisiblePersonIds(
-      fastify,
-      makeUser(UserRole.USER),
-    );
-    expect([...visible]).toEqual([]);
+describe("resolveCallerVisibility", () => {
+  it("returns empty sets (just the caller userId) for USER, no DB calls", async () => {
+    const v = await resolveCallerVisibility(fastify, makeUser(UserRole.USER));
+    expect(v.userId).toBe(100);
+    expect([...v.personIds]).toEqual([]);
+    expect([...v.opportunityIds]).toEqual([]);
+    expect([...v.agentIds]).toEqual([]);
     expect(find).not.toHaveBeenCalled();
     expect(query).not.toHaveBeenCalled();
   });
 
-  it("returns an empty set when the caller has no personId", async () => {
-    const visible = await resolveVisiblePersonIds(
+  it("returns empty when the caller has no personId", async () => {
+    const v = await resolveCallerVisibility(
       fastify,
       makeUser(UserRole.VOLUNTEER, null),
     );
-    expect([...visible]).toEqual([]);
+    expect([...v.personIds]).toEqual([]);
     expect(find).not.toHaveBeenCalled();
   });
 
-  it("returns only the own person for VOLUNTEER, no DB calls", async () => {
-    const visible = await resolveVisiblePersonIds(
-      fastify,
-      makeUser(UserRole.VOLUNTEER, 7),
-    );
-    expect([...visible]).toEqual([7]);
-    expect(find).not.toHaveBeenCalled();
-    expect(query).not.toHaveBeenCalled();
+  describe("VOLUNTEER", () => {
+    it("sees own person and the opportunities they're matched to", async () => {
+      query.mockResolvedValueOnce([
+        { opportunity_id: 11 },
+        { opportunity_id: 12 },
+      ]);
+
+      const v = await resolveCallerVisibility(
+        fastify,
+        makeUser(UserRole.VOLUNTEER, 7),
+      );
+
+      expect([...v.personIds]).toEqual([7]);
+      expect(sorted(v.opportunityIds)).toEqual([11, 12]);
+      expect([...v.agentIds]).toEqual([]);
+      expect(query.mock.calls[0][1]).toEqual([7]); // matched by own person id
+      expect(find).not.toHaveBeenCalled();
+    });
   });
 
-  describe("AGENT branch", () => {
-    it("returns own ∪ members ∪ volunteers on the agent's opportunities", async () => {
-      // 1st find: caller's memberships -> agent ids
-      find.mockResolvedValueOnce([
-        { agentId: 42, personId: 1 },
-        { agentId: 43, personId: 1 },
+  describe("AGENT", () => {
+    it("sees own ∪ members ∪ matched volunteers' persons, plus their agents + opportunities", async () => {
+      find.mockResolvedValueOnce([{ agentId: 42 }, { agentId: 43 }]); // memberships
+      find.mockResolvedValueOnce([{ personId: 1 }, { personId: 2 }]); // members
+      query.mockResolvedValueOnce([
+        { id: 100, person_id: 8 },
+        { id: 100, person_id: null }, // opportunity with no matched volunteer
+        { id: 101, person_id: 9 },
       ]);
-      // 2nd find: members of those agents
-      find.mockResolvedValueOnce([
-        { agentId: 42, personId: 1 },
-        { agentId: 42, personId: 2 },
-        { agentId: 43, personId: 3 },
-      ]);
-      // raw SQL: persons of volunteers on the agents' opportunities
-      query.mockResolvedValueOnce([{ person_id: 8 }, { person_id: 9 }]);
 
-      const visible = await resolveVisiblePersonIds(
+      const v = await resolveCallerVisibility(
         fastify,
         makeUser(UserRole.AGENT, 1),
       );
 
-      expect([...visible].sort((a, b) => a - b)).toEqual([1, 2, 3, 8, 9]);
-
-      // member lookup is scoped to the caller's agent ids
+      expect(sorted(v.agentIds)).toEqual([42, 43]);
+      expect(sorted(v.personIds)).toEqual([1, 2, 8, 9]);
+      expect(sorted(v.opportunityIds)).toEqual([100, 101]);
+      // member lookup scoped to the caller's agent ids; raw query gets them too
       expect(find).toHaveBeenNthCalledWith(2, {
         where: { agentId: expect.anything() },
       });
-      // raw SQL receives the agent ids array as its only parameter
       expect(query.mock.calls[0][1]).toEqual([[42, 43]]);
     });
 
-    it("returns only the own person when the AGENT has no memberships", async () => {
+    it("stops at own person when the AGENT has no memberships", async () => {
       find.mockResolvedValueOnce([]); // no memberships
 
-      const visible = await resolveVisiblePersonIds(
+      const v = await resolveCallerVisibility(
         fastify,
         makeUser(UserRole.AGENT, 5),
       );
 
-      expect([...visible]).toEqual([5]);
+      expect([...v.personIds]).toEqual([5]);
+      expect([...v.agentIds]).toEqual([]);
+      expect([...v.opportunityIds]).toEqual([]);
       expect(find).toHaveBeenCalledTimes(1); // no member lookup
-      expect(query).not.toHaveBeenCalled(); // no raw SQL
-    });
-
-    it("coerces raw SQL person_id values to numbers", async () => {
-      find.mockResolvedValueOnce([{ agentId: 42, personId: 1 }]);
-      find.mockResolvedValueOnce([{ agentId: 42, personId: 1 }]);
-      query.mockResolvedValueOnce([{ person_id: "8" }]); // string from pg
-
-      const visible = await resolveVisiblePersonIds(
-        fastify,
-        makeUser(UserRole.AGENT, 1),
-      );
-
-      expect(visible.has(8)).toBe(true);
-      expect(visible.has("8" as unknown as number)).toBe(false);
+      expect(query).not.toHaveBeenCalled(); // no opportunity query
     });
   });
 });


### PR DESCRIPTION
## What

Extends the PII masker from "visible person ids" to a richer **CallerVisibility** context (`personIds` + `opportunityIds` + `agentIds` + `userId`), and masks two PII scalars that previously slipped through to non-privileged callers:

- **`Accompanying`** (refugee `name`/`address`/`phone`/`email`) — masked unless the caller can see the linked **opportunity**.
- **`Comment.text`** — masked unless the caller **authored** it, or its parent `(entityType, entityId)` is visible **and** the author isn't a COORDINATOR/ADMIN (internal notes stay masked even on an entity the caller owns).

## Visibility model (non-privileged roles)

| role | sees unmasked |
|---|---|
| USER | nothing |
| VOLUNTEER | own person; opportunities they're **matched** to |
| AGENT | own person ∪ agent members ∪ persons of volunteers on their opportunities; their agent(s); their opportunities |

This covers the rule that a volunteer is unmasked to an agent-member user whose agent is the parent of a matched opportunity (the AGENT branch already adds those volunteers' persons).

## How

- `resolveVisiblePersonIds` → `resolveCallerVisibility` (returns the full context; one extra LEFT JOIN captures the agent's opportunity ids alongside the volunteer person ids it already computed; VOLUNTEER gets one matched-opportunities query).
- `maskPii(data, ctx)` gains `Opportunity`→accompanying and `Comment` branches (`isEntityVisible` / `isCommentVisible`). Person/Address behaviour unchanged.
- `resolveCallerMask` / `maskForCaller` / `makePiiSerialization` / `fetchVolunteerById` thread the context through.

Comment author role is available in both comment-loading paths (`addComments2Entity` loads `user.person`; `getVolunteerComments` loads `user`).

## Decisions (confirmed)

- Entity visibility = AGENT-owns **or** VOLUNTEER-matched.
- Coordinator/admin-authored comments stay masked even on a visible entity.
- Non-opportunity/non-agent comment parents (e.g. VOLUNTEER) are conservatively treated as not visible → masked unless self-authored.

## Tests

`mask.test.ts` (+ accompanying + comment cases, 15 total) and `visible-persons.test.ts` (rewritten for `resolveCallerVisibility`: USER/VOLUNTEER/AGENT branches). Full suite green (315).

Relates to #666 / follow-up of #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
