### PR TITLE
✨ feat: add POST /user/admin for admin-privileged user creation

### DIFF
--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -400,4 +400,89 @@ export default async function userRoutes(
       return reply.status(201).send(savedUser);
     },
   );
+
+  // Admin-only user creation — accepts any role including admin/coordinator.
+  // Unlike POST /user/ this endpoint requires an authenticated admin session
+  // and activates the account immediately (no email verification flow).
+  fastify.post<{
+    Body: ApiUserPost;
+    Reply: User | { message: string; errors?: any };
+  }>(
+    "/admin",
+    {
+      schema: {
+        body: createUserBodySchema,
+        response: {
+          201: userResponseSchemaIncludePerson,
+          ...responseErrors,
+        },
+      },
+      onRequest: [fastify.authenticate({ role: UserRole.ADMIN })],
+      preHandler: async (request) => {
+        const { person: personData, email } = request.body;
+        const personRepository = fastify.db.personRepository;
+
+        if (personData.id) {
+          const resolvedPerson = await personRepository.findOneBy({
+            id: personData.id,
+          });
+          if (!resolvedPerson) {
+            throw new BadRequestError(
+              `Person with ID ${personData.id} not found.`,
+            );
+          }
+          if (!resolvedPerson.email) {
+            resolvedPerson.email = email;
+          }
+          request.resolvedPerson = resolvedPerson;
+          return;
+        }
+
+        const newPerson = new Person(personData);
+        newPerson.email = email;
+        const errors = await validate(newPerson);
+        if (errors.length > 0) {
+          const messages = errors.flatMap((err) =>
+            Object.values(err.constraints || {}),
+          );
+          throw new BadRequestError(
+            `Validation failed for new person data: ${messages.join("; ")}`,
+          );
+        }
+        request.resolvedPerson = newPerson;
+      },
+    },
+    async (request, reply) => {
+      const { email, password: passwordPlain, role, language } = request.body;
+      const userRepository = fastify.db.userRepository;
+
+      if (await userRepository.findOneBy({ email })) {
+        throw new ConflictError("User with this email already exists.");
+      }
+
+      const newUser = new User({
+        email,
+        password: await hashPassword(passwordPlain),
+        role,
+        isActive: true,
+        language: language ?? Lang.EN,
+        timezone: "CET",
+        person: request.resolvedPerson,
+      });
+
+      const errors = await validate(newUser);
+      if (errors.length > 0) {
+        logger.error(
+          `User entity validation errors: ${JSON.stringify(errors)}`,
+        );
+        return reply.status(400).send({
+          message: "Validation failed for newUser data",
+          errors: errors.flatMap((err) => Object.values(err.constraints || {})),
+        });
+      }
+
+      const savedUser = await userRepository.save(newUser);
+      return reply.status(201).send(savedUser);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- Adds `POST /user/admin` — an admin-authenticated endpoint that creates users with any role, including `admin` and `coordinator`
- Public `POST /user/` remains unchanged (still blocks privileged roles, still sends email verification)
- Admin-created accounts are set `isActive: true` immediately — no email verification flow

## Motivation

The existing `POST /user/` endpoint is for self-registration and explicitly rejects `admin`/`coordinator` roles. There was no API path to provision privileged users without direct DB access.

## Contract

Reuses existing SDK types (`ApiUserPost` body, `userResponseSchemaIncludePerson` response) — no SDK change required.

## Test plan

- [ ] `POST /user/admin` without auth → 401
- [ ] `POST /user/admin` with volunteer session → 403
- [ ] `POST /user/admin` with admin session + `role: coordinator` → 201, `isActive: true`
- [ ] `POST /user/admin` with admin session + `role: admin` → 201, `isActive: true`
- [ ] Duplicate email → 409
- [ ] `POST /user/` with `role: admin` still → 401 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)