### PR TITLE
feat(opportunity): add volunteerNames to GET /opportunity list

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.106",
+    "need4deed-sdk": "0.0.107",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -193,6 +193,7 @@ export default async function opportunityRoutes(
         "deal.dealDistrict.district",
         "agent",
         "accompanying",
+        "opportunityVolunteer.volunteer.person",
       ];
 
       const opportunityRepository = fastify.db.opportunityRepository;

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -680,7 +680,8 @@
         },
         "location": { "type": "array", "items": { "$ref": "OptionById#" } },
         "accompanyingDetails": { "$ref": "ApiAccompanying#" },
-        "agentTitle": { "type": "string" }
+        "agentTitle": { "type": "string" },
+        "volunteerNames": { "type": "array", "items": { "type": "string" } }
       },
       "required": [
         "id",

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -40,8 +40,9 @@ export function getOpportunityContact(
 
   const person =
     opportunity.contactPerson ??
-    (submitterStillAtAgent ? submitter : opportunity.agent?.representative?.person);
-
+    (submitterStillAtAgent
+      ? submitter
+      : opportunity.agent?.representative?.person);
 
   return {
     id: person?.id,
@@ -80,6 +81,12 @@ export function dtoOpportunityGetList(
     availability: getAvailabilityTryCatch(opportunity.deal.dealTimeslot) ?? [],
     accompanyingDetails: dtoOpportunityAccompanying(opportunity.accompanying!),
     agentTitle: opportunity.agent?.title ?? "",
+    // Names of the volunteers matched to the opportunity. PII masking runs
+    // before this DTO, so masked names pass through. Needs the
+    // opportunityVolunteer.volunteer.person relation loaded.
+    volunteerNames: (opportunity.opportunityVolunteer ?? [])
+      .map((ov) => ov.volunteer?.person?.name)
+      .filter((name): name is string => Boolean(name)),
   } as ApiOpportunityGetList;
 }
 

--- a/src/test/services/dto/dto-opportunity.test.ts
+++ b/src/test/services/dto/dto-opportunity.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getOpportunityContact } from "../../../services/dto/dto-opportunity";
+import {
+  dtoOpportunityGetList,
+  getOpportunityContact,
+} from "../../../services/dto/dto-opportunity";
 
 const representativePerson = {
   id: 100,
@@ -120,5 +123,62 @@ describe("getOpportunityContact", () => {
     const result = getOpportunityContact(opportunity as any);
 
     expect(result.id).toBe(100);
+  });
+});
+
+describe("dtoOpportunityGetList", () => {
+  const baseOpportunity = {
+    id: 1,
+    title: "German tutoring",
+    type: "volunteering",
+    status: "opp-active",
+    statusMatch: "opp-vol-matched",
+    numberVolunteers: 2,
+    createdAt: new Date("2026-01-01"),
+    districtId: 5,
+    agent: { title: "Center X" },
+    accompanying: null,
+    deal: {
+      categoryId: 9,
+      dealLanguage: [],
+      dealActivity: [],
+      dealDistrict: [],
+      dealTimeslot: [],
+    },
+  };
+
+  it("maps the matched volunteers' names, skipping rows with no person", () => {
+    const opportunity = {
+      ...baseOpportunity,
+      opportunityVolunteer: [
+        { volunteer: { person: { name: "Jane Doe" } } },
+        { volunteer: { person: { name: "John Roe" } } },
+        { volunteer: { person: null } },
+        { volunteer: null },
+      ],
+    };
+
+    expect(dtoOpportunityGetList(opportunity as any).volunteerNames).toEqual([
+      "Jane Doe",
+      "John Roe",
+    ]);
+  });
+
+  it("passes masked names through verbatim", () => {
+    const opportunity = {
+      ...baseOpportunity,
+      opportunityVolunteer: [{ volunteer: { person: { name: "x*** y***" } } }],
+    };
+
+    expect(dtoOpportunityGetList(opportunity as any).volunteerNames).toEqual([
+      "x*** y***",
+    ]);
+  });
+
+  it("yields an empty array when no volunteers are matched", () => {
+    const opportunity = { ...baseOpportunity, opportunityVolunteer: [] };
+    expect(dtoOpportunityGetList(opportunity as any).volunteerNames).toEqual(
+      [],
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.106:
-  version "0.0.106"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.106.tgz#346caf2bf1c2a5bba45a9e0d90115c30eea7fa3a"
-  integrity sha512-I0fNNWfBJvr4NvKT0yQDaqFQ0YSEX0QJ//KN7VZlnzKiUl3zVx3G2kjLkVV1QYEv4/MSs+xv2oiCszuNstt7Wg==
+need4deed-sdk@0.0.107:
+  version "0.0.107"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.107.tgz#3b9e0b42970a9ef6a21045cf522bbca1cdeee902"
+  integrity sha512-UrHmAnlCg2jfBdM6oVYMESfg5H/U9dAAvIN14zWJBHP82NNtScFEqvojdZD9GlCgUxtDqW1chcWsRY/Zzm7Jvg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## What

Surfaces the names of volunteers matched (m2m) to each opportunity on `GET /opportunity` (list), via `ApiOpportunityGetList.volunteerNames`.

- bump `need4deed-sdk` `0.0.106 → 0.0.107` (`volunteerNames` on `ApiOpportunityGetList`, sdk#128)
- add `volunteerNames` (optional `string[]`) to the `ApiOpportunityGetList` definition in `sdk-types.json`
- `dtoOpportunityGetList` maps `opportunityVolunteer.volunteer.person.name` (filtered to non-empty)
- load the `opportunityVolunteer.volunteer.person` relation in the `GET /opportunity` list query

## PII

Names are `person.name`, which is **masked before the DTO** by the `preSerialization` hook — so for a non-privileged caller the array contains masked names (e.g. `"x*** y***"`) except for volunteers their role may see (e.g. the owning agent). COORDINATOR/ADMIN see full names. Field is named `volunteerNames` (not `volunteers`) to avoid implying objects.

## Tests

`dtoOpportunityGetList` unit tests: maps names + skips person-less rows, masked-passthrough, empty when none. Full suite green (325, +3).

> Note: no end-to-end request test (harness has no seeded-user route rig) — covered at the DTO unit level + server-boot schema registration, as with the earlier PII PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
