### PR TITLE
fix: keep opportunity statusMatch in sync with linked volunteers

### DIFF
--- a/src/data/entity/m2m/opportunity-volunteer.ts
+++ b/src/data/entity/m2m/opportunity-volunteer.ts
@@ -1,6 +1,7 @@
 import { IsEnum } from "class-validator";
 import { OpportunityVolunteerStatusType } from "need4deed-sdk";
 import {
+  AfterInsert,
   AfterUpdate,
   Column,
   CreateDateColumn,
@@ -61,9 +62,17 @@ export default class OpportunityVolunteer {
   @Column()
   volunteerId: number;
 
+  @AfterInsert()
+  async afterInsertHook() {
+    const { updateVolunteerMatching, updateOpportunityMatching } = await import("../../utils");
+    updateVolunteerMatching(this.volunteerId);
+    updateOpportunityMatching(this.opportunityId);
+  }
+
   @AfterUpdate()
   async afterUpdateHook() {
-    const { updateVolunteerMatching } = await import("../../utils");
+    const { updateVolunteerMatching, updateOpportunityMatching } = await import("../../utils");
     updateVolunteerMatching(this.volunteerId);
+    updateOpportunityMatching(this.opportunityId);
   }
 }

--- a/src/data/entity/m2m/opportunity-volunteer.ts
+++ b/src/data/entity/m2m/opportunity-volunteer.ts
@@ -2,6 +2,7 @@ import { IsEnum } from "class-validator";
 import { OpportunityVolunteerStatusType } from "need4deed-sdk";
 import {
   AfterInsert,
+  AfterRemove,
   AfterUpdate,
   Column,
   CreateDateColumn,
@@ -71,6 +72,13 @@ export default class OpportunityVolunteer {
 
   @AfterUpdate()
   async afterUpdateHook() {
+    const { updateVolunteerMatching, updateOpportunityMatching } = await import("../../utils");
+    updateVolunteerMatching(this.volunteerId);
+    updateOpportunityMatching(this.opportunityId);
+  }
+
+  @AfterRemove()
+  async afterRemoveHook() {
     const { updateVolunteerMatching, updateOpportunityMatching } = await import("../../utils");
     updateVolunteerMatching(this.volunteerId);
     updateOpportunityMatching(this.opportunityId);

--- a/src/data/lib/index.ts
+++ b/src/data/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./categorize";
+export * from "./resolve-opp-matching";
 export * from "./revolve-vol-matching";
 export * from "./snake-case";

--- a/src/data/lib/resolve-opp-matching.ts
+++ b/src/data/lib/resolve-opp-matching.ts
@@ -1,0 +1,33 @@
+import {
+  OpportunityMatchStatusType,
+  OpportunityVolunteerStatusType,
+} from "need4deed-sdk";
+
+export function resolveOpportunityMatchStatus(
+  currentStatus: OpportunityMatchStatusType,
+  volunteers: OpportunityVolunteerStatusType[],
+): OpportunityMatchStatusType {
+  const hasMatched = volunteers.some(
+    (s) => s === OpportunityVolunteerStatusType.MATCHED,
+  );
+  const hasActive = volunteers.some(
+    (s) => s === OpportunityVolunteerStatusType.ACTIVE,
+  );
+  const hasPending = volunteers.some(
+    (s) => s === OpportunityVolunteerStatusType.PENDING,
+  );
+
+  if (hasMatched || hasActive) {
+    return OpportunityMatchStatusType.MATCHED;
+  }
+
+  if (hasPending) {
+    return OpportunityMatchStatusType.PENDING_MATCH;
+  }
+
+  if (currentStatus !== OpportunityMatchStatusType.NO_MATCHES) {
+    return OpportunityMatchStatusType.NEEDS_REMATCH;
+  }
+
+  return OpportunityMatchStatusType.NO_MATCHES;
+}

--- a/src/data/migrations/1781600000000-backfill-opportunity-status-match.ts
+++ b/src/data/migrations/1781600000000-backfill-opportunity-status-match.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Backfill opportunity.status_match from the current opportunity_volunteer rows.
+// Prior to this migration the column was never written to after its initial
+// default ('opp-vol-no-matches'), so every opportunity appeared unmatched even
+// when volunteers were already linked.
+//
+// Logic mirrors resolveOpportunityMatchStatus:
+//   any opp-matched / opp-active link  →  opp-vol-matched
+//   any opp-pending link (no match)    →  opp-vol-pending-match
+//   anything else                      →  opp-vol-no-matches  (leave as-is)
+//
+// The NEEDS_REMATCH case (currentStatus !== NO_MATCHES) is intentionally
+// skipped: every opportunity currently has the default NO_MATCHES, so there is
+// no "previous" status to transition from.
+
+const sqlBackfill = `
+WITH computed AS (
+  SELECT
+    o.id,
+    CASE
+      WHEN EXISTS (
+        SELECT 1 FROM opportunity_volunteer ov
+        WHERE ov.opportunity_id = o.id
+          AND ov.status IN ('opp-matched', 'opp-active')
+      ) THEN 'opp-vol-matched'
+      WHEN EXISTS (
+        SELECT 1 FROM opportunity_volunteer ov
+        WHERE ov.opportunity_id = o.id
+          AND ov.status = 'opp-pending'
+      ) THEN 'opp-vol-pending-match'
+      ELSE 'opp-vol-no-matches'
+    END AS new_status
+  FROM opportunity o
+)
+UPDATE opportunity
+SET status_match = computed.new_status::"opportunity_status_match_enum"
+FROM computed
+WHERE opportunity.id = computed.id
+  AND opportunity.status_match::text != computed.new_status;
+`;
+
+export class BackfillOpportunityStatusMatch1781600000000
+  implements MigrationInterface
+{
+  name = "BackfillOpportunityStatusMatch1781600000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(sqlBackfill);
+  }
+
+  // Resets all opportunities back to the pre-migration default.
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE opportunity SET status_match = 'opp-vol-no-matches'`,
+    );
+  }
+}

--- a/src/data/utils/index.ts
+++ b/src/data/utils/index.ts
@@ -7,4 +7,5 @@ export * from "./getRRULE";
 export * from "./getStartEndDates";
 export * from "./passwd";
 export * from "./remove-data";
+export * from "./update-opportunity-matching";
 export * from "./update-volunteer-matching";

--- a/src/data/utils/update-opportunity-matching.ts
+++ b/src/data/utils/update-opportunity-matching.ts
@@ -33,7 +33,7 @@ export async function updateOpportunityMatching(id: number): Promise<void> {
       opportunityRepository.save(Object.assign(opportunity, { statusMatch })),
     );
 
-    if (!opportunity) {
+    if (error) {
       dataSource.logger.log(
         "warn",
         `During saving opportunity (id:${id}) occurred: ${error}`,

--- a/src/data/utils/update-opportunity-matching.ts
+++ b/src/data/utils/update-opportunity-matching.ts
@@ -1,0 +1,43 @@
+import { tryCatch } from "../../services/utils";
+import { dataSource } from "../data-source";
+import OpportunityVolunteer from "../entity/m2m/opportunity-volunteer";
+import Opportunity from "../entity/opportunity/opportunity.entity";
+import { resolveOpportunityMatchStatus } from "../lib";
+import { getRepository } from "./get-repository";
+
+export async function updateOpportunityMatching(id: number): Promise<void> {
+  const opportunityRepository = getRepository(dataSource, Opportunity);
+  const opportunity = await opportunityRepository.findOneBy({ id });
+  if (!opportunity) {
+    return dataSource.logger.log(
+      "warn",
+      `This shouldn't've happened but opportunity id:${id} not found.`,
+    );
+  }
+
+  const opportunityVolunteerRepository = getRepository(
+    dataSource,
+    OpportunityVolunteer,
+  );
+  const volunteersLinked = await opportunityVolunteerRepository.find({
+    where: { opportunityId: id },
+  });
+
+  const statusMatch = resolveOpportunityMatchStatus(
+    opportunity.statusMatch,
+    volunteersLinked.map(({ status }) => status),
+  );
+
+  if (statusMatch !== opportunity.statusMatch) {
+    const [, error] = await tryCatch(
+      opportunityRepository.save(Object.assign(opportunity, { statusMatch })),
+    );
+
+    if (!opportunity) {
+      dataSource.logger.log(
+        "warn",
+        `During saving opportunity (id:${id}) occurred: ${error}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- The `statusMatch` column on the `Opportunity` entity was never written to — it stayed permanently at its default `opp-vol-no-matches` regardless of actual volunteer matches
- The `OpportunityVolunteer` entity had an `@AfterUpdate` hook that updated the **volunteer's** `statusMatch`, but nothing equivalent for the **opportunity's** `statusMatch`
- Both `GET /opportunity` (list) and `GET /opportunity/:id` (profile) read this column directly, so both always showed "no matches"

## Changes
- **`src/data/lib/resolve-opp-matching.ts`** — new `resolveOpportunityMatchStatus` function mirroring `resolveVolunteerMatchStatus`: MATCHED/ACTIVE → matched, PENDING only → pending-match, previously engaged → needs-rematch, nothing → no-matches
- **`src/data/utils/update-opportunity-matching.ts`** — new `updateOpportunityMatching` utility mirroring `updateVolunteerMatching`: loads all linked volunteers, resolves status, saves if changed
- **`src/data/lib/index.ts`** / **`src/data/utils/index.ts`** — export the two new additions
- **`src/data/entity/m2m/opportunity-volunteer.ts`** — add `@AfterInsert` hook; both `@AfterInsert` and `@AfterUpdate` now call `updateOpportunityMatching(this.opportunityId)` alongside the existing `updateVolunteerMatching`

## Test plan
- [ ] Suggest a volunteer (PENDING) to an opportunity → opportunity `statusMatch` becomes `opp-vol-pending-match`
- [ ] Change status to MATCHED → opportunity `statusMatch` becomes `opp-vol-matched`; profile header shows matched badge
- [ ] Opportunity table shows matched badge for that opportunity
- [ ] Remove all volunteers → opportunity `statusMatch` becomes `opp-vol-needs-rematch`
- [ ] Existing volunteer and opportunity `statusMatch` values are unaffected for unrelated records

Closes https://github.com/need4deed-org/be/issues/690

🤖 Generated with [Claude Code](https://claude.com/claude-code)