### PR TITLE
fix: add numOpportunities to AgentList schema properties

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -1320,6 +1320,9 @@
         "numActiveVolunteers": {
           "type": "integer"
         },
+        "numOpportunities": {
+          "type": "integer"
+        },
         "email": {
           "type": "string"
         },


### PR DESCRIPTION
## Description
be#738 added `numOpportunities` to the `AgentList` schema's `required` array but not to `properties`.  That's why the count never showed up on dev. 

## Related Issues
Follow-up to be #738. Unblocks fe [712](https://github.com/need4deed-org/fe/issues/712) the agent-table opportunities column


## Changes
-  Add numOpportunities to the AgentList schema properties block 

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

