### PR TITLE
feat: add phone field to agent registration

### DIFF
--- a/src/server/schema/agent-register.schema.ts
+++ b/src/server/schema/agent-register.schema.ts
@@ -63,6 +63,7 @@ const registerAgentNewSchema = {
       type: "array",
       items: { $ref: "AgentServiceType#" },
     },
+    phone: { type: "string" },
     addressStreet: { type: "string" },
     addressPostcode: { type: "string" },
     districtId: { type: "integer" },

--- a/src/server/utils/data/write-agent-registration.ts
+++ b/src/server/utils/data/write-agent-registration.ts
@@ -7,6 +7,7 @@ import { dataSource } from "../../../data/data-source";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
 import Agent from "../../../data/entity/opportunity/agent.entity";
+import Person from "../../../data/entity/person.entity";
 import { createAddress } from "./for-routes";
 import { getAgentByAddress } from "./get-agent-by-postcode";
 import { isEmailDomainTrusted } from "./is-trusted-domain";
@@ -40,9 +41,11 @@ export class AgentAddressConflictError extends Error {
  * this only writes agent-side records. A unique-title violation bubbles up for
  * the route to convert into a 409 + join suggestion.
  */
+type AgentRegisterInput = ApiAgentRegisterNew & { phone?: string };
+
 export async function createAgentForPerson(
   personId: number,
-  input: ApiAgentRegisterNew,
+  input: AgentRegisterInput,
 ): Promise<RegisterAgentResult> {
   // Dedup: if the street+postcode already resolve to an existing agent (same
   // picker POST /opportunity/legacy uses), don't mint a duplicate — surface it
@@ -103,6 +106,12 @@ export async function createAgentForPerson(
               ({ agentId: agent.id, languageId }) as AgentLanguage,
           ),
         );
+    }
+
+    if (input.phone) {
+      await manager
+        .getRepository(Person)
+        .update({ id: personId }, { phone: input.phone });
     }
 
     result = {

--- a/src/test/server/utils/data/write-agent-registration.test.ts
+++ b/src/test/server/utils/data/write-agent-registration.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import AgentLanguage from "../../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../../data/entity/m2m/agent-person";
 import Agent from "../../../../data/entity/opportunity/agent.entity";
+import Person from "../../../../data/entity/person.entity";
 import {
   AgentAddressConflictError,
   classifyRegisterAgentConflict,
@@ -41,6 +42,7 @@ vi.mock("../../../../data/data-source", () => ({
 const agentSave = vi.fn();
 const agentPersonSave = vi.fn();
 const agentLanguageSave = vi.fn();
+const personUpdate = vi.fn();
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -53,6 +55,8 @@ beforeEach(() => {
         return { save: agentPersonSave };
       case AgentLanguage:
         return { save: agentLanguageSave };
+      case Person:
+        return { update: personUpdate };
       default:
         throw new Error(`unexpected repo: ${entity?.name}`);
     }
@@ -172,6 +176,20 @@ describe("createAgentForPerson", () => {
       { agentId: 33, languageId: 7 },
       { agentId: 33, languageId: 9 },
     ]);
+  });
+
+  it("updates person.phone inside the transaction when phone is provided", async () => {
+    personUpdate.mockResolvedValue({});
+
+    await createAgentForPerson(11, { title: "Centre HERO", phone: "+49123456789" });
+
+    expect(personUpdate).toHaveBeenCalledWith({ id: 11 }, { phone: "+49123456789" });
+  });
+
+  it("skips person.phone update when phone is not provided", async () => {
+    await createAgentForPerson(11, { title: "Centre HERO" });
+
+    expect(personUpdate).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds optional `phone` field to `registerAgentNewSchema` (JSON body schema for `POST /agent/register`)
- Extends `createAgentForPerson` input type to `ApiAgentRegisterNew & { phone?: string }`
- Persists `phone` to `person.phone` inside the existing create-agent transaction when provided

The field is optional so existing registrations continue to work before FE https://github.com/need4deed-org/fe/issues/676 (phone field in registration form) is implemented.

Closes https://github.com/need4deed-org/be/issues/685

## Test plan
- [ ] Register a new agent with `phone` in the body — confirm `person.phone` is set in DB
- [ ] Register a new agent without `phone` — confirm no error, person record unchanged
- [ ] All existing registration flows (JOIN path) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)