### PR TITLE
fix(#701): add language querystring schema to GET/PATCH /volunteer/:id and POST /volunteer/

### DIFF
--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -26,6 +26,7 @@ import {
 } from "../../../services";
 import {
   idParamSchema,
+  langQuerySchema,
   responseErrors,
   responseSchema,
   volunteerListQuerySchema,
@@ -137,6 +138,7 @@ export default async function volunteerRoutes(
     {
       schema: {
         params: idParamSchema,
+        querystring: langQuerySchema,
         response: responseSchema("volunteer-api-id#"),
       },
     },
@@ -267,6 +269,7 @@ export default async function volunteerRoutes(
       onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
+        querystring: langQuerySchema,
         body: { $ref: "volunteer-api-id-part#" },
         response: {
           200: {
@@ -442,6 +445,7 @@ export default async function volunteerRoutes(
     {
       onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
+        querystring: langQuerySchema,
         body: { $ref: "volunteer-form-data" },
         response: {
           201: {

--- a/src/server/schema/querystring.ts
+++ b/src/server/schema/querystring.ts
@@ -7,6 +7,11 @@ const paginationProps = {
 };
 const langProp = { language: { type: "string" } };
 
+export const langQuerySchema = {
+  type: "object",
+  properties: langProp,
+};
+
 const sortOrderProps = {
   sortOrder: {
     type: "string",


### PR DESCRIPTION
## Summary

Three volunteer endpoints accept a `language` query param to select the response locale but had no `querystring:` schema, so Swagger showed no parameters for them.

- `GET /volunteer/:id`
- `PATCH /volunteer/:id`
- `POST /volunteer/`

Exports `langQuerySchema` from `querystring.ts` (reusing the existing `langProp` constant already used by all list schemas) and adds it to each route's `schema` block.

## Test plan
- [ ] `GET /swagger` → each of the three endpoints now shows `language` as a query parameter

Closes #701
Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)