### PR TITLE
feat: add read_at to comment_person; PATCH /comment/:id/read endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.111",
+    "need4deed-sdk": "0.0.112",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/data/entity/m2m/comment-person.ts
+++ b/src/data/entity/m2m/comment-person.ts
@@ -41,4 +41,7 @@ export default class CommentPerson {
 
   @Column()
   personId: number;
+
+  @Column({ type: "timestamp", nullable: true, default: null })
+  readAt: Date | null;
 }

--- a/src/data/migrations/1782245067240-add-read-at-to-comment-person.ts
+++ b/src/data/migrations/1782245067240-add-read-at-to-comment-person.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddReadAtToCommentPerson1782245067240
+  implements MigrationInterface
+{
+  name = "AddReadAtToCommentPerson1782245067240";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "comment_person" ADD "read_at" TIMESTAMP`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "comment_person" DROP COLUMN "read_at"`,
+    );
+  }
+}

--- a/src/server/routes/comment.ts
+++ b/src/server/routes/comment.ts
@@ -397,6 +397,75 @@ export default async function commentRoutes(
     },
   );
 
+  //
+  // PATCH /comment/:id/read
+  //
+  fastify.patch(
+    "/:id/read",
+    {
+      schema: {
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              message: { type: "string" },
+              data: { $ref: "ApiComment#" },
+            },
+            required: ["message", "data"],
+          },
+          ...responseErrors,
+        },
+      },
+      onRequest: [fastify.authenticate()],
+    },
+    async (request, reply) => {
+      const id = Number((request.params as { id: string }).id);
+      if (isNaN(id) || id <= 0) {
+        return reply
+          .status(400)
+          .send({ message: "Invalid comment ID provided." });
+      }
+
+      const personId = request.authUser?.personId;
+      if (!personId) {
+        return reply
+          .status(403)
+          .send({ message: "No person linked to this user." });
+      }
+
+      const cpRepository =
+        fastify.db.commentRepository.manager.getRepository(CommentPerson);
+      const cp = await cpRepository.findOne({
+        where: { commentId: id, personId },
+      });
+      if (!cp) {
+        return reply
+          .status(404)
+          .send({
+            message: `No tag found for comment id:${id} on your person.`,
+          });
+      }
+
+      cp.readAt = new Date();
+      await cpRepository.save(cp);
+
+      const comment = await fastify.db.commentRepository.findOne({
+        where: { id },
+        relations: ["user", "user.person", "language", "commentPerson"],
+      });
+      if (!comment) {
+        return reply
+          .status(404)
+          .send({ message: `Comment id:${id} not found.` });
+      }
+
+      return reply.status(200).send({
+        message: `Comment id:${id} marked as read`,
+        data: commentSerializer(comment),
+      });
+    },
+  );
+
   fastify.delete(
     "/:id",
     {

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -217,7 +217,7 @@
           "type": "string"
         },
         "entityId": {
-          "type": "number"
+          "type": "integer"
         },
         "entityType": {
           "type": "string"
@@ -229,13 +229,14 @@
           "type": "string",
           "format": "date-time"
         },
-        "taggedPersonIds": {
+        "taggedPersons": {
           "type": "array",
           "items": {
-            "type": "integer"
+            "$ref": "ApiCommentTaggedPerson#"
           }
         }
-      }
+      },
+      "required": ["id", "content", "authorName", "timestamp", "taggedPersons"]
     },
     "ApiPerson": {
       "$id": "ApiPerson",
@@ -1552,6 +1553,20 @@
           "type": "string"
         }
       }
+    },
+    "ApiCommentTaggedPerson": {
+      "$id": "ApiCommentTaggedPerson",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "readAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      },
+      "required": ["id", "readAt"]
     }
   }
 }

--- a/src/services/dto/dto-comment.ts
+++ b/src/services/dto/dto-comment.ts
@@ -9,7 +9,9 @@ export function commentSerializer(comment: Comment): ApiComment {
     entityType: comment.entityType,
     authorName: comment.user?.person?.name,
     timestamp: comment.updatedAt,
-    taggedPersonIds:
-      comment.commentPerson?.map((cp) => cp.personId).filter(Boolean) ?? [],
+    taggedPersons:
+      comment.commentPerson
+        ?.filter((cp) => cp.personId)
+        .map((cp) => ({ id: cp.personId, readAt: cp.readAt ?? null })) ?? [],
   };
 }

--- a/src/test/services/dto/dto-comment.test.ts
+++ b/src/test/services/dto/dto-comment.test.ts
@@ -21,11 +21,12 @@ describe("commentSerializer", () => {
       entityType: "volunteer",
       authorName: "Coordinator Jane",
       timestamp: comment.updatedAt,
-      taggedPersonIds: [],
+      taggedPersons: [],
     });
   });
 
-  it("maps commentPerson rows to taggedPersonIds", () => {
+  it("maps commentPerson rows to taggedPersons with readAt", () => {
+    const readAt = new Date("2025-04-01");
     const comment = {
       id: 10,
       text: "Hey <@5> and <@9>",
@@ -33,14 +34,20 @@ describe("commentSerializer", () => {
       entityType: "opportunity",
       updatedAt: new Date(),
       user: { person: { name: "Author" } },
-      commentPerson: [{ personId: 5 }, { personId: 9 }],
+      commentPerson: [
+        { personId: 5, readAt },
+        { personId: 9, readAt: null },
+      ],
     };
 
     const result = commentSerializer(comment as any);
-    expect(result.taggedPersonIds).toEqual([5, 9]);
+    expect(result.taggedPersons).toEqual([
+      { id: 5, readAt },
+      { id: 9, readAt: null },
+    ]);
   });
 
-  it("returns an empty taggedPersonIds when commentPerson is missing", () => {
+  it("returns an empty taggedPersons when commentPerson is missing", () => {
     const comment = {
       id: 11,
       text: "no tags",
@@ -51,7 +58,7 @@ describe("commentSerializer", () => {
     };
 
     const result = commentSerializer(comment as any);
-    expect(result.taggedPersonIds).toEqual([]);
+    expect(result.taggedPersons).toEqual([]);
   });
 
   it("returns undefined authorName when user has no person", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.111:
-  version "0.0.111"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.111.tgz#1d30a2093ae66b891ffd61f1fb716894008cd2e4"
-  integrity sha512-p9dcuxiqkwNqCdCYPTWgwZPqfYNFJ9exBrOEqdcWpCGSP7zdaHHyOHXa71EbcFNYEubL2OXi+iZwNCx+LUO0oQ==
+need4deed-sdk@0.0.112:
+  version "0.0.112"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.112.tgz#85b60f3fc2ff0ab016c87377a26c5fa0b9a30548"
+  integrity sha512-bgWyvra5Mvyi6R/UfNyutQVMEGHAFY0uBJzVpu5S2ja2yHm0oVPm2vvG6Z2fikZwew2m2PH+pA28UjPXlQIEoQ==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

- **Schema**: `read_at TIMESTAMP NULL` added to `comment_person` (migration `add-read-at-to-comment-person`)
- **SDK 0.0.112**: `ApiComment.taggedPersonIds: number[]` replaced by `taggedPersons: { id: number; readAt: Date | null }[]`; new `ApiCommentTaggedPerson` schema registered in `sdk-types.json`
- **DTO**: `commentSerializer` updated to produce `taggedPersons`; tests updated
- **Endpoint**: `PATCH /comment/:id/read` — sets `read_at = now()` for the authenticated user's `comment_person` row on that comment; returns the updated `ApiComment`; 404 if the user's person is not tagged on that comment

## Breaking change

`ApiComment.taggedPersonIds` is gone. Consumers should migrate:
```ts
// before
comment.taggedPersonIds            // number[]
// after
comment.taggedPersons.map(p => p.id)   // number[]
comment.taggedPersons[i].readAt        // Date | null
```

## Test plan

- [ ] `GET /comment?entityId=X` — each comment's `taggedPersons` includes `{ id, readAt }` pairs; `readAt` is `null` for unread entries
- [ ] `PATCH /comment/:id/read` — returns 200 with updated comment; subsequent GET shows non-null `readAt` for the calling user's person
- [ ] `PATCH /comment/:id/read` — returns 404 when calling user's person is not tagged on the comment
- [ ] Existing POST/PATCH comment flows still work (tags are still created, `read_at` defaults to null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)