### PR TITLE
fix: expose addressStreet and addressPostcode in agent GET; remove Berlin fallback

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -879,6 +879,8 @@
       "properties": {
         "about": { "type": "string" },
         "address": { "type": "string" },
+        "addressStreet": { "type": ["string", "null"] },
+        "addressPostcode": { "type": ["string", "null"] },
         "website": { "type": "string" },
         "organizationType": { "type": "string" },
         "operator": { "type": "string" },

--- a/src/services/dto/dto-address.ts
+++ b/src/services/dto/dto-address.ts
@@ -2,15 +2,8 @@ import Address from "../../data/entity/location/address.entity";
 
 export function serializeAddress(address: Address): string {
   if (!(address && typeof address === "object")) {
-    return "Berlin";
+    return "";
   }
-  const postcodeCity = [
-    address.postcode?.value,
-    address.city ? address.city : "Berlin",
-  ]
-    .filter(Boolean)
-    .join(" ");
-  return address
-    ? [address.street, postcodeCity].filter(Boolean).join(", ")
-    : "Berlin";
+  const postcodeCity = [address.postcode?.value, address.city].filter(Boolean).join(" ");
+  return [address.street, postcodeCity].filter(Boolean).join(", ");
 }

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -44,9 +44,12 @@ export function dtoAgentGetList(agent: Agent): ApiAgentGetList {
   };
 }
 
+type AgentDetailsExtended = AgentDetails & { addressStreet?: string | null; addressPostcode?: string | null };
+type ApiAgentGetExtended = Omit<ApiAgentGet, "agentDetails"> & { agentDetails: AgentDetailsExtended };
+
 export function dtoAgentGet(
   agent: Agent & { comments: Comment[] },
-): ApiAgentGet {
+): ApiAgentGetExtended {
   return {
     ...dtoAgentGetList(agent),
     createdAt: agent.createdAt,
@@ -82,10 +85,12 @@ export function dtoOpportunityAgent(agent: Agent): ApiOpportunityAgent {
   };
 }
 
-function dtoAgentDetails(agent: Agent): AgentDetails {
+function dtoAgentDetails(agent: Agent): AgentDetails & { addressStreet?: string | null; addressPostcode?: string | null } {
   return {
     about: agent.info,
     address: serializeAddress(agent.address),
+    addressStreet: agent.address?.street ?? null,
+    addressPostcode: agent.address?.postcode?.value ?? null,
     website: agent.website,
     organizationType: agent.type,
     operator: agent?.organization?.title,

--- a/src/test/services/dto/dto-address.test.ts
+++ b/src/test/services/dto/dto-address.test.ts
@@ -13,15 +13,14 @@ describe("serializeAddress", () => {
     expect(serializeAddress(address)).toBe("Friedrichstraße 1, 10117 Berlin");
   });
 
-  it('should use "Berlin" as default when city is missing', () => {
+  it("should omit city when it is missing", () => {
     const address = {
       street: "Friedrichstraße 1",
       postcode: { value: "10117" },
       city: undefined,
     } as Address;
 
-    // Based on: address.city ? address.city : "Berlin"
-    expect(serializeAddress(address)).toBe("Friedrichstraße 1, 10117 Berlin");
+    expect(serializeAddress(address)).toBe("Friedrichstraße 1, 10117");
   });
 
   it("should handle missing postcode gracefully", () => {
@@ -42,16 +41,14 @@ describe("serializeAddress", () => {
     expect(serializeAddress(address)).toBe("20095 Hamburg");
   });
 
-  it('should return "Berlin" if the address object is null or undefined', () => {
-    expect(serializeAddress(null)).toBe("Berlin");
-    expect(serializeAddress(undefined)).toBe("Berlin");
+  it("should return empty string if the address object is null or undefined", () => {
+    expect(serializeAddress(null)).toBe("");
+    expect(serializeAddress(undefined)).toBe("");
   });
 
-  it('should handle an empty address object by defaulting to "Berlin"', () => {
+  it("should return empty string for an empty address object", () => {
     const address = {} as Address;
 
-    // postcodeCity becomes "Berlin", street is undefined
-    // Result: "Berlin"
-    expect(serializeAddress(address)).toBe("Berlin");
+    expect(serializeAddress(address)).toBe("");
   });
 });

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -118,6 +118,23 @@ describe("dtoAgentDetails (Internal Logic)", () => {
     const result = dtoAgentGet(mockAgent as any);
     expect(result.agentDetails.clientLanguages).toEqual([]);
   });
+
+  it("should expose addressStreet and addressPostcode from the address relation", () => {
+    const mockAgent = {
+      agentLanguage: [],
+      address: { street: "Musterstraße 1", postcode: { value: "10115" } },
+    };
+    const result = dtoAgentGet(mockAgent as any);
+    expect(result.agentDetails.addressStreet).toBe("Musterstraße 1");
+    expect(result.agentDetails.addressPostcode).toBe("10115");
+  });
+
+  it("should return null for addressStreet and addressPostcode when address is absent", () => {
+    const mockAgent = { agentLanguage: [] };
+    const result = dtoAgentGet(mockAgent as any);
+    expect(result.agentDetails.addressStreet).toBeNull();
+    expect(result.agentDetails.addressPostcode).toBeNull();
+  });
 });
 
 describe("dtoAgentGetList", () => {


### PR DESCRIPTION
## Summary
- `dtoAgentDetails` now returns `addressStreet` and `addressPostcode` alongside the existing serialised `address` string, allowing the FE edit form to pre-populate individual fields
- `serializeAddress` no longer falls back to `"Berlin"` — returns `""` when address is null/undefined or has no street/postcode/city, so the FE can show an empty state
- `sdk-types.json` `AgentDetails` schema updated with `addressStreet` and `addressPostcode` (nullable strings)
- `dtoAgentGet` return type widened to `ApiAgentGetExtended` to expose the new fields through TypeScript

Closes https://github.com/need4deed-org/be/issues/683
Tracked on FE: https://github.com/need4deed-org/fe/issues/657

## Test plan
- [ ] `GET /agent/:id` response includes `agentDetails.addressStreet` and `agentDetails.addressPostcode`
- [ ] Agent with no address returns `addressStreet: null`, `addressPostcode: null`, `address: ""`
- [ ] Agent with full address returns correct street/postcode and formatted `address` string (no "Berlin" appended unless the city is actually Berlin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)