### PR TITLE
fix: allow re-suggesting a volunteer to the same opportunity

### DIFF
--- a/src/server/routes/m2m/opportunity-volunteer.routes.ts
+++ b/src/server/routes/m2m/opportunity-volunteer.routes.ts
@@ -30,7 +30,18 @@ export default async function m2mOpportunityVolunteerRoutes(
         fastify.db.opportunityVolunteerRepository;
 
       const opportunityVolunteer = new OpportunityVolunteer(request.body);
-      await opportunityVolunteerRepository.save(opportunityVolunteer);
+      const existing = await opportunityVolunteerRepository.findOne({
+        where: {
+          opportunityId: opportunityVolunteer.opportunityId,
+          volunteerId: opportunityVolunteer.volunteerId,
+        },
+      });
+      if (existing) {
+        opportunityVolunteerRepository.merge(existing, { status: opportunityVolunteer.status });
+        await opportunityVolunteerRepository.save(existing);
+      } else {
+        await opportunityVolunteerRepository.save(opportunityVolunteer);
+      }
 
       return reply.status(201).send({
         message: `Created M2M opportunityId:${opportunityVolunteer.opportunityId}, volunteerId:${opportunityVolunteer.volunteerId}, status:${opportunityVolunteer.status}.`,


### PR DESCRIPTION
## Summary
- POST `/opportunity-volunteer` was failing with a DB unique constraint error when the same volunteer was suggested to the same opportunity more than once
- The entity has `@Unique(['opportunityId', 'volunteerId'])`, so a second `save()` call on a duplicate pair threw an error, causing the FE to show "Something went wrong"
- Fix: look up the existing record first; if found, update its status via `merge` + `save`; if not found, insert as before

## Test plan
- [ ] Suggest a volunteer to an opportunity in staging — should succeed (201)
- [ ] Suggest the same volunteer to the same opportunity again — should succeed (201) instead of "Something went wrong"
- [ ] Suggest the volunteer a third time — should still succeed
- [ ] Verify PATCH `/:id` and DELETE `/:id` still work correctly

Closes https://github.com/need4deed-org/be/issues/688

🤖 Generated with [Claude Code](https://claude.com/claude-code)