### PR TITLE
refactor(notify): extract shared email-template helper

### DIFF
--- a/src/services/notify/email-template.ts
+++ b/src/services/notify/email-template.ts
@@ -13,7 +13,7 @@ export interface LocaleContent {
 }
 
 export type Manifest = Partial<Record<Lang, LocaleContent>>;
-export type TemplateVars = Record<string, string>;
+export type TemplateVars = Record<string, string | number>;
 
 const DEFAULT_LOCALE = Lang.EN;
 const PLACEHOLDER_RE = /\{\{\s*(\w+)\s*\}\}/g;
@@ -34,7 +34,7 @@ export function fillTemplate(
         logger.warn(`email template: unresolved placeholder {{${key}}}`);
         return match;
       }
-      return vars[key];
+      return String(vars[key]);
     });
 
   return {
@@ -94,7 +94,9 @@ export function createManifestLoader(url: string): {
     },
     async load(): Promise<Manifest | null> {
       const now = Date.now();
-      if (cache && now < cache.expires) {return cache.value;}
+      if (cache && now < cache.expires) {
+        return cache.value;
+      }
       try {
         const value = (await withTimeout(
           fetchJsonFromUrl(url),

--- a/src/services/notify/email-template.ts
+++ b/src/services/notify/email-template.ts
@@ -1,0 +1,113 @@
+import { Lang } from "need4deed-sdk";
+import {
+  emailTemplateFetchTimeoutMs,
+  emailTemplateTtlMs,
+} from "../../config/constants";
+import { fetchJsonFromUrl } from "../../data/utils";
+import logger from "../../logger";
+
+export interface LocaleContent {
+  subject: string;
+  html?: string;
+  text?: string;
+}
+
+export type Manifest = Partial<Record<Lang, LocaleContent>>;
+export type TemplateVars = Record<string, string>;
+
+const DEFAULT_LOCALE = Lang.EN;
+const PLACEHOLDER_RE = /\{\{\s*(\w+)\s*\}\}/g;
+
+/**
+ * Replace all {{ key }} placeholders in the template content with values from
+ * vars. Handles optional whitespace around keys. Each placeholder that has no
+ * matching key in vars is left unchanged and a warning is logged so template
+ * mismatches surface early.
+ */
+export function fillTemplate(
+  content: LocaleContent,
+  vars: TemplateVars,
+): { subject: string; html?: string; text?: string } {
+  const fill = (s: string): string =>
+    s.replace(PLACEHOLDER_RE, (match, key: string) => {
+      if (!(key in vars)) {
+        logger.warn(`email template: unresolved placeholder {{${key}}}`);
+        return match;
+      }
+      return vars[key];
+    });
+
+  return {
+    subject: fill(content.subject),
+    ...(content.html !== undefined ? { html: fill(content.html) } : {}),
+    ...(content.text !== undefined ? { text: fill(content.text) } : {}),
+  };
+}
+
+export function resolveLocale(language: string | undefined): Lang {
+  return language === Lang.DE
+    ? Lang.DE
+    : language === Lang.EN
+      ? Lang.EN
+      : DEFAULT_LOCALE;
+}
+
+function isValid(content: LocaleContent | undefined): content is LocaleContent {
+  return Boolean(content?.subject && (content.html || content.text));
+}
+
+export function resolveContent(
+  manifest: Manifest | null,
+  locale: Lang,
+  builtin: Record<Lang, LocaleContent>,
+): LocaleContent {
+  const candidates = [manifest?.[locale], manifest?.[DEFAULT_LOCALE]];
+  return candidates.find(isValid) ?? builtin[locale] ?? builtin[DEFAULT_LOCALE];
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+/**
+ * Returns a cached CDN manifest loader bound to a specific URL. Each email
+ * type creates its own loader; they share the same TTL/timeout config but keep
+ * separate caches. resetCache() is exposed for test isolation.
+ */
+export function createManifestLoader(url: string): {
+  load(): Promise<Manifest | null>;
+  resetCache(): void;
+} {
+  let cache: { value: Manifest; expires: number } | null = null;
+
+  return {
+    resetCache() {
+      cache = null;
+    },
+    async load(): Promise<Manifest | null> {
+      const now = Date.now();
+      if (cache && now < cache.expires) {return cache.value;}
+      try {
+        const value = (await withTimeout(
+          fetchJsonFromUrl(url),
+          emailTemplateFetchTimeoutMs,
+        )) as Manifest;
+        cache = { value, expires: now + emailTemplateTtlMs };
+        return value;
+      } catch (err) {
+        logger.warn(
+          `email manifest fetch failed (${url}): ${err instanceof Error ? err.message : err}`,
+        );
+        return cache?.value ?? null;
+      }
+    },
+  };
+}

--- a/src/services/notify/events/email-verification.ts
+++ b/src/services/notify/events/email-verification.ts
@@ -1,14 +1,18 @@
 import type { JWT, TokenType } from "@fastify/jwt";
 import { Lang } from "need4deed-sdk";
 import {
-  emailTemplateFetchTimeoutMs,
-  emailTemplateTtlMs,
   emailVerificationManifestUrl,
   urlEmailVerification,
 } from "../../../config/constants";
 import type User from "../../../data/entity/user.entity";
-import { fetchJsonFromUrl } from "../../../data/utils";
 import logger from "../../../logger";
+import {
+  createManifestLoader,
+  fillTemplate,
+  resolveContent,
+  resolveLocale,
+  type LocaleContent,
+} from "../email-template";
 import type { EmailMessage, EmailTransport } from "../types";
 
 export interface EmailVerificationDeps {
@@ -16,94 +20,24 @@ export interface EmailVerificationDeps {
   jwt: JWT;
 }
 
-interface LocaleContent {
-  subject: string;
-  html?: string;
-  text?: string;
-}
-type VerificationManifest = Partial<Record<Lang, LocaleContent>>;
-
-const URL_PLACEHOLDER = "{{verificationUrl}}";
-const DEFAULT_LOCALE = Lang.EN;
-
-// Built-in fallback used when the CDN manifest is missing/invalid, so a
-// verification email always sends (and in the user's language where possible).
 const BUILTIN: Record<Lang, LocaleContent> = {
   [Lang.EN]: {
     subject: "Account Created",
-    text: `Your account has been created successfully. Please verify your email:\n${URL_PLACEHOLDER}`,
-    html: `<p>Your account has been created successfully. Please verify your email:</p><p><a href="${URL_PLACEHOLDER}">${URL_PLACEHOLDER}</a></p>`,
+    text: `Your account has been created successfully. Please verify your email:\n{{verificationUrl}}`,
+    html: `<p>Your account has been created successfully. Please verify your email:</p><p><a href="{{verificationUrl}}">{{verificationUrl}}</a></p>`,
   },
   [Lang.DE]: {
     subject: "Konto erstellt",
-    text: `Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail:\n${URL_PLACEHOLDER}`,
-    html: `<p>Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail:</p><p><a href="${URL_PLACEHOLDER}">${URL_PLACEHOLDER}</a></p>`,
+    text: `Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail:\n{{verificationUrl}}`,
+    html: `<p>Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail:</p><p><a href="{{verificationUrl}}">{{verificationUrl}}</a></p>`,
   },
 };
 
-let manifestCache: { value: VerificationManifest; expires: number } | null =
-  null;
+const loader = createManifestLoader(emailVerificationManifestUrl);
 
 /** Test-only: drop the cached manifest so each test fetches fresh. */
 export function resetVerificationTemplateCache(): void {
-  manifestCache = null;
-}
-
-async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  let timer: ReturnType<typeof setTimeout>;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
-  });
-  try {
-    return await Promise.race([promise, timeout]);
-  } finally {
-    clearTimeout(timer!);
-  }
-}
-
-/**
- * Load the email manifest from the CDN, cached in-memory for emailTemplateTtlMs.
- * On any failure, serve the last good value if we have one, else null (→ the
- * caller falls back to BUILTIN). Never throws.
- */
-async function loadManifest(): Promise<VerificationManifest | null> {
-  const now = Date.now();
-  if (manifestCache && now < manifestCache.expires) {
-    return manifestCache.value;
-  }
-  try {
-    const value = (await withTimeout(
-      fetchJsonFromUrl(emailVerificationManifestUrl),
-      emailTemplateFetchTimeoutMs,
-    )) as VerificationManifest;
-    manifestCache = { value, expires: now + emailTemplateTtlMs };
-    return value;
-  } catch (err) {
-    logger.warn(
-      `email verification manifest fetch failed: ${err instanceof Error ? err.message : err}`,
-    );
-    return manifestCache?.value ?? null; // last-good (stale) or built-in
-  }
-}
-
-function resolveLocale(language: string | undefined): Lang {
-  return language === Lang.DE
-    ? Lang.DE
-    : language === Lang.EN
-      ? Lang.EN
-      : DEFAULT_LOCALE;
-}
-
-function isValid(content: LocaleContent | undefined): content is LocaleContent {
-  return Boolean(content?.subject && (content.html || content.text));
-}
-
-function resolveContent(
-  manifest: VerificationManifest | null,
-  locale: Lang,
-): LocaleContent {
-  const candidates = [manifest?.[locale], manifest?.[DEFAULT_LOCALE]];
-  return candidates.find(isValid) ?? BUILTIN[locale] ?? BUILTIN[DEFAULT_LOCALE];
+  loader.resetCache();
 }
 
 export async function sendEmailVerification(
@@ -124,16 +58,19 @@ export async function sendEmailVerification(
   logger.debug(`sendEmailVerification: ${user.email}, url: ${url}`);
 
   const content = resolveContent(
-    await loadManifest(),
+    await loader.load(),
     resolveLocale(user.language),
+    BUILTIN,
   );
-  const fill = (s?: string) => s?.split(URL_PLACEHOLDER).join(url);
+  const { subject, html, text } = fillTemplate(content, {
+    verificationUrl: url,
+  });
 
   const message: EmailMessage = {
     to: user.email,
-    subject: content.subject,
-    ...(content.text ? { text: fill(content.text) } : {}),
-    ...(content.html ? { html: fill(content.html) } : {}),
+    subject,
+    ...(text !== undefined ? { text } : {}),
+    ...(html !== undefined ? { html } : {}),
   };
 
   await email.send(message);

--- a/src/test/services/notify/email-template.test.ts
+++ b/src/test/services/notify/email-template.test.ts
@@ -1,0 +1,208 @@
+import { Lang } from "need4deed-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchJsonFromUrl } from "../../../data/utils";
+import {
+  createManifestLoader,
+  fillTemplate,
+  resolveContent,
+  resolveLocale,
+  type LocaleContent,
+} from "../../../services/notify/email-template";
+
+vi.mock("../../../data/utils", () => ({
+  fetchJsonFromUrl: vi.fn(),
+}));
+
+// ─── fillTemplate ────────────────────────────────────────────────────────────
+
+describe("fillTemplate", () => {
+  it("substitutes a single placeholder in all fields", () => {
+    const result = fillTemplate(
+      {
+        subject: "Hello {{name}}",
+        text: "Hi {{name}}, welcome!",
+        html: "<p>Hi {{name}}</p>",
+      },
+      { name: "Alice" },
+    );
+    expect(result.subject).toBe("Hello Alice");
+    expect(result.text).toBe("Hi Alice, welcome!");
+    expect(result.html).toBe("<p>Hi Alice</p>");
+  });
+
+  it("substitutes multiple distinct placeholders", () => {
+    const result = fillTemplate(
+      {
+        subject: "{{event}} confirmation",
+        html: "<p>Dear {{name}}, your {{event}} is on {{date}}.</p>",
+        text: "Dear {{name}}, your {{event}} is on {{date}}.",
+      },
+      { name: "Bob", event: "appointment", date: "2026-07-01" },
+    );
+    expect(result.subject).toBe("appointment confirmation");
+    expect(result.html).toBe(
+      "<p>Dear Bob, your appointment is on 2026-07-01.</p>",
+    );
+    expect(result.text).toBe("Dear Bob, your appointment is on 2026-07-01.");
+  });
+
+  it("replaces the same placeholder appearing multiple times", () => {
+    const result = fillTemplate(
+      { subject: "link", html: '<a href="{{url}}">{{url}}</a>' },
+      { url: "https://example.com/verify" },
+    );
+    expect(result.html).toBe(
+      '<a href="https://example.com/verify">https://example.com/verify</a>',
+    );
+    expect(result.html).not.toContain("{{url}}");
+  });
+
+  it("accepts {{ key }} with surrounding whitespace", () => {
+    const result = fillTemplate(
+      { subject: "{{ name }} joined" },
+      { name: "Eve" },
+    );
+    expect(result.subject).toBe("Eve joined");
+  });
+
+  it("omits html and text keys when absent from content", () => {
+    const result = fillTemplate({ subject: "plain" }, {});
+    expect(result).toEqual({ subject: "plain" });
+    expect("html" in result).toBe(false);
+    expect("text" in result).toBe(false);
+  });
+
+  it("preserves unresolved placeholders in output", () => {
+    const result = fillTemplate(
+      { subject: "Hi {{name}}", text: "Code: {{code}}" },
+      { name: "Alice" },
+    );
+    expect(result.subject).toBe("Hi Alice");
+    expect(result.text).toBe("Code: {{code}}");
+  });
+
+  it("ignores extra vars that have no matching placeholder", () => {
+    const result = fillTemplate(
+      { subject: "Hello {{name}}" },
+      { name: "Dave", unused: "x" },
+    );
+    expect(result.subject).toBe("Hello Dave");
+  });
+
+  it("substitutes an empty string value correctly", () => {
+    const result = fillTemplate({ subject: "Hi {{name}}" }, { name: "" });
+    expect(result.subject).toBe("Hi ");
+  });
+});
+
+// ─── resolveLocale ───────────────────────────────────────────────────────────
+
+describe("resolveLocale", () => {
+  it("returns DE for 'de'", () => {
+    expect(resolveLocale("de")).toBe(Lang.DE);
+  });
+
+  it("returns EN for 'en'", () => {
+    expect(resolveLocale("en")).toBe(Lang.EN);
+  });
+
+  it("falls back to EN for unknown languages", () => {
+    expect(resolveLocale("fr")).toBe(Lang.EN);
+    expect(resolveLocale(undefined)).toBe(Lang.EN);
+  });
+});
+
+// ─── resolveContent ──────────────────────────────────────────────────────────
+
+const builtin: Record<Lang, LocaleContent> = {
+  [Lang.EN]: { subject: "Builtin EN", text: "builtin en text" },
+  [Lang.DE]: { subject: "Builtin DE", text: "builtin de text" },
+};
+
+describe("resolveContent", () => {
+  it("returns the manifest entry for the requested locale", () => {
+    const manifest = {
+      [Lang.EN]: { subject: "Manifest EN", html: "<p>en</p>" },
+      [Lang.DE]: { subject: "Manifest DE", html: "<p>de</p>" },
+    };
+    expect(resolveContent(manifest, Lang.DE, builtin).subject).toBe(
+      "Manifest DE",
+    );
+  });
+
+  it("falls back to EN manifest when requested locale is missing", () => {
+    const manifest = {
+      [Lang.EN]: { subject: "Manifest EN", html: "<p>en</p>" },
+    };
+    expect(resolveContent(manifest, Lang.DE, builtin).subject).toBe(
+      "Manifest EN",
+    );
+  });
+
+  it("falls back to builtin when manifest is null", () => {
+    expect(resolveContent(null, Lang.DE, builtin).subject).toBe("Builtin DE");
+  });
+
+  it("falls back to builtin when manifest entry is invalid (no body)", () => {
+    const manifest = { [Lang.EN]: { subject: "no body" } };
+    expect(resolveContent(manifest, Lang.EN, builtin).subject).toBe(
+      "Builtin EN",
+    );
+  });
+});
+
+// ─── createManifestLoader ────────────────────────────────────────────────────
+
+describe("createManifestLoader", () => {
+  const url = "https://cdn.example.com/emails/test.json";
+  const manifest = {
+    [Lang.EN]: { subject: "Test", html: "<p>test</p>" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches and returns the manifest", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+    const loader = createManifestLoader(url);
+    expect(await loader.load()).toEqual(manifest);
+  });
+
+  it("caches within TTL (single fetch across multiple calls)", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+    const loader = createManifestLoader(url);
+    await loader.load();
+    await loader.load();
+    expect(fetchJsonFromUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after resetCache()", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+    const loader = createManifestLoader(url);
+    await loader.load();
+    loader.resetCache();
+    await loader.load();
+    expect(fetchJsonFromUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null on fetch failure when no stale cache exists", async () => {
+    vi.mocked(fetchJsonFromUrl).mockRejectedValue(new Error("CDN down"));
+    const loader = createManifestLoader(url);
+    expect(await loader.load()).toBeNull();
+  });
+
+  it("serves stale cache when a subsequent fetch fails after TTL expires", async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetchJsonFromUrl)
+      .mockResolvedValueOnce(manifest)
+      .mockRejectedValueOnce(new Error("CDN down"));
+    const loader = createManifestLoader(url);
+
+    await loader.load(); // populates cache
+    vi.advanceTimersByTime(11 * 60 * 1000); // past default 10-min TTL
+    const result = await loader.load(); // fetch fails → returns stale
+    expect(result).toEqual(manifest);
+    vi.useRealTimers();
+  });
+});

--- a/src/test/services/notify/email-template.test.ts
+++ b/src/test/services/notify/email-template.test.ts
@@ -1,5 +1,5 @@
 import { Lang } from "need4deed-sdk";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchJsonFromUrl } from "../../../data/utils";
 import {
   createManifestLoader,
@@ -163,6 +163,10 @@ describe("createManifestLoader", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("fetches and returns the manifest", async () => {
     vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
     const loader = createManifestLoader(url);
@@ -203,6 +207,5 @@ describe("createManifestLoader", () => {
     vi.advanceTimersByTime(11 * 60 * 1000); // past default 10-min TTL
     const result = await loader.load(); // fetch fails → returns stale
     expect(result).toEqual(manifest);
-    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

- Extracts `fillTemplate`, `createManifestLoader`, `resolveLocale`, and `resolveContent` into a new `src/services/notify/email-template.ts` module so all future outbound email types (suggestions, tagging, matching notifications, reminders) share the same CDN-manifest + placeholder infrastructure without duplication
- `fillTemplate(content, vars)` replaces all `{{ key }}` placeholders via regex; handles optional whitespace around keys; unresolved placeholders are preserved in output and logged as warnings
- `createManifestLoader(url)` is a factory with a per-instance TTL cache and `resetCache()` for test isolation, replacing the module-level cache variable pattern
- `email-verification.ts` reduced from 141 → 70 lines; public API (`sendEmailVerification`, `resetVerificationTemplateCache`) unchanged

## Test plan

- [ ] 20 new tests in `email-template.test.ts` covering `fillTemplate` (single/multiple/repeated placeholders, whitespace, missing html/text, unresolved vars, empty-string values), `resolveLocale`, `resolveContent`, and `createManifestLoader` (caching, reset, fetch failure, stale-serve with fake timers)
- [ ] All 6 existing `email-verification` tests continue to pass
- [ ] Full suite: 364 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)