### PR TITLE
fix: allow null for timeslots in POST /opportunity schema

### DIFF
--- a/src/server/schema/opportunity-create.schema.ts
+++ b/src/server/schema/opportunity-create.schema.ts
@@ -23,7 +23,7 @@ export const opportunityCreateBodySchema = {
     activities: { type: "array", items: { type: "string" } },
     skills: { type: "array", items: { type: "string" } },
     berlin_locations: { type: "array", items: { type: "string" } },
-    timeslots: { type: "array" },
+    timeslots: { type: ["array", "null"] },
     onetime_date_time: { type: "string" },
     accomp_address: { type: "string" },
     accomp_postcode: { type: "string" },


### PR DESCRIPTION
## Summary

- Fastify's AJV coerces `null` → `[null]` for `{ type: "array" }` fields
- When creating an **event-type** opportunity the frontend sends `timeslots: null` (events have no recurring schedule)
- That `null` was coerced to `[null]`, the parser looped over it, and tried to destructure `null` as `[day, daytime]` → `TypeError: opportunityTime is not iterable`
- Fix: change `timeslots` to `{ type: ["array", "null"] }` — null now passes through unchanged; the existing `formData.timeslots || []` guard short-circuits to an empty array

The SDK type `OpportunityLegacyFormData.timeslots` is already `[number, string][] | null | undefined` (via `VoidableUndefined`), so this brings the JSON schema in line with the existing contract.

## Test plan

- [ ] Create an event-type opportunity via POST /opportunity — should succeed (no 500)
- [ ] Create a regular-type opportunity with timeslots — should still work
- [ ] Verify all 413 existing tests still pass (they do: CI green on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)