### PR TITLE
feat(trusted-domain): allowlist fixes brand-new agent self-registration + CRUD

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.105",
+    "need4deed-sdk": "0.0.106",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/data/data-source.ts
+++ b/src/data/data-source.ts
@@ -39,6 +39,7 @@ import Skill from "./entity/profile/skill.entity";
 import Testimonial from "./entity/testimonial.entity";
 import Timeslot from "./entity/time/timeslot.entity";
 import Timeline from "./entity/timeline.entity";
+import TrustedDomain from "./entity/trusted-domain.entity";
 import User from "./entity/user.entity";
 import Appreciation from "./entity/volunteer/appreciation.entity";
 import Volunteer from "./entity/volunteer/volunteer.entity";
@@ -94,6 +95,7 @@ export const dataSource = new DataSource({
     Testimonial,
     Timeline,
     Timeslot,
+    TrustedDomain,
     User,
     Volunteer,
   ],

--- a/src/data/entity/trusted-domain.entity.ts
+++ b/src/data/entity/trusted-domain.entity.ts
@@ -1,0 +1,27 @@
+import { IsNotEmpty, IsString } from "class-validator";
+import { Column, Entity, Index, PrimaryGeneratedColumn } from "typeorm";
+
+// Email-domain allowlist for agent self-registration: a registrant whose email
+// domain is here is treated as a known RAC org, so a brand-new representative
+// (whose org has no member yet) can still register and the join auto-approves
+// to ACTIVE. Stored lowercase; managed via the /trusted-domain CRUD.
+@Entity()
+export default class TrustedDomain {
+  constructor(trustedDomain?: Partial<TrustedDomain>) {
+    if (trustedDomain) {
+      Object.assign(this, trustedDomain);
+    }
+  }
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index({ unique: true })
+  @Column()
+  @IsNotEmpty()
+  @IsString()
+  domain: string;
+
+  @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
+  createdAt: Date;
+}

--- a/src/data/migrations/1781277697986-add-trusted-domain.ts
+++ b/src/data/migrations/1781277697986-add-trusted-domain.ts
@@ -1,0 +1,73 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Creates the trusted_domain allowlist and seeds the known RAC email domains.
+// Self-contained: raw SQL + hardcoded literals only (no entities/app code), so
+// it replays cleanly regardless of how the entity later evolves.
+//
+// The seed list is the agreed allowlist, deduped (the source had need4deed.org
+// and eu-homecare.com twice). ON CONFLICT keeps it idempotent.
+
+const TRUSTED_DOMAINS = [
+  "need4deed.org",
+  "lfg-b.de",
+  "berliner-stadtmission.de",
+  "awo-mitte.de",
+  "prisod-wohnen.de",
+  "albatrosggmbh.de",
+  "gu-oberhafen.de",
+  "heroeurope.com",
+  "tamaja-gu.de",
+  "volkssolidaritaet.de",
+  "unionhilfswerk.de",
+  "cjd.de",
+  "centro-hotels.de",
+  "stephanus.org",
+  "city54.de",
+  "milaa-berlin.de",
+  "stk118.de",
+  "drk-mueggelspree.de",
+  "laf.berlin.de",
+  "ejf.de",
+  "diakonie-stadtmitte.de",
+  "tamaja.de",
+  "pgssoziales.de",
+  "caritas-berlin.de",
+  "eu-homecare.com",
+  "ib.de",
+  "sin-ev.de",
+  "johanniter.de",
+  "gu-freudstr.de",
+  "cityeleven.de",
+  "gu-rauchstr.de",
+  "nbhs.de",
+  "soziales-berlin.com",
+  "pfefferwerk.de",
+  "kieztandem.de",
+  "xenion.org",
+];
+
+export class AddTrustedDomain1781277697986 implements MigrationInterface {
+  name = "AddTrustedDomain1781277697986";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "trusted_domain" ("id" SERIAL NOT NULL, "domain" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_b8c4fcc9a45771d9f59e1dd6b1b" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_3998cf87b5faec4e52018bddbd" ON "trusted_domain" ("domain")`,
+    );
+
+    const values = TRUSTED_DOMAINS.map((_, i) => `($${i + 1})`).join(", ");
+    await queryRunner.query(
+      `INSERT INTO "trusted_domain" ("domain") VALUES ${values} ON CONFLICT ("domain") DO NOTHING`,
+      TRUSTED_DOMAINS,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_3998cf87b5faec4e52018bddbd"`,
+    );
+    await queryRunner.query(`DROP TABLE "trusted_domain"`);
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,6 +22,7 @@ import opportunityRoutes from "./routes/opportunity/opportunity.routes";
 import optionRoutes from "./routes/option";
 import organizationRoutes from "./routes/organization.routes";
 import personRoutes from "./routes/person.routes";
+import trustedDomainRoutes from "./routes/trusted-domain.routes";
 import userRoutes from "./routes/user";
 import volunteerRoutes from "./routes/volunteer/volunteer.routes";
 import workerRoutes from "./routes/worker.routes";
@@ -177,6 +178,9 @@ export async function createServer(): Promise<FastifyInstance> {
   });
   await fastifyInstance.register(workerRoutes, {
     prefix: RoutePrefix.WORKER,
+  });
+  await fastifyInstance.register(trustedDomainRoutes, {
+    prefix: RoutePrefix.TRUSTED_DOMAIN,
   });
 
   await fastifyInstance.ready();

--- a/src/server/plugins/typeorm.ts
+++ b/src/server/plugins/typeorm.ts
@@ -16,6 +16,7 @@ import Option from "../../data/entity/option.entity";
 import Organization from "../../data/entity/organization.entity";
 import Person from "../../data/entity/person.entity";
 import Language from "../../data/entity/profile/language.entity";
+import TrustedDomain from "../../data/entity/trusted-domain.entity";
 import User from "../../data/entity/user.entity";
 import Appreciation from "../../data/entity/volunteer/appreciation.entity";
 import Volunteer from "../../data/entity/volunteer/volunteer.entity";
@@ -49,6 +50,7 @@ const typeormPlugin: FastifyPluginAsync = async (fastify) => {
       agentPersonRepository: dataSource.getRepository(AgentPerson),
       organizationRepository: dataSource.getRepository(Organization),
       postcodeRepository: dataSource.getRepository(Postcode),
+      trustedDomainRepository: dataSource.getRepository(TrustedDomain),
     });
 
     // TODO: add validation of others

--- a/src/server/routes/trusted-domain.routes.ts
+++ b/src/server/routes/trusted-domain.routes.ts
@@ -1,0 +1,139 @@
+import { FastifyInstance, FastifyPluginOptions } from "fastify";
+import {
+  ApiTrustedDomainPatch,
+  ApiTrustedDomainPost,
+  UserRole,
+} from "need4deed-sdk";
+import { Not } from "typeorm";
+import { ConflictError, NotFoundError } from "../../config";
+import TrustedDomain from "../../data/entity/trusted-domain.entity";
+import {
+  idParamSchema,
+  responseErrors,
+  responseSchema,
+  trustedDomainBodySchema,
+  trustedDomainItemResponseSchema,
+  trustedDomainListResponseSchema,
+} from "../schema";
+import { ParamsId } from "../types";
+
+const dtoTrustedDomain = (td: TrustedDomain) => ({
+  id: td.id,
+  domain: td.domain,
+});
+
+const normalize = (domain: string) => domain.trim().toLowerCase();
+
+export default async function trustedDomainRoutes(
+  fastify: FastifyInstance,
+  _options: FastifyPluginOptions,
+) {
+  // The trusted-domain allowlist gates agent self-registration, so managing it
+  // is COORDINATOR/ADMIN only (ADMIN bypasses the role check).
+  fastify.addHook(
+    "onRequest",
+    fastify.authenticate({ role: UserRole.COORDINATOR }),
+  );
+
+  fastify.get(
+    "/",
+    {
+      schema: {
+        response: { 200: trustedDomainListResponseSchema, ...responseErrors },
+      },
+    },
+    async (_request, reply) => {
+      const domains = await fastify.db.trustedDomainRepository.find({
+        order: { domain: "ASC" },
+      });
+      return reply.status(200).send({
+        message: `${domains.length} trusted domains.`,
+        data: domains.map(dtoTrustedDomain),
+      });
+    },
+  );
+
+  fastify.post<{ Body: ApiTrustedDomainPost }>(
+    "/",
+    {
+      schema: {
+        body: trustedDomainBodySchema,
+        response: {
+          201: trustedDomainItemResponseSchema,
+          ...responseErrors,
+        },
+      },
+    },
+    async (request, reply) => {
+      const domain = normalize(request.body.domain);
+      const repo = fastify.db.trustedDomainRepository;
+
+      // Surface the duplicate up front as 409; the unique index is the ultimate
+      // guard for the rare race.
+      if (await repo.findOneBy({ domain })) {
+        throw new ConflictError(`Domain "${domain}" is already trusted.`);
+      }
+
+      const saved = await repo.save(new TrustedDomain({ domain }));
+      return reply.status(201).send({
+        message: `Trusted domain "${domain}" added.`,
+        data: dtoTrustedDomain(saved),
+      });
+    },
+  );
+
+  fastify.patch<{ Params: ParamsId; Body: ApiTrustedDomainPatch }>(
+    "/:id",
+    {
+      schema: {
+        params: idParamSchema,
+        body: trustedDomainBodySchema,
+        response: { 200: trustedDomainItemResponseSchema, ...responseErrors },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const repo = fastify.db.trustedDomainRepository;
+
+      const existing = await repo.findOneBy({ id });
+      if (!existing) {
+        throw new NotFoundError(`Trusted domain (id:${id}) not found.`);
+      }
+
+      const domain = normalize(request.body.domain);
+      if (await repo.findOneBy({ domain, id: Not(id) })) {
+        throw new ConflictError(`Domain "${domain}" is already trusted.`);
+      }
+
+      existing.domain = domain;
+      const saved = await repo.save(existing);
+      return reply.status(200).send({
+        message: `Trusted domain (id:${id}) updated.`,
+        data: dtoTrustedDomain(saved),
+      });
+    },
+  );
+
+  fastify.delete<{ Params: ParamsId }>(
+    "/:id",
+    {
+      schema: {
+        params: idParamSchema,
+        response: responseSchema(""),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const { affected } = await fastify.db.trustedDomainRepository.delete({
+        id,
+      });
+      if (!affected) {
+        throw new NotFoundError(`Trusted domain (id:${id}) not found.`);
+      }
+
+      return reply
+        .status(200)
+        .send({ message: `Trusted domain (id:${id}) deleted.` });
+    },
+  );
+}

--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -28,7 +28,7 @@ import {
   userVerifyEmailSchema,
 } from "../schema/user.schema";
 import { QuerystringUserList, ReplyDataCount, RoutePrefix } from "../types";
-import { getSkipTake, getUserWhere } from "../utils";
+import { getSkipTake, getUserWhere, isEmailDomainTrusted } from "../utils";
 
 export default async function userRoutes(
   fastify: FastifyInstance,
@@ -273,8 +273,10 @@ export default async function userRoutes(
           throw new UnauthorizedError();
         }
 
-        // Agents must register from a known agent's email domain (same gate as
-        // POST /opportunity/legacy). Volunteers and users self-register freely.
+        // Agents must register from a known RAC email domain: either an
+        // existing agent member already shares it, or it's on the trusted-domain
+        // allowlist (so a brand-new org's first representative can register).
+        // Volunteers and users self-register freely.
         if (role === UserRole.AGENT) {
           const domain = (email || "").split("@").pop();
           const matchingAgent = await fastify.db.agentRepository.findOne({
@@ -282,7 +284,7 @@ export default async function userRoutes(
               agentPerson: { person: { email: ILike(`%@${domain}`) } },
             },
           });
-          if (!matchingAgent) {
+          if (!matchingAgent && !(await isEmailDomainTrusted(email))) {
             throw new NotFoundError();
           }
         }

--- a/src/server/schema/index.ts
+++ b/src/server/schema/index.ts
@@ -5,5 +5,6 @@ export * from "./person.schema";
 export * from "./querystring";
 export * from "./response-schema";
 export * from "./responseErrors";
+export * from "./trusted-domain.schema";
 export * from "./user.schema";
 export * from "./volunteer-doc.schema";

--- a/src/server/schema/trusted-domain.schema.ts
+++ b/src/server/schema/trusted-domain.schema.ts
@@ -1,0 +1,44 @@
+// Schemas for the /trusted-domain CRUD (COORDINATOR/ADMIN). The allowlist of
+// known RAC email domains used by agent self-registration.
+
+const trustedDomainSchema = {
+  type: "object",
+  required: ["id", "domain"],
+  additionalProperties: false,
+  properties: {
+    id: { type: "integer" },
+    domain: { type: "string" },
+  },
+};
+
+export const trustedDomainListResponseSchema = {
+  type: "object",
+  required: ["message", "data"],
+  properties: {
+    message: { type: "string" },
+    data: { type: "array", items: trustedDomainSchema },
+  },
+};
+
+export const trustedDomainItemResponseSchema = {
+  type: "object",
+  required: ["message", "data"],
+  properties: {
+    message: { type: "string" },
+    data: trustedDomainSchema,
+  },
+};
+
+// A bare hostname: labels of letters/digits/hyphens separated by dots, with a
+// 2+ letter TLD. Rejects emails, schemes, paths and leading "@".
+const DOMAIN_PATTERN =
+  "^(?=.{1,253}$)([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}$";
+
+export const trustedDomainBodySchema = {
+  type: "object",
+  required: ["domain"],
+  additionalProperties: false,
+  properties: {
+    domain: { type: "string", pattern: DOMAIN_PATTERN },
+  },
+};

--- a/src/server/types/enums.ts
+++ b/src/server/types/enums.ts
@@ -20,6 +20,7 @@ export const RoutePrefix = {
   REFRESH: "/refresh",
   REGISTER: "/register",
   SWAGGER: "/swagger",
+  TRUSTED_DOMAIN: "/trusted-domain",
   USER: "/user",
   VERIFY_EMAIL: "/verify-email",
   VOLUNTEER: "/volunteer",

--- a/src/server/types/fastify.d.ts
+++ b/src/server/types/fastify.d.ts
@@ -18,6 +18,7 @@ import Option from "../../data/entity/option.entity";
 import Organization from "../../data/entity/organization.entity";
 import Person from "../../data/entity/person.entity";
 import Language from "../../data/entity/profile/language.entity";
+import TrustedDomain from "../../data/entity/trusted-domain.entity";
 import User from "../../data/entity/user.entity";
 import Volunteer from "../../data/entity/volunteer/volunteer.entity";
 import { AuthOptions } from "./auth";
@@ -42,6 +43,7 @@ declare module "fastify" {
       agentPersonRepository: Repository<AgentPerson>;
       organizationRepository: Repository<Organization>;
       postcodeRepository: Repository<Postcode>;
+      trustedDomainRepository: Repository<TrustedDomain>;
     };
     jwt: JWT;
     authenticate(opts?: AuthOptions): onRequestHookHandler;

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -15,6 +15,7 @@ export * from "./get-volunteer-form-data";
 export * from "./get-volunteer-patch-data";
 export * from "./get-volunteer-where";
 export * from "./sync-comment-tags";
+export * from "./is-trusted-domain";
 export * from "./update-leads";
 export * from "./write-agent-registration";
 export * from "./write-opportunity-contact-comment";

--- a/src/server/utils/data/is-trusted-domain.ts
+++ b/src/server/utils/data/is-trusted-domain.ts
@@ -1,0 +1,18 @@
+import { dataSource } from "../../../data/data-source";
+import TrustedDomain from "../../../data/entity/trusted-domain.entity";
+
+/**
+ * True when the email's domain is on the trusted allowlist (case-insensitive).
+ * Used by the agent-registration domain checks (POST /user AGENT gate and
+ * resolveJoinStatus) so a brand-new representative from a known RAC domain can
+ * register even when their org has no existing member yet.
+ */
+export async function isEmailDomainTrusted(email: string): Promise<boolean> {
+  const domain = email.split("@").pop()?.toLowerCase();
+  if (!domain) {
+    return false;
+  }
+  return (
+    (await dataSource.getRepository(TrustedDomain).countBy({ domain })) > 0
+  );
+}

--- a/src/server/utils/data/write-agent-registration.ts
+++ b/src/server/utils/data/write-agent-registration.ts
@@ -9,6 +9,7 @@ import AgentPerson from "../../../data/entity/m2m/agent-person";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import { createAddress } from "./for-routes";
 import { getAgentByAddress } from "./get-agent-by-postcode";
+import { isEmailDomainTrusted } from "./is-trusted-domain";
 
 export interface RegisterAgentResult {
   agentId: number;
@@ -149,7 +150,10 @@ export async function resolveJoinStatus(
     );
   });
 
-  return matched ? AgentMembershipStatus.ACTIVE : AgentMembershipStatus.PENDING;
+  // Auto-approve when an existing member shares the domain, or the domain is on
+  // the trusted allowlist (a brand-new org's first representative).
+  const trusted = matched || (await isEmailDomainTrusted(registrantEmail));
+  return trusted ? AgentMembershipStatus.ACTIVE : AgentMembershipStatus.PENDING;
 }
 
 /**

--- a/src/test/server/utils/data/is-trusted-domain.test.ts
+++ b/src/test/server/utils/data/is-trusted-domain.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isEmailDomainTrusted } from "../../../../server/utils/data/is-trusted-domain";
+
+const countBy = vi.fn();
+vi.mock("../../../../data/data-source", () => ({
+  dataSource: { getRepository: () => ({ countBy }) },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("isEmailDomainTrusted", () => {
+  it("is true when the email's domain is on the allowlist", async () => {
+    countBy.mockResolvedValueOnce(1);
+    expect(await isEmailDomainTrusted("rep@need4deed.org")).toBe(true);
+    expect(countBy).toHaveBeenCalledWith({ domain: "need4deed.org" });
+  });
+
+  it("is false when the domain is not on the allowlist", async () => {
+    countBy.mockResolvedValueOnce(0);
+    expect(await isEmailDomainTrusted("rep@unknown.example")).toBe(false);
+  });
+
+  it("lowercases the domain before looking it up", async () => {
+    countBy.mockResolvedValueOnce(1);
+    await isEmailDomainTrusted("Rep@Need4Deed.ORG");
+    expect(countBy).toHaveBeenCalledWith({ domain: "need4deed.org" });
+  });
+
+  it("is false (no DB call) for an email with no domain part", async () => {
+    expect(await isEmailDomainTrusted("rep@")).toBe(false);
+    expect(await isEmailDomainTrusted("")).toBe(false);
+    expect(countBy).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/server/utils/data/write-agent-registration.test.ts
+++ b/src/test/server/utils/data/write-agent-registration.test.ts
@@ -16,6 +16,12 @@ vi.mock("../../../../server/utils/data/for-routes", () => ({
   createAddress: (...args: unknown[]) => createAddressMock(...args),
 }));
 
+const isEmailDomainTrustedMock = vi.fn();
+vi.mock("../../../../server/utils/data/is-trusted-domain", () => ({
+  isEmailDomainTrusted: (...args: unknown[]) =>
+    isEmailDomainTrustedMock(...args),
+}));
+
 const txnManager: any = { getRepository: vi.fn() };
 const agentPersonRepoFindOne = vi.fn();
 const agentPersonRepoFind = vi.fn();
@@ -55,6 +61,9 @@ beforeEach(() => {
   // Default: the address-dedup lookup (dataSource.getRepository(Agent).find)
   // finds no existing agent, so createAgentForPerson proceeds to create.
   agentPersonRepoFind.mockResolvedValue([]);
+
+  // Default: domain not on the trusted allowlist (member-match decides).
+  isEmailDomainTrustedMock.mockResolvedValue(false);
 
   agentSave.mockImplementation(async (a: any) => ({ ...a, id: 33 }));
   agentPersonSave.mockImplementation(async (ap: any) => ({ ...ap, id: 44 }));
@@ -196,6 +205,16 @@ describe("resolveJoinStatus", () => {
     const status = await resolveJoinStatus(33, "");
     expect(status).toBe(AgentMembershipStatus.PENDING);
     expect(agentPersonRepoFind).not.toHaveBeenCalled();
+  });
+
+  it("returns ACTIVE when no member matches but the domain is trusted", async () => {
+    agentPersonRepoFind.mockResolvedValueOnce([
+      { person: { email: "old@other.de", users: [] } },
+    ]);
+    isEmailDomainTrustedMock.mockResolvedValueOnce(true);
+
+    const status = await resolveJoinStatus(33, "newcomer@brandnew.de");
+    expect(status).toBe(AgentMembershipStatus.ACTIVE);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.105:
-  version "0.0.105"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.105.tgz#3333641f4319c54b4b756f2503fdcb2094f0f958"
-  integrity sha512-cyyJVg7ZhkbATgqhfHbwcVmUktmZYqQyBEPHOFDLN+odwrTSCvx+1HuIUghUwxTuIvG06j4rZQuUJVIBLY+QqA==
+need4deed-sdk@0.0.106:
+  version "0.0.106"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.106.tgz#346caf2bf1c2a5bba45a9e0d90115c30eea7fa3a"
+  integrity sha512-I0fNNWfBJvr4NvKT0yQDaqFQ0YSEX0QJ//KN7VZlnzKiUl3zVx3G2kjLkVV1QYEv4/MSs+xv2oiCszuNstt7Wg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Bug

A brand-new agent representative couldn't self-register. The domain gate — `POST /user` (`role: agent`) and `resolveJoinStatus` — only passed when an **existing** member already shared the registrant's email domain, so the **first** rep of an org not yet in the system was rejected (`POST /user` → 404).

## Fix — a managed trusted-domain allowlist as the fallback

- **`TrustedDomain`** entity (`domain` unique) + a **self-contained** seed migration (raw SQL + hardcoded list, per the migration rule) seeding the agreed allowlist, **deduped** (`need4deed.org` and `eu-homecare.com` appeared twice → **36** unique).
- **`isEmailDomainTrusted(email)`** helper + `trustedDomainRepository` decorator.
- **Wired into both gates:**
  - `POST /user` AGENT → passes if a member shares the domain **OR** `isEmailDomainTrusted`.
  - `resolveJoinStatus` → ACTIVE on member-match **OR** trusted, else PENDING.

## Manage it — `/trusted-domain` CRUD (COORDINATOR/ADMIN)

`GET` (list) · `POST {domain}` (201, 409 on dup) · `PATCH /:id {domain}` · `DELETE /:id`. Domains normalized to lowercase; `POST`/`PATCH` validate a bare hostname pattern.

## Contract

`need4deed-sdk` `0.0.105 → 0.0.106` — `ApiTrustedDomain` / `…Post` / `…Patch` (sdk#127). `0.0.106` also carries `ApiAgentAddressConflict` (sdk#126, which was published-but-unmerged; now landed on `main`).

`POST /opportunity/legacy` is unchanged, per the agreed scope.

## Verification

- Migration runs + seeds **36** distinct domains (verified against the live DB).
- typecheck ✓, lint ✓, full suite **322** (+5: `isEmailDomainTrusted` unit tests + a `resolveJoinStatus` trusted-domain path; server-boot tests confirm the new routes/schemas register).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
