### PR TITLE
fix(migrations): make data migrations self-contained (no entity/helper/enum drift)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,29 @@ Docker alternative (includes Postgres):
 docker compose up           # starts db + bootstrap + be
 ```
 
+### Flushing the database (fresh rebuild)
+
+To wipe the DB and replay the full migration chain from scratch — e.g. to
+verify migrations are self-contained and replay cleanly:
+
+```bash
+docker compose down -v                  # stop + drop the be_database volume
+RUN_MIGRATIONS=1 docker compose up      # db -> bootstrap (re-seeds) -> be runs all migrations
+```
+
+`down -v` removes the `be_database` volume (the data); the next `up` re-seeds
+via the `bootstrap` service, then `be` runs every migration on startup
+(`RUN_MIGRATIONS=1` forces it on regardless of `.env`). Watch the `be` logs —
+the run must reach `Migrations completed` with no `column ... does not exist`
+errors.
+
+**This is the canonical check that a data/seed migration is self-contained.**
+Migrations must depend only on **raw SQL + hardcoded literals** — never import
+live entities, app helpers, config constants, or **SDK enums** (an enum value
+can change with a contract update, retroactively altering what an old migration
+emits). A migration that reaches for the current entity/enum shape will pass on
+the DB it was written against but break on a fresh replay once that shape drifts.
+
 ---
 
 ## Architecture

--- a/src/data/migrations/1766352158945-change-volunteer-preferred-comm-to-array.ts
+++ b/src/data/migrations/1766352158945-change-volunteer-preferred-comm-to-array.ts
@@ -1,13 +1,22 @@
-import { VolunteerCommunicationType } from "need4deed-sdk";
 import { MigrationInterface, QueryRunner } from "typeorm";
+
+// VolunteerCommunicationType values as of this migration — hardcoded (not
+// imported from the SDK) so a later contract change to that enum can't
+// retroactively alter this historical migration's CHECK constraint / default.
+const COMMUNICATION_TYPES = [
+  "email",
+  "mobilePhone",
+  "whatsapp",
+  "telegram",
+  "sms",
+];
+const DEFAULT_COMMUNICATION_TYPE = "mobilePhone";
 
 export class ChangeVolunteerPreferredCommToArray1766352158945
   implements MigrationInterface
 {
   name = "ChangeVolunteerPreferredCommToArray1766352158945";
-  allowedValues = Object.values(VolunteerCommunicationType)
-    .map((v) => `'${v}'`)
-    .join(",");
+  allowedValues = COMMUNICATION_TYPES.map((v) => `'${v}'`).join(",");
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
@@ -30,7 +39,7 @@ export class ChangeVolunteerPreferredCommToArray1766352158945
     );
     await queryRunner.query(`
       ALTER TABLE "volunteer"
-      ADD "preferred_communication_type" text array NOT NULL DEFAULT ARRAY['${VolunteerCommunicationType.MOBILE_PHONE}']
+      ADD "preferred_communication_type" text array NOT NULL DEFAULT ARRAY['${DEFAULT_COMMUNICATION_TYPE}']
     `);
 
     await queryRunner.query(`
@@ -53,7 +62,7 @@ export class ChangeVolunteerPreferredCommToArray1766352158945
     `);
     await queryRunner.query(`
       ALTER TABLE "volunteer"
-      ADD "preferred_communication_type" "public"."volunteer_preferred_communication_type_enum" NOT NULL DEFAULT '${VolunteerCommunicationType.MOBILE_PHONE}'
+      ADD "preferred_communication_type" "public"."volunteer_preferred_communication_type_enum" NOT NULL DEFAULT '${DEFAULT_COMMUNICATION_TYPE}'
     `);
     await queryRunner.query(`
       DROP FUNCTION IF EXISTS validate_communication_types(text[])

--- a/src/data/migrations/1776321570996-update-opp-orphanage.ts
+++ b/src/data/migrations/1776321570996-update-opp-orphanage.ts
@@ -1,6 +1,4 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
-import { NotFoundError } from "../../config";
-import logger from "../../logger";
 
 export class UpdateOppOrphanage1776321570996 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
@@ -21,7 +19,7 @@ export class UpdateOppOrphanage1776321570996 implements MigrationInterface {
       );
     }
     if (!agent) {
-      throw new NotFoundError(
+      throw new Error(
         'Agent "Orphanage For Opportunities" not found and could not be created.',
       );
     }
@@ -32,9 +30,6 @@ export class UpdateOppOrphanage1776321570996 implements MigrationInterface {
       WHERE first_name = $1 AND last_name = $2`,
       ["Need4Deed", "Staff"],
     );
-    logger.debug(
-      `UpdateOppOrphanage1776321570996:1:person:${JSON.stringify(person)}`,
-    );
     if (!person) {
       [person] = await queryRunner.query(
         `INSERT INTO person (first_name, last_name)
@@ -43,11 +38,8 @@ export class UpdateOppOrphanage1776321570996 implements MigrationInterface {
         ["Need4Deed", "Staff"],
       );
     }
-    logger.debug(
-      `UpdateOppOrphanage1776321570996:2:person:${JSON.stringify(person)}`,
-    );
     if (!person) {
-      throw new NotFoundError("Person with name Need4Deed Staff not found");
+      throw new Error("Person with name Need4Deed Staff not found");
     }
 
     // 3. Create address for the person if not already set
@@ -64,7 +56,7 @@ export class UpdateOppOrphanage1776321570996 implements MigrationInterface {
         ["12435"],
       );
       if (!postcode) {
-        throw new NotFoundError("Postcode 12435 not found");
+        throw new Error("Postcode 12435 not found");
       }
 
       const [newAddress] = await queryRunner.query(

--- a/src/data/migrations/1776699111911-update-agent-entity.ts
+++ b/src/data/migrations/1776699111911-update-agent-entity.ts
@@ -1,5 +1,8 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
-import { titleOrphanageAgent } from "../../config";
+
+// Hardcoded (not imported from config) so a later change to titleOrphanageAgent
+// can't change which agent title this historical migration inserts.
+const ORPHANAGE_AGENT_TITLE = "Orphanage For Opportunities";
 
 export class UpdateAgentEntity1776699111911 implements MigrationInterface {
   name = "UpdateAgentEntity1776699111911";
@@ -18,7 +21,7 @@ export class UpdateAgentEntity1776699111911 implements MigrationInterface {
     );
 
     const sql = `INSERT INTO agent (title, info)
-            VALUES ('${titleOrphanageAgent}','The dummy agent account for parenting orphaned opportunities.')
+            VALUES ('${ORPHANAGE_AGENT_TITLE}','The dummy agent account for parenting orphaned opportunities.')
             ON CONFLICT (title) DO NOTHING;`;
     await queryRunner.query(sql);
   }

--- a/src/data/migrations/1779739039589-seed-matched-opp-vol.ts
+++ b/src/data/migrations/1779739039589-seed-matched-opp-vol.ts
@@ -1,5 +1,11 @@
-import { OpportunityVolunteerStatusType } from "need4deed-sdk";
 import { MigrationInterface, QueryRunner } from "typeorm";
+
+// OpportunityVolunteerStatusType values as of this migration — hardcoded (not
+// imported from the SDK) so a later contract change can't retroactively alter
+// what this historical seed writes / which statuses it preserves.
+const STATUS_MATCHED = "opp-matched";
+const STATUS_ACTIVE = "opp-active";
+const STATUS_PAST = "opp-past";
 
 // [volunteerId, opportunityId] — extracted from VOLVO-<id> / VOL-<id>
 const MATCHED_PAIRS: [number, number][] = [
@@ -195,13 +201,9 @@ const MATCHED_PAIRS: [number, number][] = [
 ];
 
 // An existing matched/active/past row is authoritative — never downgrade it.
-const SKIP_STATUSES = [
-  OpportunityVolunteerStatusType.MATCHED,
-  OpportunityVolunteerStatusType.ACTIVE,
-  OpportunityVolunteerStatusType.PAST,
-];
+const SKIP_STATUSES = [STATUS_MATCHED, STATUS_ACTIVE, STATUS_PAST];
 
-const MATCHED = OpportunityVolunteerStatusType.MATCHED;
+const MATCHED = STATUS_MATCHED;
 
 export class SeedMatchedOppVol1779739039589 implements MigrationInterface {
   name = "SeedMatchedOppVol1779739039589";

--- a/src/data/migrations/1780169787517-backfill-opportunity-submitted-by-person.ts
+++ b/src/data/migrations/1780169787517-backfill-opportunity-submitted-by-person.ts
@@ -1,19 +1,20 @@
-import { ILike, MigrationInterface, QueryRunner } from "typeorm";
-import { getOrCreateSubmitterPerson } from "../../server/utils/data/get-or-create-submitter-person";
-import AgentPerson from "../entity/m2m/agent-person";
-import Person from "../entity/person.entity";
+import { MigrationInterface, QueryRunner } from "typeorm";
 
 // One-shot data migration: walk Opportunity rows that still carry a legacy
 // rac_* Comment blob (text shaped as `email<|>full_name<|>address<|>plz<|>phone`,
 // userId 1, entityType 'opportunity'), parse the blob, and populate
-// Opportunity.submitted_by_person_id via the same getOrCreateSubmitterPerson
-// helper the runtime handler uses (#589). The Comment row is left in place.
+// Opportunity.submitted_by_person_id (#589). The Comment row is left in place.
 //
 // Idempotent: only touches opportunities whose submitted_by_person_id is null.
 // Reversible: down() nulls the column on opportunities that still have a
 // blob comment, preserving FKs set by the runtime handler on post-backfill
 // submissions. Person / AgentPerson rows possibly created by up() are kept
 // (they can't be reliably identified after the fact and are safe to retain).
+//
+// Self-contained: raw SQL only — no entities, app helpers, or SDK enums — so it
+// stays pinned to the schema/contract as it was here and can't break on a fresh
+// replay when those evolve (e.g. the later agent_person.status column, or an SDK
+// enum value change).
 
 interface BlobRow {
   opportunity_id: number;
@@ -21,19 +22,88 @@ interface BlobRow {
   blob: string;
 }
 
+// Mirror of getNameFields (first token -> firstName, last -> lastName, the rest
+// -> middleName). Inlined so the migration doesn't import app code. Caller trims.
+function splitName(raw: string): {
+  firstName?: string;
+  middleName?: string;
+  lastName?: string;
+} {
+  const names = raw.split(" ");
+  const firstName = names.shift() || undefined;
+  const lastName = names.pop() || undefined;
+  const middleName = names.join(" ") || undefined;
+  return { firstName, middleName, lastName };
+}
+
 export class BackfillOpportunitySubmittedByPerson1780169787517
   implements MigrationInterface
 {
   name = "BackfillOpportunitySubmittedByPerson1780169787517";
 
-  public async up(queryRunner: QueryRunner): Promise<void> {
-    const manager = queryRunner.manager;
+  // Find-or-create the submitter Person by email, refreshing name/phone from
+  // this submission (only fields actually provided). Raw SQL — no Person entity.
+  // createdAt/updatedAt/preferredCommunicationType have DB defaults, so omitting
+  // them matches what the entity save did.
+  private async resolveSubmitterPersonId(
+    queryRunner: QueryRunner,
+    email: string,
+    fullName: string,
+    phone: string,
+  ): Promise<{ id: number; preExisting: boolean }> {
+    const [existing] = await queryRunner.query(
+      `SELECT id FROM person WHERE email ILIKE $1 LIMIT 1`,
+      [email],
+    );
 
-    const [alreadySet]: [{ count: string }] = await manager.query(
+    if (existing) {
+      const sets: string[] = [];
+      const params: unknown[] = [];
+      if (fullName) {
+        const { firstName, middleName, lastName } = splitName(fullName);
+        params.push(firstName || email.split("@")[0] || "unknown");
+        sets.push(`first_name = $${params.length}`);
+        // null (not undefined) so absent parts clear stale middle/last names.
+        params.push(middleName ?? null);
+        sets.push(`middle_name = $${params.length}`);
+        params.push(lastName ?? null);
+        sets.push(`last_name = $${params.length}`);
+      }
+      if (phone) {
+        params.push(phone);
+        sets.push(`phone = $${params.length}`);
+      }
+      if (sets.length) {
+        params.push(existing.id);
+        await queryRunner.query(
+          `UPDATE person SET ${sets.join(", ")} WHERE id = $${params.length}`,
+          params,
+        );
+      }
+      return { id: existing.id, preExisting: true };
+    }
+
+    const { firstName, middleName, lastName } = splitName(fullName);
+    const [created] = await queryRunner.query(
+      `INSERT INTO person (first_name, middle_name, last_name, email, phone)
+       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+      [
+        firstName || email.split("@")[0] || "unknown",
+        middleName ?? null,
+        lastName ?? null,
+        email,
+        phone || null,
+      ],
+    );
+    return { id: created.id, preExisting: false };
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [alreadySet]: [{ count: string }] = await queryRunner.query(
       `SELECT COUNT(*)::text AS count FROM opportunity WHERE submitted_by_person_id IS NOT NULL`,
     );
 
-    const rows: BlobRow[] = await manager.query(`
+    const rows: BlobRow[] = await queryRunner.query(`
       SELECT DISTINCT ON (o.id)
         o.id AS opportunity_id,
         o.agent_id AS agent_id,
@@ -70,47 +140,58 @@ export class BackfillOpportunitySubmittedByPerson1780169787517
         const parts = row.blob.split("<|>");
         const [rac_email, rac_full_name, , , rac_phone] = parts;
 
-        if (!rac_email?.trim()) {
+        const email = (rac_email ?? "").trim();
+        if (!email) {
           counts.skippedNoEmail++;
           console.warn(`[backfill] opp ${oppId}: empty rac_email; skipping`);
           continue;
         }
 
-        const preExistingPerson = await manager.findOne(Person, {
-          where: { email: ILike(rac_email.trim()) },
-        });
-        const preExistingLink = preExistingPerson
-          ? await manager.findOne(AgentPerson, {
-              where: { agentId: row.agent_id, personId: preExistingPerson.id },
-            })
-          : null;
+        const { id: personId, preExisting } =
+          await this.resolveSubmitterPersonId(
+            queryRunner,
+            email,
+            (rac_full_name ?? "").trim(),
+            (rac_phone ?? "").trim(),
+          );
 
-        const person = await getOrCreateSubmitterPerson(
-          { rac_email, rac_full_name, rac_phone },
-          row.agent_id,
-          manager,
-        );
-        // helper only returns null when rac_email is empty, which the
-        // explicit check above already short-circuits, so this is safe.
-        if (!person) {
-          continue;
-        }
+        // Pre-existing (agent, person) link? Stats only.
+        const preExistingLink =
+          preExisting &&
+          (
+            await queryRunner.query(
+              `SELECT 1 FROM agent_person WHERE agent_id = $1 AND person_id = $2 LIMIT 1`,
+              [row.agent_id, personId],
+            )
+          ).length > 0;
 
-        await manager.query(
+        await queryRunner.query(
           `UPDATE opportunity SET submitted_by_person_id = $1 WHERE id = $2 AND submitted_by_person_id IS NULL`,
-          [person.id, oppId],
+          [personId, oppId],
         );
 
-        if (preExistingPerson && preExistingLink) {
+        // Upsert the agent_person link. 'volunteer-coordinator' is the
+        // AgentRoleType value at this migration; hardcoded so a later enum change
+        // can't alter what this historical migration writes.
+        await queryRunner.query(
+          `INSERT INTO agent_person (agent_id, person_id, role)
+           SELECT $1, $2, 'volunteer-coordinator'
+           WHERE NOT EXISTS (
+             SELECT 1 FROM agent_person WHERE agent_id = $1 AND person_id = $2
+           )`,
+          [row.agent_id, personId],
+        );
+
+        if (preExisting && preExistingLink) {
           counts.foundLinked++;
-        } else if (preExistingPerson) {
+        } else if (preExisting) {
           counts.foundNoLink++;
         } else {
           counts.created++;
         }
       }
     } finally {
-      console.log("[backfill] summary:", JSON.stringify(counts));
+      console.warn("[backfill] summary:", JSON.stringify(counts));
     }
   }
 

--- a/src/data/migrations/1780182685021-backfill-opportunity-submitted-by-person-4-field-blobs.ts
+++ b/src/data/migrations/1780182685021-backfill-opportunity-submitted-by-person-4-field-blobs.ts
@@ -1,7 +1,4 @@
-import { ILike, MigrationInterface, QueryRunner } from "typeorm";
-import { getOrCreateSubmitterPerson } from "../../server/utils/data/get-or-create-submitter-person";
-import AgentPerson from "../entity/m2m/agent-person";
-import Person from "../entity/person.entity";
+import { MigrationInterface, QueryRunner } from "typeorm";
 
 // Follow-up to #590 (see #597): the original backfill matched only the
 // 5-field blob shape (`email<|>name<|>address<|>plz<|>phone`, 4 separators),
@@ -13,7 +10,12 @@ import Person from "../entity/person.entity";
 // handler) are filtered out at the WHERE level, so this is idempotent and
 // won't re-touch them. The destructure `[email, name, , , phone] = parts`
 // already handles both shapes — `phone` falls out as `undefined` for 4-field
-// blobs, which getOrCreateSubmitterPerson treats correctly.
+// blobs.
+//
+// Self-contained: raw SQL only — no entities, app helpers, or SDK enums — so it
+// stays pinned to the schema/contract as it was here and can't break on a fresh
+// replay when those evolve (e.g. the later agent_person.status column, or an SDK
+// enum value change).
 
 interface BlobRow {
   opportunity_id: number;
@@ -21,19 +23,88 @@ interface BlobRow {
   blob: string;
 }
 
+// Mirror of getNameFields (first token -> firstName, last -> lastName, the rest
+// -> middleName). Inlined so the migration doesn't import app code. Caller trims.
+function splitName(raw: string): {
+  firstName?: string;
+  middleName?: string;
+  lastName?: string;
+} {
+  const names = raw.split(" ");
+  const firstName = names.shift() || undefined;
+  const lastName = names.pop() || undefined;
+  const middleName = names.join(" ") || undefined;
+  return { firstName, middleName, lastName };
+}
+
 export class BackfillOpportunitySubmittedByPerson4FieldBlobs1780182685021
   implements MigrationInterface
 {
   name = "BackfillOpportunitySubmittedByPerson4FieldBlobs1780182685021";
 
-  public async up(queryRunner: QueryRunner): Promise<void> {
-    const manager = queryRunner.manager;
+  // Find-or-create the submitter Person by email, refreshing name/phone from
+  // this submission (only fields actually provided). Raw SQL — no Person entity.
+  // createdAt/updatedAt/preferredCommunicationType have DB defaults, so omitting
+  // them matches what the entity save did.
+  private async resolveSubmitterPersonId(
+    queryRunner: QueryRunner,
+    email: string,
+    fullName: string,
+    phone: string,
+  ): Promise<{ id: number; preExisting: boolean }> {
+    const [existing] = await queryRunner.query(
+      `SELECT id FROM person WHERE email ILIKE $1 LIMIT 1`,
+      [email],
+    );
 
-    const [alreadySet]: [{ count: string }] = await manager.query(
+    if (existing) {
+      const sets: string[] = [];
+      const params: unknown[] = [];
+      if (fullName) {
+        const { firstName, middleName, lastName } = splitName(fullName);
+        params.push(firstName || email.split("@")[0] || "unknown");
+        sets.push(`first_name = $${params.length}`);
+        // null (not undefined) so absent parts clear stale middle/last names.
+        params.push(middleName ?? null);
+        sets.push(`middle_name = $${params.length}`);
+        params.push(lastName ?? null);
+        sets.push(`last_name = $${params.length}`);
+      }
+      if (phone) {
+        params.push(phone);
+        sets.push(`phone = $${params.length}`);
+      }
+      if (sets.length) {
+        params.push(existing.id);
+        await queryRunner.query(
+          `UPDATE person SET ${sets.join(", ")} WHERE id = $${params.length}`,
+          params,
+        );
+      }
+      return { id: existing.id, preExisting: true };
+    }
+
+    const { firstName, middleName, lastName } = splitName(fullName);
+    const [created] = await queryRunner.query(
+      `INSERT INTO person (first_name, middle_name, last_name, email, phone)
+       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+      [
+        firstName || email.split("@")[0] || "unknown",
+        middleName ?? null,
+        lastName ?? null,
+        email,
+        phone || null,
+      ],
+    );
+    return { id: created.id, preExisting: false };
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [alreadySet]: [{ count: string }] = await queryRunner.query(
       `SELECT COUNT(*)::text AS count FROM opportunity WHERE submitted_by_person_id IS NOT NULL`,
     );
 
-    const rows: BlobRow[] = await manager.query(`
+    const rows: BlobRow[] = await queryRunner.query(`
       SELECT DISTINCT ON (o.id)
         o.id AS opportunity_id,
         o.agent_id AS agent_id,
@@ -70,43 +141,58 @@ export class BackfillOpportunitySubmittedByPerson4FieldBlobs1780182685021
         const parts = row.blob.split("<|>");
         const [rac_email, rac_full_name, , , rac_phone] = parts;
 
-        if (!rac_email?.trim()) {
+        const email = (rac_email ?? "").trim();
+        if (!email) {
           counts.skippedNoEmail++;
           console.warn(`[backfill-4f] opp ${oppId}: empty rac_email; skipping`);
           continue;
         }
 
-        const preExistingPerson = await manager.findOne(Person, {
-          where: { email: ILike(rac_email.trim()) },
-        });
-        const preExistingLink = preExistingPerson
-          ? await manager.findOne(AgentPerson, {
-              where: { agentId: row.agent_id, personId: preExistingPerson.id },
-            })
-          : null;
+        const { id: personId, preExisting } =
+          await this.resolveSubmitterPersonId(
+            queryRunner,
+            email,
+            (rac_full_name ?? "").trim(),
+            (rac_phone ?? "").trim(),
+          );
 
-        const person = await getOrCreateSubmitterPerson(
-          { rac_email, rac_full_name, rac_phone },
-          row.agent_id,
-          manager,
-        );
-        if (!person) {continue;}
+        // Pre-existing (agent, person) link? Stats only.
+        const preExistingLink =
+          preExisting &&
+          (
+            await queryRunner.query(
+              `SELECT 1 FROM agent_person WHERE agent_id = $1 AND person_id = $2 LIMIT 1`,
+              [row.agent_id, personId],
+            )
+          ).length > 0;
 
-        await manager.query(
+        await queryRunner.query(
           `UPDATE opportunity SET submitted_by_person_id = $1 WHERE id = $2 AND submitted_by_person_id IS NULL`,
-          [person.id, oppId],
+          [personId, oppId],
         );
 
-        if (preExistingPerson && preExistingLink) {
+        // Upsert the agent_person link. 'volunteer-coordinator' is the
+        // AgentRoleType value at this migration; hardcoded so a later enum change
+        // can't alter what this historical migration writes.
+        await queryRunner.query(
+          `INSERT INTO agent_person (agent_id, person_id, role)
+           SELECT $1, $2, 'volunteer-coordinator'
+           WHERE NOT EXISTS (
+             SELECT 1 FROM agent_person WHERE agent_id = $1 AND person_id = $2
+           )`,
+          [row.agent_id, personId],
+        );
+
+        if (preExisting && preExistingLink) {
           counts.foundLinked++;
-        } else if (preExistingPerson) {
+        } else if (preExisting) {
           counts.foundNoLink++;
         } else {
           counts.created++;
         }
       }
     } finally {
-      console.log("[backfill-4f] summary:", JSON.stringify(counts));
+      console.warn("[backfill-4f] summary:", JSON.stringify(counts));
     }
   }
 


### PR DESCRIPTION
## Symptom

A from-scratch DB rebuild failed on:

```
Migration "BackfillOpportunitySubmittedByPerson4FieldBlobs1780182685021" failed,
error: column AgentPerson.status does not exist
```

## Root cause (a whole class of bug, not one migration)

Several data/seed migrations import **live entities, app helpers, config constants, and SDK enums** — all of which drift as the codebase evolves. On a fresh replay TypeORM emits SQL from the *current* shape, which may not match the schema/contract as it was at that point in history. The concrete break: the submitter backfills read the `AgentPerson` entity, which **later** gained a `status` column (a later migration), so replay selected a column that didn't exist yet.

## Fix — make every affected migration self-contained (raw SQL + hardcoded literals)

| Migration | Was | Now |
|---|---|---|
| `1780169787517`, `1780182685021` (submitter backfills) | `getOrCreateSubmitterPerson` helper + `Person`/`AgentPerson` entities | inline person find-or-create + `agent_person` link in raw SQL |
| `1766352158945` | SDK `VolunteerCommunicationType` | hardcoded values |
| `1779739039589` | SDK `OpportunityVolunteerStatusType` | hardcoded values |
| `1776699111911` | config `titleOrphanageAgent` | hardcoded |
| `1776321570996` | `logger` / `NotFoundError` imports | plain `Error`, no imports |

The backfill rewrite is **behaviour-identical**: those blobs carry no address, so the helper's address-sync was already a no-op there; and `created_at`/`updated_at`/`preferred_communication_type` have DB defaults, so the raw INSERT matches the old entity save (smoke-tested in a rolled-back txn).

Editing shipped migrations is safe — TypeORM tracks by **name**, so applied DBs don't re-run them; only fresh replays get the corrected body (the broken case).

## Docs

`CLAUDE.md`: adds the `docker compose down -v` + `RUN_MIGRATIONS=1 docker compose up` fresh-rebuild recipe as the canonical self-containment check, and states the rule (raw SQL + literals only; no entities/helpers/config/SDK enums).

## Verification

Full stack rebuilt from scratch (`docker compose down -v` → `RUN_MIGRATIONS=1 docker compose up`): all **26 pending migrations run clean** to `Migrations completed`, including the 4-field backfill processing **29 seeded rows** (12 created, 17 refreshed) via the new raw SQL — no `column ... does not exist`. typecheck ✓, lint ✓, full suite (317) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
