### PR TITLE
fix: add 24h expiry to email verification/registration token

### DIFF
--- a/src/services/notify/events/email-verification.ts
+++ b/src/services/notify/events/email-verification.ts
@@ -5,6 +5,7 @@ import {
   emailTemplateTtlMs,
   emailVerificationManifestUrl,
   urlEmailVerification,
+  VERIFY_LIFESPAN_MS,
 } from "../../../config/constants";
 import type User from "../../../data/entity/user.entity";
 import { fetchJsonFromUrl } from "../../../data/utils";
@@ -114,11 +115,10 @@ export async function sendEmailVerification(
     throw new Error("User email is required for verification");
   }
 
-  const token = jwt.sign({
-    id: user.id,
-    email: user.email,
-    type: "verify" as TokenType,
-  });
+  const token = jwt.sign(
+    { id: user.id, email: user.email, type: "verify" as TokenType },
+    { expiresIn: `${VERIFY_LIFESPAN_MS}` },
+  );
   const url = `${urlEmailVerification}/${token}`;
 
   logger.debug(`sendEmailVerification: ${user.email}, url: ${url}`);

--- a/src/test/services/notify/email-verification.test.ts
+++ b/src/test/services/notify/email-verification.test.ts
@@ -1,6 +1,6 @@
 import { Lang } from "need4deed-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { urlEmailVerification } from "../../../config/constants";
+import { urlEmailVerification, VERIFY_LIFESPAN_MS } from "../../../config/constants";
 import { fetchJsonFromUrl } from "../../../data/utils";
 import {
   resetVerificationTemplateCache,
@@ -12,7 +12,8 @@ vi.mock("../../../data/utils", () => ({
 }));
 
 const send = vi.fn();
-const deps = { email: { send }, jwt: { sign: () => "tok" } } as any;
+const sign = vi.fn(() => "tok");
+const deps = { email: { send }, jwt: { sign } } as any;
 const user = (over: any = {}) => ({ id: 1, email: "u@x.de", ...over });
 const expectedUrl = `${urlEmailVerification}/tok`;
 
@@ -89,5 +90,16 @@ describe("sendEmailVerification", () => {
     await expect(
       sendEmailVerification(deps, user({ email: undefined })),
     ).rejects.toThrow("User email is required");
+  });
+
+  it("signs the token with VERIFY_LIFESPAN_MS as expiresIn", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendEmailVerification(deps, user());
+
+    expect(sign).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "verify" }),
+      expect.objectContaining({ expiresIn: `${VERIFY_LIFESPAN_MS}` }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
The verify JWT (`{ id, email, type: "verify" }`) was signed without `expiresIn`, making it valid indefinitely. A token embedded in a URL can leak via logs, referrer headers, or browser history — permanent validity was a security risk.

Single change: pass `{ expiresIn: \`${VERIFY_LIFESPAN_MS}\` }` (24 hours, the constant already defined in `config/constants.ts`) to `jwt.sign` in `sendEmailVerification`.

Closes https://github.com/need4deed-org/be/issues/651

## Test plan
- [ ] New test verifies `jwt.sign` is called with `expiresIn: "86400000"` (24h in ms)
- [ ] Verification links clicked within 24h still activate the account and allow registration
- [ ] Links older than 24h are rejected with "Invalid or expired registration token." (existing error handling in `authByVerifyToken` already catches expired JWTs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)