### PR TITLE
chore: upgrade need4deed-sdk to 0.0.115, fix agentId handling in GET /user/me

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.114",
+    "need4deed-sdk": "0.0.115",
     "pg": "^8.14.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",

--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -163,7 +163,7 @@ export default async function userRoutes(
         }
 
         let agentId: number | undefined;
-        if (user.personId) {
+        if (user.role === UserRole.AGENT && user.personId) {
           // Prefer VOLUNTEER_COORDINATOR role; fall back to any active membership.
           const membership =
             (await fastify.db.agentPersonRepository.findOne({

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -456,9 +456,9 @@
         },
         "agentId": {
           "type": "integer"
-        },
-        "additionalProperties": false
+        }
       },
+      "additionalProperties": false,
       "required": ["id", "email", "role"]
     },
     "DocumentType": {

--- a/src/services/dto/dto-user.ts
+++ b/src/services/dto/dto-user.ts
@@ -1,10 +1,7 @@
 import { ApiUserGet } from "need4deed-sdk";
 import User from "../../data/entity/user.entity";
 
-export function serializeUserToMeDTO(
-  user: User,
-  agentId?: number,
-): ApiUserGet & { agentId?: number } {
+export function serializeUserToMeDTO(user: User, agentId?: number): ApiUserGet {
   return {
     id: user.id,
     // personId is nullable (person-less users); emit undefined so the

--- a/src/test/services/dto/dto-user.test.ts
+++ b/src/test/services/dto/dto-user.test.ts
@@ -55,6 +55,38 @@ describe("serializeUserToMeDTO", () => {
     expect(result.personId).toBeUndefined();
   });
 
+  it("includes agentId in the result when provided", () => {
+    const user = {
+      id: 4,
+      personId: 10,
+      email: "agent@example.com",
+      isActive: true,
+      role: "agent",
+      language: "en",
+      timezone: "CET",
+      person: { firstName: "Bob", name: "Bob Agent", avatarUrl: "" },
+    };
+
+    const result = serializeUserToMeDTO(user as any, 99);
+    expect(result.agentId).toBe(99);
+  });
+
+  it("omits agentId when not provided", () => {
+    const user = {
+      id: 5,
+      personId: 11,
+      email: "vol@example.com",
+      isActive: true,
+      role: "volunteer",
+      language: "en",
+      timezone: "CET",
+      person: { firstName: "Eve", name: "Eve Vol", avatarUrl: "" },
+    };
+
+    const result = serializeUserToMeDTO(user as any);
+    expect(result.agentId).toBeUndefined();
+  });
+
   it("falls back to default isoCode 'en' and timezone 'CET' when not set", () => {
     const user = {
       id: 3,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,10 +2937,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.114:
-  version "0.0.114"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.114.tgz#6dee6f266310de84ba7ff790db58c09f40329467"
-  integrity sha512-KkHa+PSIZBJ8XoteoAL4xhlb/eV4nkU7ViPqXMFtemKWwXTKP7nNfsxEB/wmPQlkH9MjwcG9yz9NaccJx8WzIw==
+need4deed-sdk@0.0.115:
+  version "0.0.115"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.115.tgz#cb07ffaabbd22353e65b28e9a592a3a78b269593"
+  integrity sha512-VoOpHlSnAUgNIHrUsKPrj1L4299ze+bBFsnCLs3BP5IPL5lLN5uK1vzkT+t9rAgilb8h22HqXWlzxMAPBhoTcA==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

- Bump `need4deed-sdk` 0.0.114 → 0.0.115 (sdk#136: adds `agentId` to `ApiUserGet`)
- `serializeUserToMeDTO` now returns plain `ApiUserGet` — removes local `ApiUserGet & { agentId?: number }` workaround
- Fix `additionalProperties` misplacement in `sdk-types.json` `ApiUserMe` schema (was inside `properties`, should be a sibling)
- Guard the `agentPersonRepository` lookup behind `user.role === UserRole.AGENT` — previously fired for every user with a `personId` on every session check

🤖 Generated with [Claude Code](https://claude.com/claude-code)