### PR TITLE
feat(fe#570): expose agentId on opportunity list response

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.113",
+    "need4deed-sdk": "0.0.114",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.112",
+    "need4deed-sdk": "0.0.113",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -973,7 +973,7 @@
           "type": "string"
         },
         "agentId": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "volunteerNames": {
           "type": "array",

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -972,6 +972,9 @@
         "agentTitle": {
           "type": "string"
         },
+        "agentId": {
+          "type": "integer"
+        },
         "volunteerNames": {
           "type": "array",
           "items": {
@@ -994,7 +997,8 @@
         "availability",
         "location",
         "accompanyingDetails",
-        "agentTitle"
+        "agentTitle",
+        "agentId"
       ]
     },
     "ApiOpportunityGet": {

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -82,6 +82,7 @@ export function dtoOpportunityGetList(
     availability: getAvailabilityTryCatch(opportunity.deal.dealTimeslot) ?? [],
     accompanyingDetails: dtoOpportunityAccompanying(opportunity.accompanying!),
     agentTitle: opportunity.agent?.title ?? "",
+    agentId: opportunity.agentId,
     // Names of the volunteers MATCHED to the opportunity (status opp-matched
     // only — not pending/active/past links). PII masking runs before this DTO,
     // so masked names pass through. Needs the
@@ -143,6 +144,7 @@ export function dtoOpportunityGet(
     description: getOpportunityDescription(opportunityComments) ?? "",
     numberOfVolunteers: opportunityComments.numberVolunteers,
     agentTitle: opportunityComments.agent?.title ?? "",
+    agentId: opportunityComments.agentId,
     languages: opportunityComments.deal.dealLanguage
       .filter(Boolean)
       .map((pl) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.112:
-  version "0.0.112"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.112.tgz#85b60f3fc2ff0ab016c87377a26c5fa0b9a30548"
-  integrity sha512-bgWyvra5Mvyi6R/UfNyutQVMEGHAFY0uBJzVpu5S2ja2yHm0oVPm2vvG6Z2fikZwew2m2PH+pA28UjPXlQIEoQ==
+need4deed-sdk@0.0.113:
+  version "0.0.113"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.113.tgz#119b6e47807da1d7f4c77ca46c500d0150a7f7e1"
+  integrity sha512-o7O20HVldllNHmhHjLmdVeuXqkAe+uMxHiOssCndGhxKOtvz5F0ina7/EMt+yqrREGRCpJjkTziVe9I/EVc32w==
 
 no-case@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.113:
-  version "0.0.113"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.113.tgz#119b6e47807da1d7f4c77ca46c500d0150a7f7e1"
-  integrity sha512-o7O20HVldllNHmhHjLmdVeuXqkAe+uMxHiOssCndGhxKOtvz5F0ina7/EMt+yqrREGRCpJjkTziVe9I/EVc32w==
+need4deed-sdk@0.0.114:
+  version "0.0.114"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.114.tgz#6dee6f266310de84ba7ff790db58c09f40329467"
+  integrity sha512-KkHa+PSIZBJ8XoteoAL4xhlb/eV4nkU7ViPqXMFtemKWwXTKP7nNfsxEB/wmPQlkH9MjwcG9yz9NaccJx8WzIw==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

Adds `agentId: number` to `GET /opportunity` list and detail responses (`dtoOpportunityGetList` + `dtoOpportunityGet`), alongside the existing `agentTitle`.

No schema change — `agentId` already exists on the `opportunity` entity. SDK bumped to 0.0.113.

Unblocks fe#570 (NGO view column masking): the FE can now compare `row.agentId` against the authenticated user's own agent ID to decide which columns to show.

## Test plan

- [ ] `GET /opportunity` — each item includes `agentId` matching the opportunity's agent
- [ ] `GET /opportunity/:id` — response includes `agentId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)