### PR TITLE
fix: support title in PATCH /opportunity/:id

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.122",
+    "need4deed-sdk": "0.0.125",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -781,6 +781,9 @@
       "$id": "ApiVolunteerOpportunityPatch",
       "type": "object",
       "properties": {
+        "title": {
+          "type": "string"
+        },
         "statusOpportunity": {
           "$ref": "OpportunityStatusType#"
         },

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -30,6 +30,7 @@ export function parseOpportunity(body: ApiOpportunityPatch) {
   return {
     ...getEmptyPropsNull({
       opportunity: {
+        title: body.title,
         status: body.statusOpportunity,
         numberVolunteers: body.numberVolunteers,
         info: body.description,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.122:
-  version "0.0.122"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.122.tgz#2513f94fe2beed9f0fbd7b4837c47308c13a5aac"
-  integrity sha512-GtmQBUd0jYyfUDsGhuqXVJB24ddDreHIq0guBimPoBrNb8yyHH2TM5B9ulkEQ6MGAPEuOR86PxogeuLmEBIgrw==
+need4deed-sdk@0.0.125:
+  version "0.0.125"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.125.tgz#adee2cbc342da82c1f6dedfeebafac2502648d46"
+  integrity sha512-g/7Bwk1zqcyLZYvmgnACeXhuem5TGfDcwexzQVsaxR2HfXQW3zcJ3NHFaKqaKT9p4hOoRqkJR1vtaFOvFOAgfg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

- Upgrades `need4deed-sdk` 0.0.122 → 0.0.125 (0.0.125 adds `title` to `ApiOpportunityPatch`)
- Adds `"title"` to the `ApiVolunteerOpportunityPatch` JSON schema so Fastify/AJV accepts it (the schema has `additionalProperties: false`, so unknown fields were silently rejected with a 400)
- Maps `body.title` into the `opportunity` object in `parseOpportunity` so it reaches `patchEntity(Opportunity, ...)`

## Context

Part of the fix for opportunity title editing on the dashboard profile page (fe#340 / fe#360). The field was visible in display mode but saving was broken end-to-end: the FE was sending `title` to an endpoint that didn't accept it, and the BE's `additionalProperties: false` schema was rejecting it silently.

The full chain: sdk#151 (add `title` to `ApiOpportunityPatch`) → this PR → fe#781 (restore title edit field, already open).

## Test plan

- [ ] `PATCH /opportunity/:id` with `{ "title": "New name" }` — verify 204 and title updated in DB
- [ ] `PATCH /opportunity/:id` without `title` — verify other fields still save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)