### PR TITLE
feat(notify): split SMTP into verify and notify transports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@ SMTP_PASS=fake-string
 
 # Notification emails (cron scans, status-change triggers) — Infomaniak SMTP account #2.
 # Infomaniak does not allow multiple senders on one SMTP account, hence the split.
-EMAIL_FROM_NOTIFY=notifications@need4deed.org
+EMAIL_FROM_NOTIFY=coordinators@need4deed.org
 SMTP_NOTIFY_HOST=mail.infomaniak.com
 SMTP_NOTIFY_PORT=587
-SMTP_NOTIFY_USER=notifications@need4deed.org
+SMTP_NOTIFY_USER=coordinators@need4deed.org
 SMTP_NOTIFY_PASS=fake-string
 
 # Verification email content is read from a per-locale CDN manifest

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,18 @@
-# Transactional email via Infomaniak SMTP.
+# Verification emails (email-verification, password-reset) — Infomaniak SMTP account #1.
 EMAIL_FROM=no-reply@need4deed.org
 SMTP_HOST=mail.infomaniak.com
 SMTP_PORT=587
 SMTP_USER=no-reply@need4deed.org
 SMTP_PASS=fake-string
+
+# Notification emails (cron scans, status-change triggers) — Infomaniak SMTP account #2.
+# Infomaniak does not allow multiple senders on one SMTP account, hence the split.
+EMAIL_FROM_NOTIFY=notifications@need4deed.org
+SMTP_NOTIFY_HOST=mail.infomaniak.com
+SMTP_NOTIFY_PORT=587
+SMTP_NOTIFY_USER=notifications@need4deed.org
+SMTP_NOTIFY_PASS=fake-string
+
 # Verification email content is read from a per-locale CDN manifest
 # (${CDN_BASE_URL}emails/verification.json), cached in-memory; falls back to
 # built-in copy. Optional tuning:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,8 @@ Copy `.env.example` to `.env` and fill in real values. Key variables:
 - `JWT_SECRET` — required; server refuses to start without it
 - `NODE_ENV` — `development` | `test` | `production`
 - `RUN_MIGRATIONS` — when truthy, auto-run pending migrations on server startup (always on in prod regardless of this flag); see Commands section
-- `EMAIL_FROM`, `BREVO_API_KEY` — transactional email via Brevo (verified sender + API key)
+- `EMAIL_FROM`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` — Infomaniak SMTP account for verification emails (email-verification, password-reset)
+- `EMAIL_FROM_NOTIFY`, `SMTP_NOTIFY_HOST`, `SMTP_NOTIFY_PORT`, `SMTP_NOTIFY_USER`, `SMTP_NOTIFY_PASS` — Infomaniak SMTP account for notification emails (cron scans, status-change triggers); separate account because Infomaniak does not allow multiple senders on one SMTP account
 - `EMAIL_TEMPLATE_TTL_MS`, `EMAIL_TEMPLATE_FETCH_TIMEOUT_MS` — optional; cache TTL + fetch timeout for the verification-email CDN manifest (`${CDN_BASE_URL}emails/verification.json`); falls back to built-in copy
 - `CORS_ORIGINS` — comma-separated list of allowed origins
 

--- a/src/server/plugins/notify.ts
+++ b/src/server/plugins/notify.ts
@@ -66,17 +66,25 @@ function isDryRun(transportKey: string): boolean {
   return !isProd;
 }
 
-function buildEmailTransport(): EmailTransport {
+function buildVerifyEmailTransport(): EmailTransport {
   const smtp = new SmtpEmailTransport({
     host: process.env.SMTP_HOST ?? "mail.infomaniak.com",
     port: Number(process.env.SMTP_PORT ?? 587),
     user: process.env.SMTP_USER ?? "",
     password: process.env.SMTP_PASS ?? "",
   });
-  if (isDryRun("EMAIL")) {
-    return new DryRunEmailTransport(smtp);
-  }
-  return smtp;
+  return isDryRun("EMAIL") ? new DryRunEmailTransport(smtp) : smtp;
+}
+
+function buildNotifyEmailTransport(): EmailTransport {
+  const smtp = new SmtpEmailTransport({
+    host: process.env.SMTP_NOTIFY_HOST ?? "mail.infomaniak.com",
+    port: Number(process.env.SMTP_NOTIFY_PORT ?? 587),
+    user: process.env.SMTP_NOTIFY_USER ?? "",
+    password: process.env.SMTP_NOTIFY_PASS ?? "",
+    from: process.env.EMAIL_FROM_NOTIFY ?? "",
+  });
+  return isDryRun("EMAIL") ? new DryRunEmailTransport(smtp) : smtp;
 }
 
 function buildSlackTransport(): SlackTransport | undefined {
@@ -98,34 +106,35 @@ function buildSlackTransport(): SlackTransport | undefined {
 }
 
 async function notifyPlugin(fastify: FastifyInstance) {
-  const email = buildEmailTransport();
+  const emailVerify = buildVerifyEmailTransport();
+  const emailNotify = buildNotifyEmailTransport();
   const slack = buildSlackTransport();
 
   fastify.decorate("notify", {
     emailVerification: (user: User) =>
-      sendEmailVerification({ email, jwt: fastify.jwt }, user),
+      sendEmailVerification({ email: emailVerify, jwt: fastify.jwt }, user),
     passwordReset: (user: User) =>
-      sendPasswordReset({ email, jwt: fastify.jwt }, user),
+      sendPasswordReset({ email: emailVerify, jwt: fastify.jwt }, user),
     opsAlert: (text: string) => sendOpsAlert({ slack }, text),
     commentTagged: (input: CommentTaggedInput) =>
       sendCommentTagged({ slack }, input),
     emailSuggestion: (ov: OpportunityVolunteer) =>
-      sendEmailSuggestion(email, ov),
-    emailStale: (ov: OpportunityVolunteer) => sendEmailStale(email, ov),
+      sendEmailSuggestion(emailNotify, ov),
+    emailStale: (ov: OpportunityVolunteer) => sendEmailStale(emailNotify, ov),
     emailIntroduction: (ov: OpportunityVolunteer) =>
-      sendEmailIntroduction(email, ov),
+      sendEmailIntroduction(emailNotify, ov),
     emailPostMatchCheckup: (ov: OpportunityVolunteer) =>
-      sendEmailPostMatchCheckup(email, ov),
+      sendEmailPostMatchCheckup(emailNotify, ov),
     emailAccompanyNotFound: (opportunity: Opportunity) =>
-      sendEmailAccompanyNotFound(email, opportunity),
+      sendEmailAccompanyNotFound(emailNotify, opportunity),
     emailAccompanyMatch: (ov: OpportunityVolunteer) =>
-      sendEmailAccompanyMatch(email, ov),
+      sendEmailAccompanyMatch(emailNotify, ov),
     emailRegularUpdate: (opportunity: Opportunity) =>
-      sendEmailRegularUpdate(email, opportunity),
+      sendEmailRegularUpdate(emailNotify, opportunity),
     emailNewRegular: (opportunity: Opportunity) =>
-      sendEmailNewRegular(email, opportunity),
+      sendEmailNewRegular(emailNotify, opportunity),
     emailNewAccompanying: (opportunity: Opportunity) =>
-      sendEmailNewAccompanying(email, opportunity),
+      sendEmailNewAccompanying(emailNotify, opportunity),
   });
 }
 


### PR DESCRIPTION
## Summary

Infomaniak does not allow multiple senders on a single SMTP account. Two separate transports are now used:

| Transport | Env vars | Used for |
|---|---|---|
| Verify | `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` / `EMAIL_FROM` | `emailVerification`, `passwordReset` |
| Notify | `SMTP_NOTIFY_HOST` / `SMTP_NOTIFY_PORT` / `SMTP_NOTIFY_USER` / `SMTP_NOTIFY_PASS` / `EMAIL_FROM_NOTIFY` | all cron-scan and status-change notification emails (10 events) |

Both transports respect the existing `NOTIFY_EMAIL_DRY_RUN` / `NOTIFY_DRY_RUN` flags.

`.env.example` and `CLAUDE.md` updated to document the new variables.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn test:run` — all 418 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)