### PR TITLE
fix: move seed files out of gitignored dev/ directory

### DIFF
--- a/src/data/seeds/populate/agent.seed.ts
+++ b/src/data/seeds/populate/agent.seed.ts
@@ -1,0 +1,129 @@
+import { EntityTableName } from "need4deed-sdk";
+import { DataSource } from "typeorm";
+import { seedAgentsFile, titleOrphanageAgent } from "../../../config";
+import { tryCatch } from "../../../services/utils";
+import Postcode from "../../entity/location/postcode.entity";
+import AgentPerson from "../../entity/m2m/agent-person";
+import AgentPostcode from "../../entity/m2m/agent-postcode";
+import NotionRelation from "../../entity/notion-relation.entity";
+import Agent from "../../entity/opportunity/agent.entity";
+import { fetchJsonFromUrl, getRepository } from "../../utils";
+import {
+  getAgentEngagement,
+  getAgentPersonRole,
+  getAgentSearchStatus,
+  getAgentService,
+  getAgentTrustLevel,
+  getAgentType,
+  getCount,
+  getOrCreatePerson,
+} from "../utils";
+import { AgentJSON } from "./types";
+
+export async function seedAgents(dataSource: DataSource): Promise<void> {
+  const agentRepository = getRepository(dataSource, Agent);
+
+  const count = await getCount(agentRepository);
+  if (count !== 0) {
+    dataSource.logger.log("log", "Skipping seeding agents.");
+    return;
+  }
+
+  const agentsJson = (await fetchJsonFromUrl(seedAgentsFile)) as AgentJSON[];
+
+  // create an agent for orphan opportunities
+  agentsJson.unshift({
+    title: titleOrphanageAgent,
+    about: "the dummy agent account for parenting orphaned opportunities.",
+  } as AgentJSON);
+
+  for (const agentJson of agentsJson ?? []) {
+    const agentObj = new Agent({
+      title: agentJson.title || agentJson.website || "unknown",
+      info: agentJson.about,
+      website: agentJson.website,
+      type: getAgentType(agentJson.type),
+      trustLevel: getAgentTrustLevel(agentJson.trustLevel),
+      searchStatus: getAgentSearchStatus(agentJson.statusSearch),
+      engagementStatus: getAgentEngagement(agentJson.statusEngagement),
+      services: agentJson.services?.map(getAgentService),
+    });
+    const [agent, error] = await tryCatch(agentRepository.save(agentObj));
+
+    if (error) {
+      dataSource.logger.log(
+        "warn",
+        `While creating an agent ${agentJson.nid} occurred: ${error}`,
+      );
+      continue;
+    }
+
+    const agentPostcodeRepository = getRepository(dataSource, AgentPostcode);
+    const postcodeRepository = getRepository(dataSource, Postcode);
+    const postcode12345 = await postcodeRepository.findOneBy({
+      value: "12345",
+    });
+    const postcodesJson = agentJson.postcodes ?? [];
+    for (const postcodeJson of postcodesJson) {
+      const postcode = await postcodeRepository.findOneBy({
+        value: postcodeJson,
+      });
+      const [, error] = await tryCatch(
+        agentPostcodeRepository.save(
+          new AgentPostcode({ postcode: postcode! || postcode12345, agent }),
+        ),
+      );
+
+      if (error) {
+        dataSource.logger.log(
+          "warn",
+          `During storing postcode:${postcodeJson} for agent:${agentJson.nid} occurred: ${error}`,
+        );
+      }
+    }
+
+    const personsJson = agentJson.person ?? [];
+    for (const personJson of personsJson) {
+      if (Object.values(personJson).filter(Boolean).length) {
+        const person = await getOrCreatePerson(personJson, dataSource);
+        const agentPersonRepository = getRepository(dataSource, AgentPerson);
+        const agentPersonOnj = new AgentPerson({
+          agentId: agent.id,
+          personId: person.id,
+          role: getAgentPersonRole(personJson.role),
+        });
+        const [, error] = await tryCatch(
+          agentPersonRepository.save(agentPersonOnj),
+        );
+        if (error) {
+          dataSource.logger.log(
+            "warn",
+            `Storing agent-person m2m (agentId:${agent.id}, personId:${person.id}) occurred: ${error}`,
+          );
+        }
+      }
+    }
+
+    const notionRelationRepository = getRepository(dataSource, NotionRelation);
+    const opportunityNids = agentJson.opportunityNids ?? [];
+    for (const opportunityNid of opportunityNids) {
+      const notionRel = new NotionRelation({
+        hostId: agent.id,
+        hostType: EntityTableName.AGENT,
+        hostNid: agentJson.nid,
+        tenantType: EntityTableName.OPPORTUNITY,
+        tenantNid: opportunityNid,
+      });
+
+      const [, error] = await tryCatch(
+        notionRelationRepository.save(notionRel),
+      );
+      if (error) {
+        dataSource.logger.log(
+          "warn",
+          `Storing notion relation (agentNid:${agentJson.nid}, opportunityNid:${opportunityNid}) occurred: ${error}`,
+        );
+      }
+    }
+  }
+}

--- a/src/data/seeds/populate/dev-parsing.ts
+++ b/src/data/seeds/populate/dev-parsing.ts
@@ -1,0 +1,17 @@
+import { DataSource } from "typeorm";
+import { seedVolunteersFile } from "../../../config";
+import { fetchJsonFromUrl } from "../../utils";
+import { createDealTimeslots } from "../utils";
+import { VolunteerJSON } from "./types";
+
+export async function devTime(dataSource: DataSource) {
+  const volunteersJson = (await fetchJsonFromUrl(
+    seedVolunteersFile,
+  )) as VolunteerJSON[];
+
+  for (const volunteerJson of volunteersJson) {
+    if (volunteerJson.nid === "VOLVO-525") {
+      await createDealTimeslots(dataSource, volunteerJson.deal.time);
+    }
+  }
+}

--- a/src/data/seeds/populate/opportunity.seed.ts
+++ b/src/data/seeds/populate/opportunity.seed.ts
@@ -1,0 +1,127 @@
+import {
+  EntityTableName,
+  OpportunityType,
+  TranslatedIntoType,
+} from "need4deed-sdk";
+import { DataSource } from "typeorm";
+import { seedOpportunitiesFile } from "../../../config/constants";
+import logger from "../../../logger";
+import { tryCatch } from "../../../services/utils";
+import NotionRelation from "../../entity/notion-relation.entity";
+import Accompanying from "../../entity/opportunity/accompanying.entity";
+import Opportunity from "../../entity/opportunity/opportunity.entity";
+import { fetchJsonFromUrl, getRepository } from "../../utils";
+import {
+  createDeal,
+  getCount,
+  getEnumValue,
+  getOrCreateAgent,
+  getToTranslate,
+} from "../utils";
+import { OpportunityJSON } from "./types";
+
+export async function seedOpportunities(dataSource: DataSource): Promise<void> {
+  if (!dataSource) {
+    throw new Error("DataSource is not initialized.");
+  }
+
+  const opportunityRepository = getRepository(dataSource, Opportunity);
+
+  const count = await getCount(opportunityRepository);
+  if (count !== 0) {
+    logger.info("Skipping seeding opportunities.");
+    return;
+  }
+
+  const opportunities = (await fetchJsonFromUrl(
+    seedOpportunitiesFile,
+  )) as OpportunityJSON[];
+
+  for (const opportunity of opportunities ?? []) {
+    try {
+      const title = opportunity.title;
+
+      if (!title) {
+        throw new Error("title is missing.");
+      }
+
+      const deal = await createDeal(opportunity.deal, dataSource);
+
+      const notionRelationRepository = getRepository(
+        dataSource,
+        NotionRelation,
+      );
+      const [notionRelation] = await tryCatch(
+        notionRelationRepository.findOne({
+          where: {
+            tenantNid: opportunity.nid,
+            tenantType: EntityTableName.OPPORTUNITY,
+            hostType: EntityTableName.AGENT,
+          },
+        }),
+      );
+
+      const accompanyingRepository = getRepository(dataSource, Accompanying);
+      const [accompanying] = await tryCatch(
+        opportunity.accompanying
+          ? accompanyingRepository.save(
+              new Accompanying({
+                address: opportunity.accompanying.address || "Berlin",
+                name: opportunity.accompanying.name || "unknown",
+                phone: opportunity.accompanying.phone,
+                date: new Date(opportunity.accompanying.date),
+                languageToTranslate: getToTranslate(
+                  opportunity.accompanying.languageToTranslate,
+                ),
+              }),
+            )
+          : Promise.reject(),
+      );
+
+      const newOpportunity = new Opportunity({
+        title,
+        type:
+          getEnumValue(OpportunityType, opportunity.type) ||
+          OpportunityType.REGULAR,
+        translationType:
+          getEnumValue(TranslatedIntoType, opportunity.translationType) ||
+          TranslatedIntoType.NO_TRANSLATION,
+        info: opportunity.info || "",
+        infoConfidential: opportunity.infoConfidential || "",
+        numberVolunteers: Number(opportunity.numberVolunteers || 1),
+        createdAt: new Date(opportunity.timestamp),
+        updatedAt: new Date(opportunity.timestamp),
+        ...(accompanying?.id ? { accompanyingId: accompanying.id } : {}),
+        ...(notionRelation?.hostId
+          ? { agentId: notionRelation?.hostId }
+          : { agent: await getOrCreateAgent(opportunity.agent, dataSource) }),
+        deal,
+      });
+      await opportunityRepository.save(newOpportunity);
+
+      for (const [volunteerNid, payroll] of opportunity.volunteerNids) {
+        const [, error] = await tryCatch(
+          notionRelationRepository.save(
+            new NotionRelation({
+              payroll,
+              hostNid: opportunity.nid,
+              hostId: newOpportunity.id,
+              hostType: EntityTableName.OPPORTUNITY,
+              tenantNid: volunteerNid,
+              tenantType: EntityTableName.VOLUNTEER,
+            }),
+          ),
+        );
+        if (error) {
+          logger.warn(
+            `Seems like pair: ${opportunity.nid}-${volunteerNid} already exists.`,
+          );
+        }
+      }
+    } catch (error) {
+      logger.info(
+        `Creation of opportunity ${opportunity?.title} rolled back due to error: ${(error as Error).message}`,
+      );
+    }
+  }
+}

--- a/src/data/seeds/populate/types.ts
+++ b/src/data/seeds/populate/types.ts
@@ -1,0 +1,114 @@
+import {
+  DocumentStatusType,
+  LangProficiency,
+  OpportunityType,
+  VolunteerStateType,
+} from "need4deed-sdk";
+import { DealType } from "../../types";
+
+export interface ProfileJSON {
+  info: string;
+  activities: string[];
+  skills: string[];
+  languages: [string, LangProficiency][];
+}
+export interface TimeJSON {
+  timeslots: {
+    day: string;
+    daytime: string[];
+    info: string;
+    start: string;
+  }[];
+}
+export interface LocationJSON {
+  districts: string[];
+}
+export interface DealJSON {
+  type: DealType;
+  postcode: string;
+  profile: ProfileJSON;
+  time: TimeJSON;
+  location: LocationJSON;
+}
+export interface AddressJSON {
+  postcode: number;
+  street?: string;
+}
+export interface PersonJSON {
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  address: AddressJSON;
+}
+export interface OrganizationJSON {
+  title: string;
+  phone: string;
+  email: string;
+  address: AddressJSON;
+  person: PersonJSON;
+}
+export interface _AgentJSON {
+  title: string;
+  page_id: string;
+  organization: OrganizationJSON;
+  person: PersonJSON;
+  postcode: string;
+}
+export interface VolunteerJSON {
+  nid: string;
+  timestamp: string;
+  status: VolunteerStateType;
+  statusEngagement: string;
+  accompanying: boolean;
+  statusCGC: DocumentStatusType;
+  statusVaccination: DocumentStatusType;
+  infoAbout: string;
+  infoExperience: string;
+  person: PersonJSON;
+  deal: DealJSON;
+}
+export interface AccompanyingJSON {
+  address: string;
+  name: string;
+  phone: string;
+  date: string;
+  languageToTranslate: string;
+}
+export interface OpportunityJSON {
+  status: string;
+  title: string;
+  nid: string;
+  timestamp: string;
+  type: OpportunityType;
+  translationType: string;
+  info: string;
+  numberVolunteers: string;
+  infoConfidential: string;
+  deal: DealJSON;
+  agent: _AgentJSON;
+  accompanying?: AccompanyingJSON;
+  volunteerNids: string[];
+}
+export interface AgentJSON {
+  nid: string;
+  title: string;
+  about: string;
+  website: string;
+  type: string;
+  district: object;
+  trustLevel: string;
+  statusEngagement: string;
+  statusSearch: string;
+  languages: string;
+  services: string[];
+  address: object;
+  postcodes: string[];
+  phone: string;
+  status: string;
+  person: (PersonJSON & { role: string })[];
+  operator: string;
+  opportunityNids: string[];
+  accompanyingRelations: string[];
+}

--- a/src/data/seeds/populate/volunteer.seed.ts
+++ b/src/data/seeds/populate/volunteer.seed.ts
@@ -1,0 +1,86 @@
+import { EntityTableName, OpportunityVolunteerStatusType } from "need4deed-sdk";
+import { DataSource } from "typeorm";
+import { seedVolunteersFile } from "../../../config/constants";
+import logger from "../../../logger";
+import OpportunityVolunteer from "../../entity/m2m/opportunity-volunteer";
+import NotionRelation from "../../entity/notion-relation.entity";
+import Volunteer from "../../entity/volunteer/volunteer.entity";
+import { fetchJsonFromUrl, getRepository } from "../../utils";
+import {
+  createDeal,
+  getCount,
+  getDocumentStatus,
+  getEnumValue,
+  getOrCreatePerson,
+  getVolunteerState,
+} from "../utils";
+import { VolunteerJSON } from "./types";
+
+export async function seedVolunteers(dataSource: DataSource): Promise<void> {
+  if (!dataSource) {
+    throw new Error("DataSource is not initialized.");
+  }
+
+  const volunteerRepository = getRepository(dataSource, Volunteer);
+
+  const count = await getCount(volunteerRepository);
+  if (count !== 0) {
+    logger.info("Skipping seeding volunteers.");
+    return;
+  }
+
+  const volunteers = (await fetchJsonFromUrl(
+    seedVolunteersFile,
+  )) as VolunteerJSON[];
+
+  for (const volunteer of volunteers ?? []) {
+    try {
+      const person = await getOrCreatePerson(volunteer.person, dataSource);
+
+      const deal = await createDeal(volunteer.deal, dataSource);
+
+      const newVolunteer = new Volunteer({
+        ...getVolunteerState(volunteer),
+        statusCGC: getDocumentStatus(volunteer.statusCGC),
+        statusVaccination: getDocumentStatus(volunteer.statusVaccination),
+        infoAbout: volunteer.infoAbout || "",
+        infoExperience: volunteer.infoExperience || "",
+        createdAt: new Date(volunteer.timestamp),
+        updatedAt: new Date(volunteer.timestamp),
+        person,
+        deal,
+      });
+      await volunteerRepository.save(newVolunteer);
+
+      const notionRelationRepository = getRepository(
+        dataSource,
+        NotionRelation,
+      );
+      const relationsOpp = await notionRelationRepository.find({
+        where: {
+          hostType: EntityTableName.OPPORTUNITY,
+          tenantType: EntityTableName.VOLUNTEER,
+          tenantNid: volunteer.nid,
+        },
+      });
+
+      const opportunityVolunteerRepository = getRepository(
+        dataSource,
+        OpportunityVolunteer,
+      );
+      for (const { payroll, hostId } of relationsOpp ?? []) {
+        await opportunityVolunteerRepository.save(
+          new OpportunityVolunteer({
+            status: getEnumValue(OpportunityVolunteerStatusType, payroll),
+            opportunityId: hostId,
+            volunteerId: newVolunteer.id,
+          }),
+        );
+      }
+    } catch (error) {
+      logger.info(
+        `Creation of volunteer ${volunteer?.person?.email} rolled back due to error: ${(error as Error).message}`,
+      );
+    }
+  }
+}

--- a/src/data/seeds/seed.ts
+++ b/src/data/seeds/seed.ts
@@ -1,9 +1,9 @@
 import { DataSource } from "typeorm";
 import { check } from "..";
-import { seedAgents } from "./dev/agent.seed";
-import { devTime } from "./dev/dev-parsing";
-import { seedOpportunities } from "./dev/opportunity.seed";
-import { seedVolunteers } from "./dev/volunteer.seed";
+import { seedAgents } from "./populate/agent.seed";
+import { devTime } from "./populate/dev-parsing";
+import { seedOpportunities } from "./populate/opportunity.seed";
+import { seedVolunteers } from "./populate/volunteer.seed";
 import { seedReference } from "./reference";
 import { seedUser } from "./user.seed";
 

--- a/src/data/seeds/utils.ts
+++ b/src/data/seeds/utils.ts
@@ -51,7 +51,7 @@ import {
   PersonJSON,
   TimeJSON,
   VolunteerJSON,
-} from "./dev/types";
+} from "./populate/types";
 
 const noGenderAvatarUrl = "all_genders_avatar.png";
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     environment: "node",
     setupFiles: ["./src/test/setup.ts"], // Optional: for DB connection logic
     include: ["**/*.{test,spec}.ts"],
+    exclude: ["**/node_modules/**", "src/test/e2e/**"],
     env: {
       JWT_SECRET: "test-secret-only-for-vitest",
       NODE_ENV: "test",


### PR DESCRIPTION
## Summary

- `src/data/seeds/dev/` was silently excluded by the `dev/` entry in `.gitignore`, which matches any directory named `dev` at any depth. Docker build never received those 5 TypeScript files, causing `TS2307: Cannot find module` errors on CI.
- Renamed `seeds/dev/` → `seeds/populate/` and updated the two import sites (`seed.ts`, `utils.ts`).
- Fixed a pre-existing bug where e2e smoke tests (which need `vitest.e2e.config.ts`'s `globalSetup` to seed the DB) were being picked up by the default `yarn test` / pre-push hook. Added `src/test/e2e/**` to `vitest.config.ts`'s exclude list alongside the existing node_modules exclusion.

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn test:run` — 47 files / 413 tests all pass (local, with Postgres running)
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)