### PR TITLE
Change password

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -82,9 +82,16 @@ export const urlEmailVerification =
   process.env.URL_EMAIL_VERIFICATION ||
   "https://app.need4deed.org/verify-email";
 
+export const urlPasswordReset =
+  process.env.URL_PASSWORD_RESET || "https://app.need4deed.org/reset-password";
+
 // CDN manifest (per-locale subject + html/text) for the verification email.
 export const emailVerificationManifestUrl =
   CDNBaseUrl + "/emails/verification.json";
+
+// CDN manifest (per-locale subject + html/text) for the password reset email.
+export const emailPasswordResetManifestUrl =
+  CDNBaseUrl + "/emails/password-reset.json";
 // How long a fetched email manifest is cached in-memory (default 10 min).
 export const emailTemplateTtlMs =
   Number(process.env.EMAIL_TEMPLATE_TTL_MS) || 10 * 60 * 1000;
@@ -95,6 +102,7 @@ export const emailTemplateFetchTimeoutMs =
 export const REFRESH_LIFESPAN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
 export const ACCESS_LIFESPAN_MS = 15 * 60 * 1000; // 15 minutes in milliseconds
 export const VERIFY_LIFESPAN_MS = 24 * 60 * 60 * 1000; // 24h in milliseconds
+export const RESET_LIFESPAN_MS = 60 * 60 * 1000; // 60 minutes in milliseconds
 export const pluginTimeout = 300 * 1000; // 30s in milliseconds
 
 export const accessCookieName = "access";

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -2,6 +2,11 @@ import fastifyJwt from "@fastify/jwt";
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
 import { UserRole } from "need4deed-sdk";
+import {
+  BadRequestError,
+  UnauthenticatedError,
+  UnauthorizedError,
+} from "../../config";
 import { accessCookieName, cookieOptions } from "../../config/constants";
 import logger from "../../logger";
 import { AuthOptions } from "../types";
@@ -34,9 +39,9 @@ async function jwtPlugin(
       try {
         try {
           await request.jwtVerify();
-        } catch (_error) {
+        } catch {
           reply.status(401);
-          throw new Error("Authorization failed.");
+          throw new UnauthenticatedError("Authorization failed.");
         }
 
         const userId = request.user?.id;
@@ -53,7 +58,7 @@ async function jwtPlugin(
 
         if (!user) {
           reply.status(404);
-          throw new Error("User not found.");
+          throw new BadRequestError("User not found.");
         }
 
         // Expose the already-loaded user (carries personId + DB-authoritative
@@ -77,14 +82,14 @@ async function jwtPlugin(
 
         if (role && role !== user.role) {
           reply.status(403);
-          throw new Error("Permission denied");
+          throw new UnauthorizedError("Permission denied");
         }
 
         if (allowSelf) {
           const requestParamId = (request.params as { id?: string }).id;
           if (String(userId) !== requestParamId) {
             reply.status(403);
-            throw new Error("Permission denied");
+            throw new UnauthorizedError("Permission denied");
           }
         }
       } catch (error) {

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -35,9 +35,6 @@ async function jwtPlugin(
         try {
           await request.jwtVerify();
         } catch (_error) {
-          if (opt?.optional) {
-            return;
-          }
           reply.status(401);
           throw new Error("Authorization failed.");
         }

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -35,6 +35,9 @@ async function jwtPlugin(
         try {
           await request.jwtVerify();
         } catch (_error) {
+          if (opt?.optional) {
+            return;
+          }
           reply.status(401);
           throw new Error("Authorization failed.");
         }

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -1,13 +1,8 @@
 import fastifyJwt from "@fastify/jwt";
-import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { FastifyInstance, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
 import { UserRole } from "need4deed-sdk";
-import {
-  BadRequestError,
-  BaseError,
-  UnauthenticatedError,
-  UnauthorizedError,
-} from "../../config";
+import { UnauthenticatedError, UnauthorizedError } from "../../config";
 import { accessCookieName, cookieOptions } from "../../config/constants";
 import logger from "../../logger";
 import { AuthOptions } from "../types";
@@ -25,7 +20,7 @@ async function jwtPlugin(
   });
 
   fastify.decorate("authenticate", function (opt?: AuthOptions) {
-    return async function (request: FastifyRequest, reply: FastifyReply) {
+    return async function (request: FastifyRequest) {
       logger.debug(
         `jwtPlugin:authenticate called with request.routeOptions.config: ${JSON.stringify(request.routeOptions.config)}`,
       );
@@ -38,67 +33,49 @@ async function jwtPlugin(
       }
 
       try {
-        try {
-          await request.jwtVerify();
-        } catch {
-          throw new UnauthenticatedError("Authorization failed.");
-        }
+        await request.jwtVerify();
+      } catch {
+        throw new UnauthenticatedError("Authorization failed.");
+      }
 
-        const userId = request.user?.id;
-        logger.debug(`jwtPlugin:authenticated: ${userId}`);
+      const userId = request.user?.id;
+      logger.debug(`jwtPlugin:authenticated: ${userId}`);
 
-        const userRepository = fastify.db.userRepository;
-        if (!userRepository) {
-          throw new Error("User repository is not initialized.");
-        }
+      const userRepository = fastify.db.userRepository;
+      const user = await userRepository.findOne({
+        where: { id: userId },
+      });
 
-        const user = await userRepository.findOne({
-          where: { id: userId },
-        });
+      if (!user) {
+        throw new UnauthorizedError("User not found.");
+      }
 
-        if (!user) {
-          throw new BadRequestError("User not found.");
-        }
+      // Expose the already-loaded user (carries personId + DB-authoritative
+      // role) for downstream hooks (PII masking, self-auth) — avoids a second
+      // lookup and a JWT claim.
+      request.authUser = user;
 
-        // Expose the already-loaded user (carries personId + DB-authoritative
-        // role) for downstream hooks (PII masking, self-auth) — avoids a second
-        // lookup and a JWT claim.
-        request.authUser = user;
-
-        if (user.role === UserRole.ADMIN) {
-          logger.debug(
-            `Admin user ${userId} authenticated, bypassing further checks.`,
-          );
-          reply.status(200);
-          return;
-        }
-
-        const { role, allowSelf } = opt || {};
-
+      if (user.role === UserRole.ADMIN) {
         logger.debug(
-          `authenticate role:${role}, allowSelf:${allowSelf}, userId:${userId}`,
+          `Admin user ${userId} authenticated, bypassing further checks.`,
         );
+        return;
+      }
 
-        if (role && role !== user.role) {
+      const { role, allowSelf } = opt || {};
+
+      logger.debug(
+        `authenticate role:${role}, allowSelf:${allowSelf}, userId:${userId}`,
+      );
+
+      if (role && role !== user.role) {
+        throw new UnauthorizedError("Permission denied");
+      }
+
+      if (allowSelf) {
+        const requestParamId = (request.params as { id?: string }).id;
+        if (String(userId) !== requestParamId) {
           throw new UnauthorizedError("Permission denied");
-        }
-
-        if (allowSelf) {
-          const requestParamId = (request.params as { id?: string }).id;
-          if (String(userId) !== requestParamId) {
-            throw new UnauthorizedError("Permission denied");
-          }
-        }
-      } catch (error) {
-        logger.warn(`JWT verification failed: ${error.message}`); // Log the warning
-
-        if (error instanceof BaseError) {
-          throw error;
-        } else {
-          reply.send({
-            message: `Authentication failed: ${error.message}`,
-            error: error.message,
-          });
         }
       }
     };

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -4,6 +4,7 @@ import fp from "fastify-plugin";
 import { UserRole } from "need4deed-sdk";
 import {
   BadRequestError,
+  BaseError,
   UnauthenticatedError,
   UnauthorizedError,
 } from "../../config";
@@ -40,7 +41,6 @@ async function jwtPlugin(
         try {
           await request.jwtVerify();
         } catch {
-          reply.status(401);
           throw new UnauthenticatedError("Authorization failed.");
         }
 
@@ -57,7 +57,6 @@ async function jwtPlugin(
         });
 
         if (!user) {
-          reply.status(404);
           throw new BadRequestError("User not found.");
         }
 
@@ -81,23 +80,26 @@ async function jwtPlugin(
         );
 
         if (role && role !== user.role) {
-          reply.status(403);
           throw new UnauthorizedError("Permission denied");
         }
 
         if (allowSelf) {
           const requestParamId = (request.params as { id?: string }).id;
           if (String(userId) !== requestParamId) {
-            reply.status(403);
             throw new UnauthorizedError("Permission denied");
           }
         }
       } catch (error) {
         logger.warn(`JWT verification failed: ${error.message}`); // Log the warning
-        reply.send({
-          message: `Authentication failed: ${error.message}`,
-          error: error.message,
-        });
+
+        if (error instanceof BaseError) {
+          throw error;
+        } else {
+          reply.send({
+            message: `Authentication failed: ${error.message}`,
+            error: error.message,
+          });
+        }
       }
     };
   });

--- a/src/server/plugins/notify.ts
+++ b/src/server/plugins/notify.ts
@@ -8,6 +8,7 @@ import {
   sendCommentTagged,
   sendEmailVerification,
   sendOpsAlert,
+  sendPasswordReset,
   SlackChannel,
   SlackTransport,
   SlackWebhookTransport,
@@ -15,6 +16,7 @@ import {
 
 interface NotifyService {
   emailVerification(user: User): Promise<void>;
+  passwordReset(user: User): Promise<void>;
   opsAlert(text: string): Promise<void>;
   commentTagged(input: CommentTaggedInput): Promise<void>;
 }
@@ -50,6 +52,8 @@ async function notifyPlugin(fastify: FastifyInstance) {
   fastify.decorate("notify", {
     emailVerification: (user: User) =>
       sendEmailVerification({ email, jwt: fastify.jwt }, user),
+    passwordReset: (user: User) =>
+      sendPasswordReset({ email, jwt: fastify.jwt }, user),
     opsAlert: (text: string) => sendOpsAlert({ slack }, text),
     commentTagged: (input: CommentTaggedInput) =>
       sendCommentTagged({ slack }, input),

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -11,12 +11,16 @@ import { hashPassword } from "../../data/utils";
 import logger from "../../logger";
 import { responseErrors } from "../schema/responseErrors";
 import {
+  changePasswordSchema,
+  messageResponseSchema,
   refreshAccessResponseSchema,
   refreshAccessSchema,
+  requestResetSchema,
+  resetPasswordSchema,
   userLoginResponseSchema,
   userLoginSchema,
 } from "../schema/user.schema";
-import { RoutePrefix } from "../types";
+import { ReplyMessage, RoutePrefix } from "../types";
 
 async function authRoutes(
   fastify: FastifyInstance,
@@ -217,11 +221,7 @@ async function authRoutes(
     {
       schema: {
         response: {
-          200: {
-            type: "object",
-            properties: { message: { type: "string" } },
-            required: ["message"],
-          },
+          200: messageResponseSchema,
           ...responseErrors,
         },
       },
@@ -240,22 +240,14 @@ async function authRoutes(
 
   fastify.post<{
     Body: { email: string };
-    Reply: { message: string };
+    Reply: ReplyMessage;
   }>(
     prefixedPath + RoutePrefix.REQUEST_RESET,
     {
       schema: {
-        body: {
-          type: "object",
-          properties: { email: { type: "string", format: "email" } },
-          required: ["email"],
-        },
+        body: requestResetSchema,
         response: {
-          200: {
-            type: "object",
-            properties: { message: { type: "string" } },
-            required: ["message"],
-          },
+          200: messageResponseSchema,
           ...responseErrors,
         },
       },
@@ -284,25 +276,14 @@ async function authRoutes(
 
   fastify.post<{
     Body: { token: string; newPassword: string };
-    Reply: { message: string };
+    Reply: ReplyMessage;
   }>(
     prefixedPath + RoutePrefix.RESET_PASSWORD,
     {
       schema: {
-        body: {
-          type: "object",
-          properties: {
-            token: { type: "string" },
-            newPassword: { type: "string", minLength: 8, maxLength: 50 },
-          },
-          required: ["token", "newPassword"],
-        },
+        body: resetPasswordSchema,
         response: {
-          200: {
-            type: "object",
-            properties: { message: { type: "string" } },
-            required: ["message"],
-          },
+          200: messageResponseSchema,
           ...responseErrors,
         },
       },
@@ -342,26 +323,15 @@ async function authRoutes(
 
   fastify.post<{
     Body: { password: string; newPassword: string };
-    Reply: { message: string };
+    Reply: ReplyMessage;
   }>(
     prefixedPath + RoutePrefix.CHANGE_PASSWORD,
     {
       onRequest: [fastify.authenticate()],
       schema: {
-        body: {
-          type: "object",
-          properties: {
-            password: { type: "string" },
-            newPassword: { type: "string", minLength: 8, maxLength: 50 },
-          },
-          required: ["password", "newPassword"],
-        },
+        body: changePasswordSchema,
         response: {
-          200: {
-            type: "object",
-            properties: { message: { type: "string" } },
-            required: ["message"],
-          },
+          200: messageResponseSchema,
           ...responseErrors,
         },
       },

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -283,21 +283,19 @@ async function authRoutes(
   );
 
   fastify.post<{
-    Body: { token?: string; password?: string; newPassword: string };
+    Body: { token: string; newPassword: string };
     Reply: { message: string };
   }>(
     prefixedPath + RoutePrefix.RESET_PASSWORD,
     {
-      onRequest: [fastify.authenticate({ optional: true })],
       schema: {
         body: {
           type: "object",
           properties: {
             token: { type: "string" },
-            password: { type: "string" },
             newPassword: { type: "string", minLength: 8, maxLength: 50 },
           },
-          required: ["newPassword"],
+          required: ["token", "newPassword"],
         },
         response: {
           200: {
@@ -309,51 +307,68 @@ async function authRoutes(
         },
       },
     },
-
     async (request, reply) => {
-      const { token, password, newPassword } = request.body;
+      const { token, newPassword } = request.body;
       const TOKEN_ERROR_MESSAGE = "Invalid reset token.";
 
-      if (token) {
-        let payload: { id: number; email: string; type?: string };
-        try {
-          payload = await fastify.jwt.verify(token);
-        } catch {
-          return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
-        }
-
-        if (payload.type !== "reset") {
-          return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
-        }
-
-        const user = await fastify.db.userRepository.findOne({
-          where: { id: payload.id },
-        });
-
-        if (!user) {
-          return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
-        }
-
-        await fastify.db.userRepository.update(
-          { id: user.id },
-          { password: await hashPassword(newPassword) },
-        );
-
-        return reply.status(200).send({
-          message: "Password has been reset.",
-        });
+      let payload: { id: number; email: string; type?: string };
+      try {
+        payload = await fastify.jwt.verify(token);
+      } catch {
+        return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
       }
 
-      const authUser = request.authUser;
-      if (!authUser) {
-        return reply.status(403).send({ message: "Authentication required." });
+      if (payload.type !== "reset") {
+        return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
       }
 
-      if (!password) {
-        return reply
-          .status(400)
-          .send({ message: "Current password is required." });
+      const user = await fastify.db.userRepository.findOne({
+        where: { id: payload.id },
+      });
+      if (!user) {
+        return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
       }
+
+      await fastify.db.userRepository.update(
+        { id: user.id },
+        { password: await hashPassword(newPassword) },
+      );
+
+      return reply.status(200).send({
+        message: "Password has been reset.",
+      });
+    },
+  );
+
+  fastify.post<{
+    Body: { password: string; newPassword: string };
+    Reply: { message: string };
+  }>(
+    prefixedPath + RoutePrefix.CHANGE_PASSWORD,
+    {
+      onRequest: [fastify.authenticate()],
+      schema: {
+        body: {
+          type: "object",
+          properties: {
+            password: { type: "string" },
+            newPassword: { type: "string", minLength: 8, maxLength: 50 },
+          },
+          required: ["password", "newPassword"],
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: { message: { type: "string" } },
+            required: ["message"],
+          },
+          ...responseErrors,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { password, newPassword } = request.body;
+      const authUser = request.authUser!;
 
       if (!(await authUser.checkPassword(password))) {
         return reply
@@ -367,7 +382,7 @@ async function authRoutes(
       );
 
       return reply.status(200).send({
-        message: "Password has been changed successfully.",
+        message: "Password has been changed.",
       });
     },
   );

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -236,6 +236,50 @@ async function authRoutes(
       return reply.status(200).send({ message: "Logout successful." });
     },
   );
+
+  fastify.post<{
+    Body: { email: string };
+    Reply: { message: string };
+  }>(
+    prefixedPath + RoutePrefix.REQUEST_RESET,
+    {
+      schema: {
+        body: {
+          type: "object",
+          properties: { email: { type: "string", format: "email" } },
+          required: ["email"],
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: { message: { type: "string" } },
+            required: ["message"],
+          },
+          ...responseErrors,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { email } = request.body;
+
+      const user = await fastify.db.userRepository.findOne({
+        where: { email },
+      });
+
+      if (user?.isActive) {
+        fastify.notify.passwordReset(user).catch((err) => {
+          logger.error(
+            `Failed to send password reset for user ${user.id}: ${err instanceof Error ? err.message : err}`,
+          );
+        });
+      }
+
+      return reply.status(200).send({
+        message:
+          "If an account with that email exists, a reset link has been sent.",
+      });
+    },
+  );
 }
 
 export default fp(authRoutes, {

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -9,6 +9,7 @@ import {
 } from "../../config/constants";
 import { hashPassword } from "../../data/utils";
 import logger from "../../logger";
+import { responseSchema } from "../schema";
 import { responseErrors } from "../schema/responseErrors";
 import {
   changePasswordSchema,
@@ -246,10 +247,7 @@ async function authRoutes(
     {
       schema: {
         body: requestResetSchema,
-        response: {
-          200: messageResponseSchema,
-          ...responseErrors,
-        },
+        response: responseSchema(""),
       },
     },
     async (request, reply) => {
@@ -282,10 +280,7 @@ async function authRoutes(
     {
       schema: {
         body: resetPasswordSchema,
-        response: {
-          200: messageResponseSchema,
-          ...responseErrors,
-        },
+        response: responseSchema(""),
       },
     },
     async (request, reply) => {
@@ -330,10 +325,7 @@ async function authRoutes(
       onRequest: [fastify.authenticate()],
       schema: {
         body: changePasswordSchema,
-        response: {
-          200: messageResponseSchema,
-          ...responseErrors,
-        },
+        response: responseSchema(""),
       },
     },
     async (request, reply) => {

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -7,6 +7,7 @@ import {
   REFRESH_LIFESPAN_MS,
   refreshCookieName,
 } from "../../config/constants";
+import { hashPassword } from "../../data/utils";
 import logger from "../../logger";
 import { responseErrors } from "../schema/responseErrors";
 import {
@@ -277,6 +278,96 @@ async function authRoutes(
       return reply.status(200).send({
         message:
           "If an account with that email exists, a reset link has been sent.",
+      });
+    },
+  );
+
+  fastify.post<{
+    Body: { token?: string; password?: string; newPassword: string };
+    Reply: { message: string };
+  }>(
+    prefixedPath + RoutePrefix.RESET_PASSWORD,
+    {
+      onRequest: [fastify.authenticate({ optional: true })],
+      schema: {
+        body: {
+          type: "object",
+          properties: {
+            token: { type: "string" },
+            password: { type: "string" },
+            newPassword: { type: "string", minLength: 8, maxLength: 50 },
+          },
+          required: ["newPassword"],
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: { message: { type: "string" } },
+            required: ["message"],
+          },
+          ...responseErrors,
+        },
+      },
+    },
+
+    async (request, reply) => {
+      const { token, password, newPassword } = request.body;
+      const TOKEN_ERROR_MESSAGE = "Invalid reset token.";
+
+      if (token) {
+        let payload: { id: number; email: string; type?: string };
+        try {
+          payload = await fastify.jwt.verify(token);
+        } catch {
+          return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
+        }
+
+        if (payload.type !== "reset") {
+          return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
+        }
+
+        const user = await fastify.db.userRepository.findOne({
+          where: { id: payload.id },
+        });
+
+        if (!user) {
+          return reply.status(400).send({ message: TOKEN_ERROR_MESSAGE });
+        }
+
+        await fastify.db.userRepository.update(
+          { id: user.id },
+          { password: await hashPassword(newPassword) },
+        );
+
+        return reply.status(200).send({
+          message: "Password has been reset.",
+        });
+      }
+
+      const authUser = request.authUser;
+      if (!authUser) {
+        return reply.status(403).send({ message: "Authentication required." });
+      }
+
+      if (!password) {
+        return reply
+          .status(400)
+          .send({ message: "Current password is required." });
+      }
+
+      if (!(await authUser.checkPassword(password))) {
+        return reply
+          .status(400)
+          .send({ message: "Current password is incorrect." });
+      }
+
+      await fastify.db.userRepository.update(
+        { id: authUser.id },
+        { password: await hashPassword(newPassword) },
+      );
+
+      return reply.status(200).send({
+        message: "Password has been changed successfully.",
       });
     },
   );

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -133,3 +133,33 @@ export const userResponseSchemaIncludePerson = {
     "person",
   ],
 };
+
+export const messageResponseSchema = {
+  type: "object",
+  properties: { message: { type: "string" } },
+  required: ["message"],
+};
+
+export const requestResetSchema = {
+  type: "object",
+  properties: { email: { type: "string", format: "email" } },
+  required: ["email"],
+};
+
+export const resetPasswordSchema = {
+  type: "object",
+  properties: {
+    token: { type: "string" },
+    newPassword: { type: "string", minLength: 8, maxLength: 50 },
+  },
+  required: ["token", "newPassword"],
+};
+
+export const changePasswordSchema = {
+  type: "object",
+  properties: {
+    password: { type: "string" },
+    newPassword: { type: "string", minLength: 8, maxLength: 50 },
+  },
+  required: ["password", "newPassword"],
+};

--- a/src/server/types/auth.ts
+++ b/src/server/types/auth.ts
@@ -3,4 +3,5 @@ import { UserRole } from "need4deed-sdk";
 export interface AuthOptions {
   role?: UserRole;
   allowSelf?: boolean;
+  optional?: boolean;
 }

--- a/src/server/types/auth.ts
+++ b/src/server/types/auth.ts
@@ -3,5 +3,4 @@ import { UserRole } from "need4deed-sdk";
 export interface AuthOptions {
   role?: UserRole;
   allowSelf?: boolean;
-  optional?: boolean;
 }

--- a/src/server/types/enums.ts
+++ b/src/server/types/enums.ts
@@ -19,6 +19,7 @@ export const RoutePrefix = {
   OPTION: "/option",
   PERSON: "/person",
   REFRESH: "/refresh",
+  REQUEST_RESET: "/request-reset",
   REGISTER: "/register",
   SWAGGER: "/swagger",
   TRUSTED_DOMAIN: "/trusted-domain",

--- a/src/server/types/enums.ts
+++ b/src/server/types/enums.ts
@@ -20,6 +20,7 @@ export const RoutePrefix = {
   PERSON: "/person",
   REFRESH: "/refresh",
   REQUEST_RESET: "/request-reset",
+  RESET_PASSWORD: "/password-reset",
   REGISTER: "/register",
   SWAGGER: "/swagger",
   TRUSTED_DOMAIN: "/trusted-domain",

--- a/src/server/types/enums.ts
+++ b/src/server/types/enums.ts
@@ -21,6 +21,7 @@ export const RoutePrefix = {
   REFRESH: "/refresh",
   REQUEST_RESET: "/request-reset",
   RESET_PASSWORD: "/password-reset",
+  CHANGE_PASSWORD: "/password-change",
   REGISTER: "/register",
   SWAGGER: "/swagger",
   TRUSTED_DOMAIN: "/trusted-domain",

--- a/src/server/types/fastify.d.ts
+++ b/src/server/types/fastify.d.ts
@@ -63,7 +63,7 @@ declare module "@fastify/jwt" {
   // It's crucial to extend the original FastifyJWT interface here
   // so that your custom 'payload' and 'user' types merge correctly
   // with the types that @fastify/jwt already defines (like jwtSign and jwtVerify methods on reply/request).
-  type TokenType = "access" | "refresh" | "verify";
+  type TokenType = "access" | "refresh" | "verify" | "reset";
   interface FastifyJWT {
     // Payload type when signing a token (`reply.jwtSign(payload)`)
     payload: {

--- a/src/services/notify/events/email-password-reset.ts
+++ b/src/services/notify/events/email-password-reset.ts
@@ -1,0 +1,81 @@
+import type { JWT } from "@fastify/jwt";
+import { Lang } from "need4deed-sdk";
+import {
+  emailPasswordResetManifestUrl,
+  RESET_LIFESPAN_MS,
+  urlPasswordReset,
+} from "../../../config/constants";
+import type User from "../../../data/entity/user.entity";
+import logger from "../../../logger";
+import {
+  createManifestLoader,
+  fillTemplate,
+  resolveContent,
+  resolveLocale,
+  type LocaleContent,
+} from "../email-template";
+import type { EmailMessage, EmailTransport } from "../types";
+
+export interface PasswordResetDeps {
+  email: EmailTransport;
+  jwt: JWT;
+}
+
+const BUILTIN: Record<Lang, LocaleContent> = {
+  [Lang.EN]: {
+    subject: "Password Reset",
+    text: `A password reset has been requested for your account. To reset your password, follow this link:\n{{resetUrl}}\n\nIf you did not request this, please ignore this email.`,
+    html: `<p>A password reset has been requested for your account.</p>\n<p><a href="{{resetUrl}}">Reset your password</a></p>\n<p>If you did not request this, please ignore this email.</p>`,
+  },
+  [Lang.DE]: {
+    subject: "Passwort zurücksetzen",
+    text: `Es wurde ein Zurücksetzen des Passworts für dein Konto angefordert. Um dein Passwort zurückzusetzen, folge diesem Link:\n{{resetUrl}}\n\nFalls du dies nicht angefordert hast, ignoriere diese E-Mail bitte.`,
+    html: `<p>Es wurde ein Zurücksetzen des Passworts für dein Konto angefordert.</p>\n<p><a href="{{resetUrl}}">Passwort zurücksetzen</a></p>\n<p>Falls du dies nicht angefordert hast, ignoriere diese E-Mail bitte.</p>`,
+  },
+};
+
+const loader = createManifestLoader(emailPasswordResetManifestUrl);
+
+export function resetPasswordResetTemplateCache(): void {
+  loader.resetCache();
+}
+
+export async function sendPasswordReset(
+  { email, jwt }: PasswordResetDeps,
+  user: User,
+): Promise<void> {
+  if (!user?.email) {
+    throw new Error("User email is required for password reset");
+  }
+
+  const token = jwt.sign(
+    {
+      id: user.id,
+      email: user.email,
+      type: "reset",
+    },
+    { expiresIn: `${RESET_LIFESPAN_MS}` },
+  );
+
+  const url = `${urlPasswordReset}?token=${encodeURIComponent(token)}`;
+
+  logger.debug(`sendPasswordReset: ${user.email}, url: ${url}`);
+
+  const content = resolveContent(
+    await loader.load(),
+    resolveLocale(user.language),
+    BUILTIN,
+  );
+  const { subject, html, text } = fillTemplate(content, {
+    resetUrl: url,
+  });
+
+  const message: EmailMessage = {
+    to: user.email,
+    subject,
+    ...(text !== undefined ? { text } : {}),
+    ...(html !== undefined ? { html } : {}),
+  };
+
+  await email.send(message);
+}

--- a/src/services/notify/index.ts
+++ b/src/services/notify/index.ts
@@ -5,3 +5,4 @@ export * from "./transports/slack-webhook";
 export * from "./events/email-verification";
 export * from "./events/ops-alert";
 export * from "./events/comment-tagged";
+export * from "./events/email-password-reset";

--- a/src/test/server/routes/auth.test.ts
+++ b/src/test/server/routes/auth.test.ts
@@ -121,16 +121,6 @@ describe("POST /auth/reset-password", () => {
     expect(response.statusCode).toBe(400);
   });
 
-  it("returns 403 when no token and no auth cookie", async () => {
-    const response = await fastify.inject({
-      method: "POST",
-      url: "/auth/password-reset",
-      payload: { newPassword: "newpass123456" },
-    });
-
-    expect(response.statusCode).toBe(403);
-  });
-
   it("resets password with a valid reset token", async () => {
     const resetToken = fastify.jwt.sign({
       id: 999,
@@ -157,8 +147,58 @@ describe("POST /auth/reset-password", () => {
     );
     expect(response.statusCode).toBe(200);
   });
+});
 
-  it("resets password via cookie when password matches", async () => {
+describe("POST /auth/password-change", () => {
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-change",
+      payload: { password: "currentpass123", newPassword: "newpass123456" },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it("returns 400 when current password is incorrect", async () => {
+    const accessToken = fastify.jwt.sign({
+      id: 999,
+      email: "test@example.com",
+      type: "access",
+    });
+
+    const checkPassword = vi.fn().mockResolvedValue(false);
+    vi.spyOn(fastify.db.userRepository, "findOne").mockResolvedValue({
+      id: 999,
+      checkPassword,
+    } as any);
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-change",
+      cookies: { access: accessToken },
+      payload: { password: "wrongpass", newPassword: "newpass123456" },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("changes password when current password matches", async () => {
     const accessToken = fastify.jwt.sign({
       id: 999,
       email: "test@example.com",
@@ -177,7 +217,7 @@ describe("POST /auth/reset-password", () => {
     const currentPass = "currentpass123";
     const response = await fastify.inject({
       method: "POST",
-      url: "/auth/password-reset",
+      url: "/auth/password-change",
       cookies: { access: accessToken },
       payload: { password: currentPass, newPassword: "newpass123456" },
     });

--- a/src/test/server/routes/auth.test.ts
+++ b/src/test/server/routes/auth.test.ts
@@ -1,7 +1,27 @@
 import { FastifyInstance } from "fastify";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { accessCookieName, refreshCookieName } from "../../../config/constants";
 import { createServer } from "../../../server";
+
+vi.mock("../../../data/utils", async () => {
+  const actual = await vi.importActual("../../../data/utils");
+  return {
+    ...actual,
+    hashPassword: vi
+      .fn()
+      .mockImplementation((password: string) =>
+        Promise.resolve("hashed-password-" + password),
+      ),
+  };
+});
 
 describe("POST /auth/logout", () => {
   let fastify: FastifyInstance;
@@ -55,6 +75,10 @@ describe("POST /auth/reset-password", () => {
     await fastify.close();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("rejects a token of type 'access'", async () => {
     const nonResetToken = fastify.jwt.sign({
       id: 999,
@@ -105,5 +129,135 @@ describe("POST /auth/reset-password", () => {
     });
 
     expect(response.statusCode).toBe(403);
+  });
+
+  it("resets password with a valid reset token", async () => {
+    const resetToken = fastify.jwt.sign({
+      id: 999,
+      email: "test@example.com",
+      type: "reset",
+    });
+
+    vi.spyOn(fastify.db.userRepository, "findOne").mockResolvedValue({
+      id: 999,
+    } as any);
+    const updateSpy = vi
+      .spyOn(fastify.db.userRepository, "update")
+      .mockResolvedValue({} as any);
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-reset",
+      payload: { token: resetToken, newPassword: "newpass123456" },
+    });
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      { id: 999 },
+      { password: "hashed-password-newpass123456" },
+    );
+    expect(response.statusCode).toBe(200);
+  });
+
+  it("resets password via cookie when password matches", async () => {
+    const accessToken = fastify.jwt.sign({
+      id: 999,
+      email: "test@example.com",
+      type: "access",
+    });
+
+    const checkPassword = vi.fn().mockResolvedValue(true);
+    vi.spyOn(fastify.db.userRepository, "findOne").mockResolvedValue({
+      id: 999,
+      checkPassword,
+    } as any);
+    const updateSpy = vi
+      .spyOn(fastify.db.userRepository, "update")
+      .mockResolvedValue({} as any);
+
+    const currentPass = "currentpass123";
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-reset",
+      cookies: { access: accessToken },
+      payload: { password: currentPass, newPassword: "newpass123456" },
+    });
+
+    expect(checkPassword).toHaveBeenCalledWith(currentPass);
+    expect(updateSpy).toHaveBeenCalledWith(
+      { id: 999 },
+      { password: "hashed-password-newpass123456" },
+    );
+    expect(response.statusCode).toBe(200);
+  });
+});
+
+describe("POST /auth/request-reset", () => {
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends reset email when user exists and is active", async () => {
+    const mockUser = { id: 1, email: "test@example.com", isActive: true };
+    vi.spyOn(fastify.db.userRepository, "findOne").mockResolvedValue(
+      mockUser as any,
+    );
+
+    const passwordResetSpy = vi.fn().mockResolvedValue(undefined);
+    fastify.notify.passwordReset = passwordResetSpy;
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/request-reset",
+      payload: { email: "test@example.com" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(passwordResetSpy).toHaveBeenCalledWith(mockUser);
+  });
+
+  it("does not send email when user is inactive", async () => {
+    const mockUser = { id: 1, email: "test@example.com", isActive: false };
+    vi.spyOn(fastify.db.userRepository, "findOne").mockResolvedValue(
+      mockUser as any,
+    );
+
+    const passwordResetSpy = vi.fn().mockResolvedValue(undefined);
+    fastify.notify.passwordReset = passwordResetSpy;
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/request-reset",
+      payload: { email: "test@example.com" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(passwordResetSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not send email when user does not exist", async () => {
+    vi.spyOn(fastify.db.userRepository, "findOne").mockResolvedValue(null);
+
+    const passwordResetSpy = vi.fn().mockResolvedValue(undefined);
+    fastify.notify.passwordReset = passwordResetSpy;
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/request-reset",
+      payload: { email: "test@example.com" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(passwordResetSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/test/server/routes/auth.test.ts
+++ b/src/test/server/routes/auth.test.ts
@@ -42,3 +42,68 @@ describe("POST /auth/logout", () => {
     }
   });
 });
+
+describe("POST /auth/reset-password", () => {
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  it("rejects a token of type 'access'", async () => {
+    const nonResetToken = fastify.jwt.sign({
+      id: 999,
+      email: "test@example.com",
+      type: "access",
+    });
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-reset",
+      payload: { token: nonResetToken, newPassword: "newpass123456" },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("rejects a token of type 'verify'", async () => {
+    const nonResetToken = fastify.jwt.sign({
+      id: 999,
+      email: "test@example.com",
+      type: "verify",
+    });
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-reset",
+      payload: { token: nonResetToken, newPassword: "newpass123456" },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("rejects an invalid token", async () => {
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-reset",
+      payload: { token: "not-a-valid-jwt", newPassword: "newpass123456" },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("returns 403 when no token and no auth cookie", async () => {
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-reset",
+      payload: { newPassword: "newpass123456" },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+});

--- a/src/test/server/routes/auth.test.ts
+++ b/src/test/server/routes/auth.test.ts
@@ -11,6 +11,14 @@ import {
 import { accessCookieName, refreshCookieName } from "../../../config/constants";
 import { createServer } from "../../../server";
 
+vi.mock("../../../data", async () => {
+  const actual = await vi.importActual("../../../data");
+  return {
+    ...actual,
+    initDatabase: vi.fn().mockImplementation(() => Promise.resolve()),
+  };
+});
+
 vi.mock("../../../data/utils", async () => {
   const actual = await vi.importActual("../../../data/utils");
   return {
@@ -92,6 +100,10 @@ describe("POST /auth/reset-password", () => {
       payload: { token: nonResetToken, newPassword: "newpass123456" },
     });
 
+    // Since 400 can also be returned for other reasons, check message
+    expect(response.json()).toEqual({
+      message: "Invalid reset token.",
+    });
     expect(response.statusCode).toBe(400);
   });
 
@@ -108,6 +120,10 @@ describe("POST /auth/reset-password", () => {
       payload: { token: nonResetToken, newPassword: "newpass123456" },
     });
 
+    // Since 400 can also be returned for other reasons, check message
+    expect(response.json()).toEqual({
+      message: "Invalid reset token.",
+    });
     expect(response.statusCode).toBe(400);
   });
 
@@ -118,6 +134,10 @@ describe("POST /auth/reset-password", () => {
       payload: { token: "not-a-valid-jwt", newPassword: "newpass123456" },
     });
 
+    // Since 400 can also be returned for other reasons, check message
+    expect(response.json()).toEqual({
+      message: "Invalid reset token.",
+    });
     expect(response.statusCode).toBe(400);
   });
 
@@ -195,6 +215,10 @@ describe("POST /auth/password-change", () => {
       payload: { password: "wrongpass", newPassword: "newpass123456" },
     });
 
+    // Since 400 can also be returned for other reasons, check message
+    expect(response.json()).toEqual({
+      message: "Current password is incorrect.",
+    });
     expect(response.statusCode).toBe(400);
   });
 

--- a/src/test/services/notify/email-password-reset.test.ts
+++ b/src/test/services/notify/email-password-reset.test.ts
@@ -1,0 +1,93 @@
+import { Lang } from "need4deed-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { urlPasswordReset } from "../../../config/constants";
+import { fetchJsonFromUrl } from "../../../data/utils";
+import {
+  resetPasswordResetTemplateCache,
+  sendPasswordReset,
+} from "../../../services/notify/events/email-password-reset";
+
+vi.mock("../../../data/utils", () => ({
+  fetchJsonFromUrl: vi.fn(),
+}));
+
+const send = vi.fn();
+const deps = { email: { send }, jwt: { sign: () => "tok" } } as any;
+const user = (over: any = {}) => ({ id: 1, email: "u@x.de", ...over });
+const expectedUrl = `${urlPasswordReset}?token=${encodeURIComponent("tok")}`;
+
+const manifest = {
+  en: {
+    subject: "Password Reset",
+    html: '<a href="{{resetUrl}}">{{resetUrl}}</a>',
+    text: "reset: {{resetUrl}}",
+  },
+  de: {
+    subject: "Passwort zurücksetzen",
+    html: '<a href="{{resetUrl}}">{{resetUrl}}</a>',
+    text: "zurücksetzen: {{resetUrl}}",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetPasswordResetTemplateCache();
+});
+
+describe("sendPasswordReset", () => {
+  it("uses the manifest entry for the user's locale and substitutes the URL", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendPasswordReset(deps, user({ language: Lang.DE }));
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.subject).toBe("Passwort zurücksetzen");
+    expect(msg.text).toBe(`zurücksetzen: ${expectedUrl}`);
+    expect(msg.html).toBe(`<a href="${expectedUrl}">${expectedUrl}</a>`);
+    expect(msg.html).not.toContain("{{resetUrl}}");
+  });
+
+  it("falls back to the default locale (en) for an unsupported language", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendPasswordReset(deps, user({ language: "fr" }));
+
+    expect(send.mock.calls[0][0].subject).toBe("Password Reset");
+  });
+
+  it("caches the manifest within TTL (single fetch across two sends)", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendPasswordReset(deps, user({ language: Lang.EN }));
+    await sendPasswordReset(deps, user({ language: Lang.DE }));
+
+    expect(fetchJsonFromUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to built-in content when the manifest fetch fails, and still sends", async () => {
+    vi.mocked(fetchJsonFromUrl).mockRejectedValue(new Error("CDN down"));
+
+    await sendPasswordReset(deps, user({ language: Lang.DE }));
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.subject).toBe("Passwort zurücksetzen");
+    expect(msg.text).toContain(expectedUrl);
+    expect(msg.text).not.toContain("{{resetUrl}}");
+  });
+
+  it("falls back to built-in when the manifest entry is invalid (missing body)", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue({
+      en: { subject: "no body here" },
+    });
+
+    await sendPasswordReset(deps, user({ language: Lang.EN }));
+
+    expect(send.mock.calls[0][0].subject).toBe("Password Reset");
+  });
+
+  it("throws when the user has no email", async () => {
+    await expect(
+      sendPasswordReset(deps, user({ email: undefined })),
+    ).rejects.toThrow("User email is required");
+  });
+});


### PR DESCRIPTION
## Description
Implemented reset request and reset password endpoints

**Some concerns**

1) It seems like password-reset endpoint should ultimately be 2 different endpoints:
password-reset and password-change
One is for the reset password use case, and other for the change password use case. It's two different user flows, and there is no pros that I can see in combining them into one endpoint, other than "a little bit less amount of code".
If we split them:
- We will avoid confusing token vs authed user logic in the handler
- You can filter metrics/logs
- You can change and maintain the one without risk of broking the other

We can leave it as is, or if you agree to split them, say so. It's a short fix

2) There is no new password complexity validation. I looked at the register endpoint, and there are also seems to be none. Is that planned on just an overlook? It's probably better to forbid users to use simple passwords such as "11111111"

## Related Issues
Closes #582 

## Changes
- Added /auth/request-reset endpoint
- Added new file to "notify/events" for resetPassword email. It's basically the same as email verification file, please check if cdn route for reset email template is acceptable
- Added /auth/password-reset endpoint
- Added parameter "optional" in fastify.authenticate. Since we need to resolve a access cookie to a user, but if there none allow handler to run.
- Added basic tests for both endpoints

## Screenshots / Demos
-

## Checklist

[x] POST /auth/request-reset sends a reset email with a token link when the email exists
[x] POST /auth/password-reset supports both the token-based path and the password-confirmation path

Missing both token and password returns 400

