### PR TITLE
fix: clear auth cookies at the start of POST /auth/login

### DIFF
--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -51,6 +51,9 @@ async function authRoutes(
       },
     },
     async (request, reply) => {
+      reply.clearCookie(accessCookieName, cookieOptions);
+      reply.clearCookie(refreshCookieName, cookieOptions);
+
       const { email, password } = request.body;
 
       if (!email || !password) {


### PR DESCRIPTION
## Summary

- Clears both `access` and `refresh` httpOnly cookies at the beginning of the login handler, before any credential checks
- Any login attempt — successful or not — now starts with a clean slate
- Prevents stale sessions from persisting in the browser after a failed login (wrong password, inactive user, user not found)

## Why top of handler, not on each error path

Adding `clearCookie` once at the top is simpler than sprinkling it on every failure branch, and ensures no failure path is accidentally missed in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)