### PR TITLE
chore: upgrade need4deed-sdk to 0.0.120

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.119",
+    "need4deed-sdk": "0.0.120",
     "node-cron": "^4.5.0",
     "pg": "^8.14.1",
     "pino": "^10.3.1",

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -37,7 +37,6 @@ export function dtoAgentGetList(agent: Agent): ApiAgentGetList {
     trustLevel: agent.trustLevel,
     volunteerSearch: agent.searchStatus,
     activeVolunteers: agent.activeVolunteers,
-    numActiveVolunteers: agent.activeVolunteers,
     numOpportunities: agent.opportunity?.length ?? 0,
     email:
       agent.representative?.person?.email || agent.organization?.email || "",

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -1,4 +1,4 @@
-import { AgentVolunteerSearchType } from "need4deed-sdk";
+import { AgentTrustType, AgentVolunteerSearchType } from "need4deed-sdk";
 import { describe, expect, it, vi } from "vitest";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import {
@@ -152,7 +152,7 @@ describe("dtoAgentGetList", () => {
   it("maps all scalar fields from a fully-loaded agent", () => {
     const fullAgent = {
       ...mockAgentBase,
-      trustLevel: 3,
+      trustLevel: AgentTrustType.HIGH,
       address: {
         street: "Main St",
         city: "Berlin",
@@ -170,9 +170,8 @@ describe("dtoAgentGetList", () => {
       id: 1,
       title: "Helping Hands",
       type: "NGO",
-      trustLevel: 3,
+      trustLevel: AgentTrustType.HIGH,
       activeVolunteers: 10,
-      numActiveVolunteers: 10,
       numOpportunities: 2,
       email: "contact@helping-hands.org",
       district: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,10 +2942,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.119:
-  version "0.0.119"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.119.tgz#e7d3ad32223b3ad2712e9e8b6d9d61c9d4426c01"
-  integrity sha512-hYXEdcm3p1zv8cTTRdCf4MSPG2QOunObrIdY45WKEdqO6ZsHa7FGX2Xgb7c+yXlB8ZWlIuEaklxJ6rZYJA+XeA==
+need4deed-sdk@0.0.120:
+  version "0.0.120"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.120.tgz#dfc49febd1fb4dde61b3b1c80c4acb8ddccbb90c"
+  integrity sha512-ehpWMuM09QUnEYsW1Cto/fWd9Ms/iES+8fa/Gmw9i8XjKHWRcS14Lz3Lhu10To8ZoU9bKHJqgz6KrU9+iHnY0w==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

- Upgrades `need4deed-sdk` to `0.0.120`
- Drops `numActiveVolunteers` from `dtoAgentGetList` (removed from SDK contract; `fe` uses `activeVolunteers` exclusively)
- Updates test mock to use `AgentTrustType.HIGH` instead of bare number

🤖 Generated with [Claude Code](https://claude.com/claude-code)