### PR TITLE
ci: AITS deploy workflow

### DIFF
--- a/.github/workflows/deploy-aits.yaml
+++ b/.github/workflows/deploy-aits.yaml
@@ -1,0 +1,36 @@
+name: deploy-aits
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/need4deed-org/be:develop
+
+      - name: Roll out new image on AITS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.AITS_HOST }}
+          username: root
+          key: ${{ secrets.AITS_SSH_KEY }}
+          script: kubectl rollout restart deployment/be -n n4d-dev


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-aits.yaml`
- Triggers on every merge to `develop`
- Builds and pushes `ghcr.io/need4deed-org/be:develop` to GHCR
- SSHes to the AITS VPS and runs `kubectl rollout restart deployment/be -n n4d-dev`

## Required repo secrets
Add these under **Settings → Secrets → Actions** before the first deploy:
- `AITS_HOST` — IPv4 of the Infomaniak VPS
- `AITS_SSH_KEY` — private key for root SSH access

## Test plan
- [ ] Add `AITS_HOST` and `AITS_SSH_KEY` secrets to the `be` repo
- [ ] VPS bootstrapped (see `infra` repo `scripts/bootstrap.sh`)
- [ ] Merge a change to `develop` and verify the action runs green and the pod restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)