### PR TITLE
refactor(post): extract validateRelationIds helper

### DIFF
--- a/src/server/routes/post.routes.ts
+++ b/src/server/routes/post.routes.ts
@@ -21,6 +21,7 @@ import {
 } from "../types";
 import { getSkipTake } from "../utils";
 import { getAgentPersonRepresentative } from "../utils/data/get-agent-person-representative";
+import { validateRelationIds } from "../utils/data/validate-relation-ids";
 
 export default async function postRoutes(
   fastify: FastifyInstance,
@@ -119,27 +120,12 @@ export default async function postRoutes(
           : [],
       ]);
 
-      const existingPersonIds = new Set(taggedPersons.map((p) => p.id));
-      const missingPersonIds = [...new Set(taggedPersonIds)].filter(
-        (id) => !existingPersonIds.has(id),
+      validateRelationIds(taggedPersonIds, taggedPersons, "tagged person");
+      validateRelationIds(
+        linkedOpportunityIds,
+        linkedOpportunities,
+        "linked opportunity",
       );
-      if (missingPersonIds.length) {
-        throw new BadRequestError(
-          `Invalid tagged person id(s): ${missingPersonIds.join(", ")}`,
-        );
-      }
-
-      const existingOpportunityIds = new Set(
-        linkedOpportunities.map((o) => o.id),
-      );
-      const missingOpportunityIds = [...new Set(linkedOpportunityIds)].filter(
-        (id) => !existingOpportunityIds.has(id),
-      );
-      if (missingOpportunityIds.length) {
-        throw new BadRequestError(
-          `Invalid linked opportunity id(s): ${missingOpportunityIds.join(", ")}`,
-        );
-      }
 
       const post = fastify.db.postRepository.create({
         text,
@@ -156,7 +142,9 @@ export default async function postRoutes(
         relations: ["author", "taggedPersons", "linkedOpportunities"],
       });
 
-      if (!full) {throw new NotFoundError("Post not found.");}
+      if (!full) {
+        throw new NotFoundError("Post not found.");
+      }
       return reply
         .status(201)
         .send({ message: "Post created.", data: dtoPost(full) });
@@ -220,15 +208,7 @@ export default async function postRoutes(
               id: In(taggedPersonIds),
             })
           : [];
-        const existingIds = new Set(found.map((p) => p.id));
-        const missing = [...new Set(taggedPersonIds)].filter(
-          (id) => !existingIds.has(id),
-        );
-        if (missing.length) {
-          throw new BadRequestError(
-            `Invalid tagged person id(s): ${missing.join(", ")}`,
-          );
-        }
+        validateRelationIds(taggedPersonIds, found, "tagged person");
         post.taggedPersons = found;
       }
       if (linkedOpportunityIds !== null && linkedOpportunityIds !== undefined) {
@@ -237,15 +217,7 @@ export default async function postRoutes(
               id: In(linkedOpportunityIds),
             })
           : [];
-        const existingIds = new Set(found.map((o) => o.id));
-        const missing = [...new Set(linkedOpportunityIds)].filter(
-          (id) => !existingIds.has(id),
-        );
-        if (missing.length) {
-          throw new BadRequestError(
-            `Invalid linked opportunity id(s): ${missing.join(", ")}`,
-          );
-        }
+        validateRelationIds(linkedOpportunityIds, found, "linked opportunity");
         post.linkedOpportunities = found;
       }
 

--- a/src/server/utils/data/validate-relation-ids.ts
+++ b/src/server/utils/data/validate-relation-ids.ts
@@ -1,0 +1,15 @@
+import { BadRequestError } from "../../../config";
+
+export function validateRelationIds(
+  requestedIds: number[],
+  foundEntities: { id: number }[],
+  label: string,
+): void {
+  const existingIds = new Set(foundEntities.map((e) => e.id));
+  const missing = [...new Set(requestedIds)].filter(
+    (id) => !existingIds.has(id),
+  );
+  if (missing.length) {
+    throw new BadRequestError(`Invalid ${label} id(s): ${missing.join(", ")}`);
+  }
+}

--- a/src/test/server/utils/data/validate-relation-ids.test.ts
+++ b/src/test/server/utils/data/validate-relation-ids.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { BadRequestError } from "../../../../config";
+import { validateRelationIds } from "../../../../server/utils/data/validate-relation-ids";
+
+describe("validateRelationIds", () => {
+  it("does not throw when all requested ids are found", () => {
+    expect(() =>
+      validateRelationIds(
+        [1, 2, 3],
+        [{ id: 1 }, { id: 2 }, { id: 3 }],
+        "person",
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws BadRequestError when any id is missing", () => {
+    expect(() => validateRelationIds([1, 2, 3], [{ id: 1 }], "person")).toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("includes the label and missing ids in the error message", () => {
+    expect(() =>
+      validateRelationIds([1, 2, 3], [{ id: 1 }], "tagged person"),
+    ).toThrow("Invalid tagged person id(s): 2, 3");
+  });
+
+  it("deduplicates requested ids before checking", () => {
+    expect(() =>
+      validateRelationIds([1, 1, 2], [{ id: 1 }, { id: 2 }], "person"),
+    ).not.toThrow();
+  });
+
+  it("does not throw when requestedIds is empty", () => {
+    expect(() => validateRelationIds([], [], "person")).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #737

## Summary

- Extracted `validateRelationIds(requestedIds, foundEntities, label)` into `src/server/utils/data/validate-relation-ids.ts` — a pure synchronous helper that throws `BadRequestError` listing any missing ids
- Replaced the four copy-pasted Set-intersection validation blocks in the `POST /post` and `PATCH /post/:id` handlers with two calls each
- Added unit test in `src/test/server/utils/data/validate-relation-ids.test.ts` (5 cases; no DB required)

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn test:run` — all 418 tests pass including the 5 new unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)