### PR TITLE
fix: upgrade need4deed-sdk to 0.0.122; fix dtoAgentOpportunity

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.120",
+    "need4deed-sdk": "0.0.122",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/routes/agent/agent-opportunity.routes.ts
+++ b/src/server/routes/agent/agent-opportunity.routes.ts
@@ -27,7 +27,14 @@ export default async function agentOpportunityRoutes(
     async (request, reply) => {
       const { id } = request.params;
       const agentRepository = fastify.db.agentRepository;
-      const relations = ["opportunity.opportunityVolunteer.volunteer.person"];
+      const relations = [
+        "opportunity.opportunityVolunteer.volunteer.person",
+        "opportunity.deal.dealLanguage.language",
+        "opportunity.deal.dealActivity.activity",
+        "opportunity.deal.dealDistrict.district",
+        "opportunity.deal.dealTimeslot.timeslot",
+        "opportunity.district",
+      ];
       const agent = await agentRepository.findOne({ where: { id }, relations });
 
       if (!agent) {

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -13,6 +13,7 @@ import Opportunity from "../../data/entity/opportunity/opportunity.entity";
 import { serializeAddress } from "./dto-address";
 import { commentSerializer } from "./dto-comment";
 import { dtoSerializePerson } from "./dto-person";
+import { getAvailability, getLanguages } from "./utils";
 
 // Serializes an agent<->person membership for the moderation endpoints.
 // Expects the `agent` and `person` relations to be loaded.
@@ -123,10 +124,20 @@ export function dtoAgentOpportunity(
   return {
     id: opportunity.id,
     title: opportunity.title,
+    volunteerType: opportunity.type,
     statusOpportunity: opportunity.status,
     statusMatch: opportunity.statusMatch,
     numberOfVolunteers: opportunity.numberVolunteers,
     createdAt: opportunity.createdAt,
+    district: { id: opportunity.district?.id ?? opportunity.districtId },
+    languages: getLanguages(opportunity.deal?.dealLanguage ?? []),
+    activities: (opportunity.deal?.dealActivity ?? [])
+      .filter(Boolean)
+      .map((da) => ({ id: da.activity.id })),
+    location: (opportunity.deal?.dealDistrict ?? [])
+      .filter(Boolean)
+      .map((dd) => ({ id: dd.district.id })),
+    availability: getAvailability(opportunity.deal?.dealTimeslot ?? []) ?? [],
     volunteers: (opportunity.opportunityVolunteer ?? [])
       .filter(Boolean)
       .map((ov) => ({

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -207,10 +207,19 @@ describe("dtoAgentOpportunity", () => {
   const baseOpportunity = {
     id: 42,
     title: "German tutoring",
+    type: "regular",
     status: "opp-active",
     statusMatch: "opp-vol-matched",
     numberVolunteers: 3,
     createdAt: new Date("2026-01-15"),
+    districtId: 7,
+    district: { id: 7 },
+    deal: {
+      dealLanguage: [],
+      dealActivity: [],
+      dealDistrict: [],
+      dealTimeslot: [],
+    },
   };
 
   it("maps the opportunity scalars and its linked volunteers", () => {
@@ -229,10 +238,16 @@ describe("dtoAgentOpportunity", () => {
     expect(dtoAgentOpportunity(opportunity as any)).toEqual({
       id: 42,
       title: "German tutoring",
+      volunteerType: "regular",
       statusOpportunity: "opp-active",
       statusMatch: "opp-vol-matched",
       numberOfVolunteers: 3,
       createdAt: new Date("2026-01-15"),
+      district: { id: 7 },
+      languages: [],
+      activities: [],
+      location: [],
+      availability: [],
       volunteers: [
         {
           id: 5,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.120:
-  version "0.0.120"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.120.tgz#dfc49febd1fb4dde61b3b1c80c4acb8ddccbb90c"
-  integrity sha512-ehpWMuM09QUnEYsW1Cto/fWd9Ms/iES+8fa/Gmw9i8XjKHWRcS14Lz3Lhu10To8ZoU9bKHJqgz6KrU9+iHnY0w==
+need4deed-sdk@0.0.122:
+  version "0.0.122"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.122.tgz#2513f94fe2beed9f0fbd7b4837c47308c13a5aac"
+  integrity sha512-GtmQBUd0jYyfUDsGhuqXVJB24ddDreHIq0guBimPoBrNb8yyHH2TM5B9ulkEQ6MGAPEuOR86PxogeuLmEBIgrw==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

- Upgrades `need4deed-sdk` from 0.0.120 → 0.0.122, which adds the five `CommunicationType` enum values (`ACCOMPANYING_MATCHED`, `MATCHED`, `OPPORTUNITY_CONFIRMATION`, `ACCOMPANYING_NOT_FOUND`, `OPPORTUNITY_UPDATED`) that were in the PostgreSQL enum since migration `1782903516653` but missing from the TypeScript enum, and adds `opportunityId?: number` to `ApiCommunicationGet`
- Fixes `dtoAgentOpportunity` to return the full `ApiAgentOpportunity` shape: `volunteerType`, `district`, `languages`, `activities`, `location`, `availability` — previously only scalar fields were returned
- Updates `agentOpportunityRoutes` to load the `deal.*` and `district` relations needed by the DTO
- Updates `dto-agent.test.ts` to cover the new fields

All 12 pre-existing `tsc` errors are now resolved; `yarn build` in Docker should complete successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)