### PR TITLE
fix(opportunity): volunteerNames = only opp-matched volunteers

### DIFF
--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -4,6 +4,7 @@ import {
   ApiOpportunityGetList,
   ApiVolunteerOpportunityGetList,
   OpportunityType,
+  OpportunityVolunteerStatusType,
 } from "need4deed-sdk";
 import Comment from "../../data/entity/comment.entity";
 import District from "../../data/entity/location/district.entity";
@@ -81,10 +82,12 @@ export function dtoOpportunityGetList(
     availability: getAvailabilityTryCatch(opportunity.deal.dealTimeslot) ?? [],
     accompanyingDetails: dtoOpportunityAccompanying(opportunity.accompanying!),
     agentTitle: opportunity.agent?.title ?? "",
-    // Names of the volunteers matched to the opportunity. PII masking runs
-    // before this DTO, so masked names pass through. Needs the
+    // Names of the volunteers MATCHED to the opportunity (status opp-matched
+    // only — not pending/active/past links). PII masking runs before this DTO,
+    // so masked names pass through. Needs the
     // opportunityVolunteer.volunteer.person relation loaded.
     volunteerNames: (opportunity.opportunityVolunteer ?? [])
+      .filter((ov) => ov.status === OpportunityVolunteerStatusType.MATCHED)
       .map((ov) => ov.volunteer?.person?.name)
       .filter((name): name is string => Boolean(name)),
   } as ApiOpportunityGetList;

--- a/src/test/services/dto/dto-opportunity.test.ts
+++ b/src/test/services/dto/dto-opportunity.test.ts
@@ -147,14 +147,22 @@ describe("dtoOpportunityGetList", () => {
     },
   };
 
-  it("maps the matched volunteers' names, skipping rows with no person", () => {
+  it("maps only opp-matched volunteers' names, skipping other statuses + rows with no person", () => {
     const opportunity = {
       ...baseOpportunity,
       opportunityVolunteer: [
-        { volunteer: { person: { name: "Jane Doe" } } },
-        { volunteer: { person: { name: "John Roe" } } },
-        { volunteer: { person: null } },
-        { volunteer: null },
+        { status: "opp-matched", volunteer: { person: { name: "Jane Doe" } } },
+        { status: "opp-matched", volunteer: { person: { name: "John Roe" } } },
+        // not matched -> excluded
+        {
+          status: "opp-pending",
+          volunteer: { person: { name: "Penny Pend" } },
+        },
+        { status: "opp-active", volunteer: { person: { name: "Active Al" } } },
+        { status: "opp-past", volunteer: { person: { name: "Past Pat" } } },
+        // matched but no person -> filtered out
+        { status: "opp-matched", volunteer: { person: null } },
+        { status: "opp-matched", volunteer: null },
       ],
     };
 
@@ -164,10 +172,12 @@ describe("dtoOpportunityGetList", () => {
     ]);
   });
 
-  it("passes masked names through verbatim", () => {
+  it("passes masked names of matched volunteers through verbatim", () => {
     const opportunity = {
       ...baseOpportunity,
-      opportunityVolunteer: [{ volunteer: { person: { name: "x*** y***" } } }],
+      opportunityVolunteer: [
+        { status: "opp-matched", volunteer: { person: { name: "x*** y***" } } },
+      ],
     };
 
     expect(dtoOpportunityGetList(opportunity as any).volunteerNames).toEqual([
@@ -176,7 +186,12 @@ describe("dtoOpportunityGetList", () => {
   });
 
   it("yields an empty array when no volunteers are matched", () => {
-    const opportunity = { ...baseOpportunity, opportunityVolunteer: [] };
+    const opportunity = {
+      ...baseOpportunity,
+      opportunityVolunteer: [
+        { status: "opp-pending", volunteer: { person: { name: "Penny" } } },
+      ],
+    };
     expect(dtoOpportunityGetList(opportunity as any).volunteerNames).toEqual(
       [],
     );


### PR DESCRIPTION
## What

Follow-up to #686: restrict `volunteerNames` on `GET /opportunity` (list) to volunteers whose `opportunity_volunteer.status` is **`opp-matched`** — excluding `opp-pending` / `opp-active` / `opp-past` links.

```ts
.filter((ov) => ov.status === OpportunityVolunteerStatusType.MATCHED)
```

BE-only — the contract (`ApiOpportunityGetList.volunteerNames: string[]`) is unchanged, so no SDK bump. The `opportunityVolunteer` relation already loads `status` (a column), so no query change either.

## Tests

`dtoOpportunityGetList` tests updated: only `opp-matched` names map (pending/active/past excluded), masked-passthrough for a matched volunteer, empty when the only link is non-matched. Suite green (325).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
