### PR TITLE
feat: include agentId in GET /user/me response

### DIFF
--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -1,6 +1,8 @@
 import { validate } from "class-validator";
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
+  AgentMembershipStatus,
+  AgentRoleType,
   ApiUserGet,
   ApiUserPost,
   Lang,
@@ -160,7 +162,29 @@ export default async function userRoutes(
           return reply.status(404).send({ message: "User not found." });
         }
 
-        const payload = serializeUserToMeDTO(user);
+        let agentId: number | undefined;
+        if (user.personId) {
+          // Prefer VOLUNTEER_COORDINATOR role; fall back to any active membership.
+          const membership =
+            (await fastify.db.agentPersonRepository.findOne({
+              where: {
+                personId: user.personId,
+                status: AgentMembershipStatus.ACTIVE,
+                role: AgentRoleType.VOLUNTEER_COORDINATOR,
+              },
+              order: { id: "ASC" },
+            })) ??
+            (await fastify.db.agentPersonRepository.findOne({
+              where: {
+                personId: user.personId,
+                status: AgentMembershipStatus.ACTIVE,
+              },
+              order: { id: "ASC" },
+            }));
+          agentId = membership?.agentId;
+        }
+
+        const payload = serializeUserToMeDTO(user, agentId);
         return reply
           .status(200)
           .send({ message: "Logged in User", data: payload });

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -349,6 +349,9 @@
         "timezone": {
           "type": "string"
         },
+        "agentId": {
+          "type": "integer"
+        },
         "additionalProperties": false
       },
       "required": ["id", "email", "role"]

--- a/src/services/dto/dto-user.ts
+++ b/src/services/dto/dto-user.ts
@@ -1,7 +1,10 @@
 import { ApiUserGet } from "need4deed-sdk";
 import User from "../../data/entity/user.entity";
 
-export function serializeUserToMeDTO(user: User): ApiUserGet {
+export function serializeUserToMeDTO(
+  user: User,
+  agentId?: number,
+): ApiUserGet & { agentId?: number } {
   return {
     id: user.id,
     // personId is nullable (person-less users); emit undefined so the
@@ -15,5 +18,6 @@ export function serializeUserToMeDTO(user: User): ApiUserGet {
     avatarUrl: user.person?.avatarUrl || "",
     isoCode: user.language || "en",
     timezone: user.timezone || "CET",
+    agentId,
   };
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/need4deed-org/be/issues/684

- Adds optional `agentId` field to `ApiUserMe` schema and `serializeUserToMeDTO`
- `GET /user/me` now queries `agent_person` for the logged-in user's active membership and includes the `agentId` in the response
- Selection rule: prefer `VOLUNTEER_COORDINATOR` role; fall back to any active membership; tie-break by lowest `id`
- Field is omitted when the user has no active agent membership

This replaces the originally proposed `GET /agent/me` route. As noted in the issue discussion, a *user* logs in — not an agent. Putting `agentId` in `/user/me` keeps the concepts clean: the FE reads `agentId` from the user session and fetches full agent details via the existing `GET /agent/:id`.

## Test plan
- [ ] Log in as an agent user → `GET /user/me` returns `agentId` matching their linked agent
- [ ] Log in as a volunteer/coordinator → `GET /user/me` returns no `agentId` field
- [ ] Agent linked to multiple agents as VOLUNTEER_COORDINATOR → returns the one with the lowest `id`
- [ ] Agent with only a PENDING membership → `agentId` is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)