### PR TITLE
feat(agent): reuse getAgentByAddress picker in self-registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.104",
+    "need4deed-sdk": "0.0.105",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/server/routes/agent/register.routes.ts
+++ b/src/server/routes/agent/register.routes.ts
@@ -22,8 +22,10 @@ import {
   responseErrors,
 } from "../../schema";
 import {
+  AgentAddressConflictError,
   classifyRegisterAgentConflict,
   createAgentForPerson,
+  getAgentByAddress,
   joinAgent,
   resolveJoinStatus,
 } from "../../utils";
@@ -72,7 +74,9 @@ export default async function agentRegisterRoutes(
   // GET /agent/register/search?token=&street= — minimal agent lookup for the
   // self-registration picker, so a registrant can JOIN their org instead of
   // creating a duplicate. Token-gated (not the COORDINATOR-only GET /agent).
-  fastify.get<{ Querystring: { token: string; street?: string } }>(
+  fastify.get<{
+    Querystring: { token: string; street?: string; postcode?: string };
+  }>(
     "/search",
     {
       config: { public: true } as FastifyContextConfig,
@@ -85,36 +89,35 @@ export default async function agentRegisterRoutes(
     },
     async (request, reply) => {
       const street = (request.query.street ?? "").trim();
+      const postcode = (request.query.postcode ?? "").trim();
       const domain = request.registrant?.email.split("@").pop()?.toLowerCase();
-      if (street.length < 3 || !domain) {
+      if (street.length < 3 || !postcode || !domain) {
         return reply.status(200).send({ message: "No query", data: [] });
       }
 
-      // Only surface agents the registrant is tied to by email domain — i.e.
-      // an existing member shares their domain (Person.email, falling back to
-      // the linked User.email). This keeps the picker to orgs they can join and
-      // narrows enumeration. Mirrors resolveJoinStatus, so a picked agent
-      // auto-approves to ACTIVE.
-      const rows = await fastify.db.agentRepository
+      // Candidates: only agents the registrant is tied to by email domain — an
+      // existing member shares their domain (Person.email, falling back to the
+      // linked User.email). Keeps the picker to orgs they can join (mirrors
+      // resolveJoinStatus, so a picked agent auto-approves to ACTIVE) and
+      // narrows enumeration. Load the relations getAgentByAddress reads.
+      const candidates = await fastify.db.agentRepository
         .createQueryBuilder("agent")
-        .select("agent.id", "id")
-        .addSelect("agent.title", "title")
-        .distinct(true)
-        .innerJoin("agent.address", "address")
+        .leftJoinAndSelect("agent.address", "address")
+        .leftJoinAndSelect("address.postcode", "postcode")
+        .leftJoinAndSelect("agent.agentPostcode", "agentPostcode")
+        .leftJoinAndSelect("agentPostcode.postcode", "agentPostcodePostcode")
         .innerJoin("agent.agentPerson", "ap")
         .innerJoin("ap.person", "person")
         .leftJoin("person.users", "usr")
-        .where("address.street ILIKE :street", { street: `%${street}%` })
-        .andWhere("(person.email ILIKE :suffix OR usr.email ILIKE :suffix)", {
+        .where("(person.email ILIKE :suffix OR usr.email ILIKE :suffix)", {
           suffix: `%@${domain}`,
         })
-        .limit(10)
-        .getRawMany<{ id: number; title: string }>();
+        .getMany();
 
-      const data = rows.map((row) => ({
-        id: Number(row.id),
-        title: row.title,
-      }));
+      // Reuse the POST /opportunity/legacy picker (strict street+PLZ, then fuzzy
+      // street-name) — returns the single best match (or none).
+      const match = getAgentByAddress(candidates, street, postcode);
+      const data = match ? [{ id: match.id, title: match.title }] : [];
       return reply
         .status(200)
         .send({ message: `Found ${data.length} matches`, data });
@@ -170,6 +173,13 @@ export default async function agentRegisterRoutes(
 
         return reply.status(201).send({ message, data: result });
       } catch (err) {
+        if (err instanceof AgentAddressConflictError) {
+          return reply.status(409).send({
+            message: "An agent at this address already exists.",
+            conflict: "address",
+            agentId: err.agentId,
+          });
+        }
         if (classifyRegisterAgentConflict(err) === "title") {
           const title = "agent" in body ? body.agent.title : undefined;
           const existing = title

--- a/src/server/schema/agent-register.schema.ts
+++ b/src/server/schema/agent-register.schema.ts
@@ -26,6 +26,7 @@ export const registerSearchQuerySchema = {
   properties: {
     token: { type: "string", minLength: 1 },
     street: { type: "string" },
+    postcode: { type: "string" },
   },
 };
 
@@ -109,14 +110,15 @@ export const registerAgentResponseSchema = {
   },
 };
 
-// 409 on CREATE when the title is taken — carries the existing agent id so the
-// client can offer to JOIN instead. Overrides the generic 409 in responseErrors.
+// 409 on CREATE when the title is taken (`title`) or the street+postcode
+// already resolve to an existing agent (`address`) — carries that agent's id so
+// the client can offer to JOIN instead. Overrides the generic 409.
 export const registerAgentConflictSchema = {
   type: "object",
   required: ["message", "conflict"],
   properties: {
     message: { type: "string" },
-    conflict: { type: "string", enum: ["title"] },
+    conflict: { type: "string", enum: ["title", "address"] },
     agentId: { type: "integer" },
   },
 };

--- a/src/server/utils/data/write-agent-registration.ts
+++ b/src/server/utils/data/write-agent-registration.ts
@@ -8,10 +8,23 @@ import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import { createAddress } from "./for-routes";
+import { getAgentByAddress } from "./get-agent-by-postcode";
 
 export interface RegisterAgentResult {
   agentId: number;
   membershipStatus: AgentMembershipStatus;
+}
+
+/**
+ * Raised by createAgentForPerson when the street+postcode already match an
+ * existing agent (via the same getAgentByAddress picker POST /opportunity/legacy
+ * uses). The route maps it to a 409 + agentId so the client can offer JOIN.
+ */
+export class AgentAddressConflictError extends Error {
+  constructor(public readonly agentId: number) {
+    super("An agent at this address already exists.");
+    this.name = "AgentAddressConflictError";
+  }
 }
 
 /**
@@ -30,6 +43,23 @@ export async function createAgentForPerson(
   personId: number,
   input: ApiAgentRegisterNew,
 ): Promise<RegisterAgentResult> {
+  // Dedup: if the street+postcode already resolve to an existing agent (same
+  // picker POST /opportunity/legacy uses), don't mint a duplicate — surface it
+  // so the client can offer JOIN instead.
+  if (input.addressStreet && input.addressPostcode) {
+    const agents = await dataSource.getRepository(Agent).find({
+      relations: ["address.postcode", "agentPostcode.postcode"],
+    });
+    const match = getAgentByAddress(
+      agents,
+      input.addressStreet,
+      input.addressPostcode,
+    );
+    if (match) {
+      throw new AgentAddressConflictError(match.id);
+    }
+  }
+
   let result!: RegisterAgentResult;
 
   await dataSource.manager.transaction(async (manager) => {

--- a/src/test/server/utils/data/write-agent-registration.test.ts
+++ b/src/test/server/utils/data/write-agent-registration.test.ts
@@ -4,6 +4,7 @@ import AgentLanguage from "../../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../../data/entity/m2m/agent-person";
 import Agent from "../../../../data/entity/opportunity/agent.entity";
 import {
+  AgentAddressConflictError,
   classifyRegisterAgentConflict,
   createAgentForPerson,
   joinAgent,
@@ -51,6 +52,10 @@ beforeEach(() => {
     }
   });
 
+  // Default: the address-dedup lookup (dataSource.getRepository(Agent).find)
+  // finds no existing agent, so createAgentForPerson proceeds to create.
+  agentPersonRepoFind.mockResolvedValue([]);
+
   agentSave.mockImplementation(async (a: any) => ({ ...a, id: 33 }));
   agentPersonSave.mockImplementation(async (ap: any) => ({ ...ap, id: 44 }));
   agentLanguageSave.mockImplementation(async (rows: any[]) => rows);
@@ -97,6 +102,30 @@ describe("createAgentForPerson", () => {
       txnManager,
     );
     expect(agentSave.mock.calls[0][0].addressId).toBe(99);
+  });
+
+  it("throws AgentAddressConflictError (no create) when street+postcode match an existing agent", async () => {
+    // The dedup lookup finds an agent at the same address (getAgentByAddress
+    // strict match on normalized street + postcode).
+    agentPersonRepoFind.mockResolvedValueOnce([
+      {
+        id: 77,
+        address: {
+          street: "Bitterfelder Str 11",
+          postcode: { value: "12681" },
+        },
+      },
+    ]);
+
+    const err = await createAgentForPerson(11, {
+      title: "Centre HERO",
+      addressStreet: "Bitterfelder Str 11",
+      addressPostcode: "12681",
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AgentAddressConflictError);
+    expect(err.agentId).toBe(77);
+    expect(agentSave).not.toHaveBeenCalled();
   });
 
   it("skips Address when only street or only postcode is given", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.104:
-  version "0.0.104"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.104.tgz#dc40993f8a47c38620669b4ada63bd3fe287327c"
-  integrity sha512-0aNx67Q91mTeL4Q0+kqpxYago7O+Zd7diBkOmWhL6yBa0MzJVCwAoEA5CfV3BsybRxPNw7lbyC8u4Qek3cAULA==
+need4deed-sdk@0.0.105:
+  version "0.0.105"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.105.tgz#3333641f4319c54b4b756f2503fdcb2094f0f958"
+  integrity sha512-cyyJVg7ZhkbATgqhfHbwcVmUktmZYqQyBEPHOFDLN+odwrTSCvx+1HuIUghUwxTuIvG06j4rZQuUJVIBLY+QqA==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## What

Reuses the `POST /opportunity/legacy` agent picker (`getAgentByAddress` — strict normalized street + PLZ, then fuzzy street-name-in-title with house-number consistency) across **both** agent-picking surfaces of the self-registration flow (#591/#601), replacing the naive `street ILIKE`.

### 1. `GET /agent/register/search`
- New `postcode` query param (alongside `street`).
- Loads the **domain-scoped** candidate agents (member shares the registrant's email domain — unchanged) with the relations the matcher reads, then runs `getAgentByAddress`.
- Returns the **single best match** (or none) — same picker semantics as legacy.

### 2. `POST /agent/register` (CREATE)
- `createAgentForPerson` now **dedups before creating**: if `addressStreet`+`addressPostcode` already resolve to an existing agent, it throws `AgentAddressConflictError`, which the route maps to **409 + `agentId`** (`conflict: "address"`) so the client can offer to JOIN. This is the dedup #591 deferred.

## Contract

- `registerSearchQuerySchema` gains `postcode`; `registerAgentConflictSchema.conflict` enum gains `"address"`.
- SDK: need4deed-org/sdk#126 adds `ApiAgentAddressConflict` + `ApiAgentRegisterConflict`. **The BE doesn't import the conflict type** (the 409 is validated against the local AJV schema), so no `need4deed-sdk` bump is required here — the SDK PR just keeps the published contract/Swagger in sync for the FE.

## FE coordination

The search picker now **requires** `postcode` to return matches (without it, it returns `[]`). The FE registration wizard already collects a postcode, so it should pass `&postcode=` to `/agent/register/search`.

## Notes / behaviour

- Search result shape is unchanged (array); it now contains 0 or 1 item (the best address match) rather than up to 10 ILIKE hits. `getAgentByAddress` deliberately returns nothing when a fuzzy match is ambiguous (multiple candidates) — the FE flow still allows creating.
- Create-flow dedup scans all agents (not domain-scoped) to catch any duplicate at that address; the subsequent JOIN still applies `resolveJoinStatus` (domain match → ACTIVE, else PENDING).

## Tests

`write-agent-registration.test.ts` (+1: dedup throws `AgentAddressConflictError`, no create; existing create tests default the dedup lookup to "no match"). Full suite green (317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
