### PR TITLE
feat(opportunity): POST /opportunity with explicit agent + submitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.107",
+    "need4deed-sdk": "0.0.110",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -296,6 +296,23 @@ export default async function opportunityRoutes(
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
       }
 
+      // An AGENT may only create opportunities for an agent they belong to;
+      // COORDINATOR/ADMIN may create for any agent.
+      if (role === UserRole.AGENT) {
+        const personId = request.authUser?.personId;
+        const membership = personId
+          ? await fastify.db.agentPersonRepository.findOneBy({
+              agentId,
+              personId,
+            })
+          : null;
+        if (!membership) {
+          throw new UnauthorizedError(
+            "Agents can only create opportunities for their own agent.",
+          );
+        }
+      }
+
       // The form is legacy-shaped minus the rac_* fields; the legacy parsers
       // accept it. deal.postcode comes from the owning agent's address.
       const legacyBody = body as OpportunityLegacyFormData;

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -2,10 +2,16 @@ import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
   ApiOpportunityGet,
   ApiOpportunityPatch,
+  OpportunityFormDataWithAgentSubmitter,
+  OpportunityLegacyFormData,
   SortOrder,
   UserRole,
 } from "need4deed-sdk";
-import { BadRequestError, NotFoundError } from "../../../config";
+import {
+  BadRequestError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../../config";
 import Comment from "../../../data/entity/comment.entity";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
 import DealLanguage from "../../../data/entity/m2m/deal-language";
@@ -18,12 +24,17 @@ import Person from "../../../data/entity/person.entity";
 import { getDistrictFromPostcode } from "../../../data/utils/get-district";
 import logger from "../../../logger";
 import {
+  accompanyingParserOpportunity,
   dtoOpportunityGet,
   dtoOpportunityGetList,
   parseOpportunity,
+  parseOpportunityLegacy,
 } from "../../../services";
+import { dealParserOpportunity } from "../../../services/dto/parser-deal-opportunity";
 import {
   idParamSchema,
+  opportunityCreateBodySchema,
+  opportunityCreateResponseSchema,
   opportunityListQuerySchema,
   responseSchema,
 } from "../../schema";
@@ -39,6 +50,7 @@ import {
   getCategoryToDealHandler,
   getDistrictToAgentHandler,
   getDistrictToOpportunityHandler,
+  getOpportunityNotificationText,
   getOpportunityOrphanageAgent,
   getOpportunityWhere,
   getOrCreateTimeslot,
@@ -46,6 +58,7 @@ import {
   getSkipTake,
   patchEntity,
   updateOptionList,
+  writeOpportunityLegacy,
 } from "../../utils";
 import {
   makePiiSerialization,
@@ -239,6 +252,80 @@ export default async function opportunityRoutes(
         message: `Opportunities page:${request.query.page}.`,
         data: opportunitiesCategoryDistrict,
         count,
+      });
+    },
+  );
+
+  // Create an opportunity with its satellites (deal + m2m, accompanying). Unlike
+  // POST /opportunity/legacy, the owning agent and submitter are given in the
+  // body / caller — no address/email guessing.
+  fastify.post<{
+    Body: OpportunityFormDataWithAgentSubmitter;
+    Reply: ReplyData<{ id: number }>;
+  }>(
+    "/",
+    {
+      schema: {
+        body: opportunityCreateBodySchema,
+        response: opportunityCreateResponseSchema,
+      },
+    },
+    async (request, reply) => {
+      // GETs are open to any logged-in user (parent onRequest hook); creating an
+      // opportunity is COORDINATOR/AGENT (ADMIN bypasses).
+      const role = request.authUser?.role;
+      if (
+        role !== UserRole.COORDINATOR &&
+        role !== UserRole.AGENT &&
+        role !== UserRole.ADMIN
+      ) {
+        throw new UnauthorizedError();
+      }
+
+      const body = request.body;
+
+      const agentId = body.agent_id;
+      if (!agentId) {
+        throw new BadRequestError("agent_id is required.");
+      }
+      const agent = await fastify.db.agentRepository.findOne({
+        where: { id: agentId },
+        relations: ["address.postcode"],
+      });
+      if (!agent) {
+        throw new NotFoundError(`Agent (id:${agentId}) not found.`);
+      }
+
+      // The form is legacy-shaped minus the rac_* fields; the legacy parsers
+      // accept it. deal.postcode comes from the owning agent's address.
+      const legacyBody = body as OpportunityLegacyFormData;
+      const opportunity = await parseOpportunityLegacy(legacyBody);
+      opportunity.deal = await dealParserOpportunity(
+        legacyBody,
+        agent.address?.postcode?.value,
+      );
+      opportunity.accompanying =
+        body.opportunity_type === "accompanying"
+          ? await accompanyingParserOpportunity(legacyBody)
+          : undefined;
+
+      opportunity.agentId = agentId;
+      // Submitter: the explicit body value, else the authenticated caller.
+      opportunity.submittedByPersonId =
+        body.submitted_by_id ?? request.authUser?.personId;
+
+      const { addDistrictToOpportunity } = getDistrictToOpportunityHandler();
+      Object.assign(opportunity, await addDistrictToOpportunity(opportunity));
+
+      const id = await writeOpportunityLegacy(opportunity);
+
+      fastify.notify.opsAlert(
+        getOpportunityNotificationText(opportunity.title),
+      );
+
+      return reply.status(201).send({
+        message: `Opportunity (${id}) created.`,
+        data: { id },
       });
     },
   );

--- a/src/server/schema/index.ts
+++ b/src/server/schema/index.ts
@@ -3,6 +3,7 @@ export * from "./agent-register.schema";
 export * from "./param";
 export * from "./person.schema";
 export * from "./querystring";
+export * from "./opportunity-create.schema";
 export * from "./response-schema";
 export * from "./responseErrors";
 export * from "./trusted-domain.schema";

--- a/src/server/schema/opportunity-create.schema.ts
+++ b/src/server/schema/opportunity-create.schema.ts
@@ -1,0 +1,54 @@
+import { responseErrors } from "./responseErrors";
+
+// Body for POST /opportunity (SDK OpportunityFormDataWithAgentSubmitter): the
+// legacy opportunity form minus the rac_* fields, plus agent_id + the optional
+// submitted_by_id. The form is loosely typed (voidable), so additional
+// properties are allowed; agent_id presence is enforced in the handler.
+export const opportunityCreateBodySchema = {
+  type: "object",
+  additionalProperties: true,
+  properties: {
+    agent_id: { type: "integer" },
+    submitted_by_id: { type: "integer" },
+    title: { type: "string" },
+    opportunity_type: {
+      type: "string",
+      enum: ["accompanying", "volunteering"],
+    },
+    volunteers_number: { type: ["integer", "string"] },
+    vo_information: { type: "string" },
+    category: { type: "string" },
+    category_id: { type: ["integer", "string"] },
+    languages: { type: "array", items: { type: "string" } },
+    activities: { type: "array", items: { type: "string" } },
+    skills: { type: "array", items: { type: "string" } },
+    berlin_locations: { type: "array", items: { type: "string" } },
+    timeslots: { type: "array" },
+    onetime_date_time: { type: "string" },
+    accomp_address: { type: "string" },
+    accomp_postcode: { type: "string" },
+    accomp_datetime: { type: "string" },
+    accomp_name: { type: "string" },
+    accomp_phone: { type: "string" },
+    accomp_information: { type: "string" },
+    accomp_translation: { type: "string" },
+    language: { type: "string" },
+    last_edited_time_notion: { type: "string" },
+  },
+};
+
+export const opportunityCreateResponseSchema = {
+  201: {
+    type: "object",
+    required: ["message", "data"],
+    properties: {
+      message: { type: "string" },
+      data: {
+        type: "object",
+        required: ["id"],
+        properties: { id: { type: "integer" } },
+      },
+    },
+  },
+  ...responseErrors,
+};

--- a/src/services/dto/parser-deal-opportunity.ts
+++ b/src/services/dto/parser-deal-opportunity.ts
@@ -33,9 +33,13 @@ import {
 
 export async function dealParserOpportunity(
   formData: OpportunityLegacyFormData,
+  postcodeValue?: string,
 ): Promise<Deal> {
-  // postcode
-  const postcode = await getPostcode(String(formData.rac_plz));
+  // postcode: explicit value (e.g. the owning agent's, for POST /opportunity)
+  // wins, else the form's rac_plz. Skip when neither is present so we don't mint
+  // a bogus "undefined" postcode.
+  const code = postcodeValue ?? formData.rac_plz;
+  const postcode = code ? await getPostcode(String(code)) : null;
 
   // activities
   const dealActivity: DealActivity[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.107:
-  version "0.0.107"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.107.tgz#3b9e0b42970a9ef6a21045cf522bbca1cdeee902"
-  integrity sha512-UrHmAnlCg2jfBdM6oVYMESfg5H/U9dAAvIN14zWJBHP82NNtScFEqvojdZD9GlCgUxtDqW1chcWsRY/Zzm7Jvg==
+need4deed-sdk@0.0.110:
+  version "0.0.110"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.110.tgz#4428170ca81fddd35ec80f7a72825c3e6b29d8e7"
+  integrity sha512-kHa6B13x3CcHMhexam+9CBfRX9AV9/8K1RrUTDSAVdRcJ0PecNFs3JSscwBkJ7UWqjSKV89xaqVkN6N3qGQnAA==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## What

`POST /opportunity` — create an opportunity with all its satellites (deal + m2m, accompanying), taking SDK `OpportunityFormDataWithAgentSubmitter` (the legacy opportunity form **minus `rac_*`**, plus `agent_id` / `submitted_by_id`). Like `POST /opportunity/legacy`, but the owning agent and submitter are **given**, not guessed — no `findOrCreateAgent` (address matching) or `getOrCreateSubmitterPerson` (email matching).

## Behaviour
- **Auth:** COORDINATOR or AGENT (ADMIN bypasses); the parent `/opportunity` hook already requires login.
- **Agent:** `agent_id` required → load agent (404 if missing). `deal.postcode` comes from the **agent's address**.
- **Submitter:** `body.submitted_by_id ?? authenticated caller's personId`.
- Reuses `parseOpportunityLegacy` / `dealParserOpportunity` / `accompanyingParserOpportunity` + `writeOpportunityLegacy`; district enrichment; ops alert; returns `201 { id }`.
- `dealParserOpportunity` gains an optional `postcodeValue` arg (the agent's postcode for this endpoint); also fixes a latent legacy bug where a missing `rac_plz` minted a bogus `"undefined"` postcode.
- `POST /opportunity/legacy` unchanged.

## SDK
`need4deed-sdk` `0.0.107 → 0.0.110`. (Note: `0.0.109` had regressed `volunteerNames` because the opp-form line branched off a `main` missing sdk#128; `0.0.110` restores it alongside `agent_id`/`submitted_by_id`.)

## Verification
- typecheck ✓, lint ✓, full suite **329** (server-boot registers the new route + body/response schemas).
- Live: `POST /opportunity` → 401 unauthenticated (route registered + gated). The authenticated data path isn't covered by an automated test (no seeded-user route harness) — same limitation as prior opportunity PRs.

## Follow-up (flagged, not in this PR)
The SDK `main` is still behind the registry (releases cut from unmerged branches), which caused the `0.0.109` volunteerNames regression. Worth a one-time reconciliation of `main` so future SDK changes don't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
