### PR TITLE
feat(notify): add CC addresses to outbound notification emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ SMTP_PASS=fake-string
 EMAIL_TEMPLATE_TTL_MS=600000
 EMAIL_TEMPLATE_FETCH_TIMEOUT_MS=5000
 
+# Sender addresses for outbound notification emails (fall back to these defaults if unset).
+EMAIL_FROM_VOLUNTEER=volunteer@need4deed.org
+EMAIL_FROM_CONTACT=contact@need4deed.org
+EMAIL_FROM_ACCOMPANYING=accompanying@need4deed.org
+
 # Notification controls (default: dry-run on in non-prod, cron active)
 # NOTIFY_DRY_RUN=true        — redirect all emails to test@need4deed.org with [TO: <original>] subject prefix
 # NOTIFY_EMAIL_DRY_RUN=true  — same, email-only override

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ EMAIL_TEMPLATE_TTL_MS=600000
 EMAIL_TEMPLATE_FETCH_TIMEOUT_MS=5000
 
 # Sender addresses for outbound notification emails (fall back to these defaults if unset).
+# EMAIL_FROM_NOTIFY is the SMTP account used as `from` on all 8 notification triggers.
+EMAIL_FROM_NOTIFY=coordinators@need4deed.org
 EMAIL_FROM_VOLUNTEER=volunteer@need4deed.org
 EMAIL_FROM_CONTACT=contact@need4deed.org
 EMAIL_FROM_ACCOMPANYING=accompanying@need4deed.org

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -119,9 +119,12 @@ export const emailNewRegularManifestUrl =
 export const emailNewAccompanyingManifestUrl =
   CDNBaseUrl + "/emails/confirmationaccompanying.json";
 
-export const emailFromVolunteer = "volunteer@need4deed.org";
-export const emailFromContact = "contact@need4deed.org";
-export const emailFromAccompanying = "accompanying@need4deed.org";
+export const emailFromVolunteer =
+  process.env.EMAIL_FROM_VOLUNTEER || "volunteer@need4deed.org";
+export const emailFromContact =
+  process.env.EMAIL_FROM_CONTACT || "contact@need4deed.org";
+export const emailFromAccompanying =
+  process.env.EMAIL_FROM_ACCOMPANYING || "accompanying@need4deed.org";
 // How long a fetched email manifest is cached in-memory (default 10 min).
 export const emailTemplateTtlMs =
   Number(process.env.EMAIL_TEMPLATE_TTL_MS) || 10 * 60 * 1000;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -125,6 +125,8 @@ export const emailFromContact =
   process.env.EMAIL_FROM_CONTACT || "contact@need4deed.org";
 export const emailFromAccompanying =
   process.env.EMAIL_FROM_ACCOMPANYING || "accompanying@need4deed.org";
+export const emailFromNotify =
+  process.env.EMAIL_FROM_NOTIFY || "coordinators@need4deed.org";
 // How long a fetched email manifest is cached in-memory (default 10 min).
 export const emailTemplateTtlMs =
   Number(process.env.EMAIL_TEMPLATE_TTL_MS) || 10 * 60 * 1000;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -121,6 +121,7 @@ export const emailNewAccompanyingManifestUrl =
 
 export const emailFromVolunteer = "volunteer@need4deed.org";
 export const emailFromContact = "contact@need4deed.org";
+export const emailFromAccompanying = "accompanying@need4deed.org";
 // How long a fetched email manifest is cached in-memory (default 10 min).
 export const emailTemplateTtlMs =
   Number(process.env.EMAIL_TEMPLATE_TTL_MS) || 10 * 60 * 1000;

--- a/src/services/notify/events/email-accompany-match.ts
+++ b/src/services/notify/events/email-accompany-match.ts
@@ -2,6 +2,7 @@ import { Lang } from "need4deed-sdk";
 import {
   emailAccompanyMatchManifestUrl,
   emailFromContact,
+  emailFromNotify,
 } from "../../../config/constants";
 import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
 import { getLanguages } from "../../dto/utils";
@@ -122,7 +123,7 @@ export async function sendEmailAccompanyMatch(
   await email.send({
     to: contactPersonEmail,
     cc: emailFromContact,
-    from: emailFromContact,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),

--- a/src/services/notify/events/email-accompany-match.ts
+++ b/src/services/notify/events/email-accompany-match.ts
@@ -121,6 +121,7 @@ export async function sendEmailAccompanyMatch(
 
   await email.send({
     to: contactPersonEmail,
+    cc: emailFromContact,
     from: emailFromContact,
     subject,
     ...(text !== undefined ? { text } : {}),

--- a/src/services/notify/events/email-accompany-not-found.ts
+++ b/src/services/notify/events/email-accompany-not-found.ts
@@ -1,6 +1,7 @@
 import { Lang } from "need4deed-sdk";
 import {
   emailAccompanyNotFoundManifestUrl,
+  emailFromAccompanying,
   emailFromContact,
 } from "../../../config/constants";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
@@ -68,6 +69,7 @@ export async function sendEmailAccompanyNotFound(
 
   await email.send({
     to: contactPersonEmail,
+    cc: emailFromAccompanying,
     from: emailFromContact,
     subject,
     ...(text !== undefined ? { text } : {}),

--- a/src/services/notify/events/email-accompany-not-found.ts
+++ b/src/services/notify/events/email-accompany-not-found.ts
@@ -2,7 +2,7 @@ import { Lang } from "need4deed-sdk";
 import {
   emailAccompanyNotFoundManifestUrl,
   emailFromAccompanying,
-  emailFromContact,
+  emailFromNotify,
 } from "../../../config/constants";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import {
@@ -70,7 +70,7 @@ export async function sendEmailAccompanyNotFound(
   await email.send({
     to: contactPersonEmail,
     cc: emailFromAccompanying,
-    from: emailFromContact,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),

--- a/src/services/notify/events/email-introduction.ts
+++ b/src/services/notify/events/email-introduction.ts
@@ -1,6 +1,7 @@
 import { DocumentStatusType, Lang, VolunteerStateCGCType } from "need4deed-sdk";
 import {
   emailFromContact,
+  emailFromNotify,
   emailFromVolunteer,
   emailIntroductionManifestUrl,
 } from "../../../config/constants";
@@ -152,7 +153,7 @@ export async function sendEmailIntroduction(
   await email.send({
     to: [volunteerEmail, contactPersonEmail],
     cc: [emailFromContact, emailFromVolunteer],
-    from: emailFromContact,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),

--- a/src/services/notify/events/email-introduction.ts
+++ b/src/services/notify/events/email-introduction.ts
@@ -150,7 +150,8 @@ export async function sendEmailIntroduction(
   });
 
   await email.send({
-    to: [volunteerEmail, contactPersonEmail, emailFromVolunteer],
+    to: [volunteerEmail, contactPersonEmail],
+    cc: [emailFromContact, emailFromVolunteer],
     from: emailFromContact,
     subject,
     ...(text !== undefined ? { text } : {}),

--- a/src/services/notify/events/email-new-accompanying.ts
+++ b/src/services/notify/events/email-new-accompanying.ts
@@ -1,5 +1,6 @@
 import { Lang } from "need4deed-sdk";
 import {
+  emailFromAccompanying,
   emailFromContact,
   emailNewAccompanyingManifestUrl,
 } from "../../../config/constants";
@@ -82,6 +83,7 @@ export async function sendEmailNewAccompanying(
 
   await email.send({
     to: contactPersonEmail,
+    cc: [emailFromContact, emailFromAccompanying],
     from: emailFromContact,
     subject,
     ...(text !== undefined ? { text } : {}),

--- a/src/services/notify/events/email-new-accompanying.ts
+++ b/src/services/notify/events/email-new-accompanying.ts
@@ -2,6 +2,7 @@ import { Lang } from "need4deed-sdk";
 import {
   emailFromAccompanying,
   emailFromContact,
+  emailFromNotify,
   emailNewAccompanyingManifestUrl,
 } from "../../../config/constants";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
@@ -84,7 +85,7 @@ export async function sendEmailNewAccompanying(
   await email.send({
     to: contactPersonEmail,
     cc: [emailFromContact, emailFromAccompanying],
-    from: emailFromContact,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),

--- a/src/services/notify/events/email-post-match-checkup.ts
+++ b/src/services/notify/events/email-post-match-checkup.ts
@@ -48,6 +48,7 @@ export async function sendEmailPostMatchCheckup(
 
   await email.send({
     to: volunteerEmail,
+    cc: emailFromVolunteer,
     from: emailFromVolunteer,
     subject,
     ...(text !== undefined ? { text } : {}),

--- a/src/services/notify/events/email-post-match-checkup.ts
+++ b/src/services/notify/events/email-post-match-checkup.ts
@@ -1,5 +1,6 @@
 import { Lang } from "need4deed-sdk";
 import {
+  emailFromNotify,
   emailFromVolunteer,
   emailPostMatchCheckupManifestUrl,
 } from "../../../config/constants";
@@ -49,7 +50,7 @@ export async function sendEmailPostMatchCheckup(
   await email.send({
     to: volunteerEmail,
     cc: emailFromVolunteer,
-    from: emailFromVolunteer,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),

--- a/src/services/notify/events/email-regular-update.ts
+++ b/src/services/notify/events/email-regular-update.ts
@@ -53,6 +53,7 @@ export async function sendEmailRegularUpdate(
 
   await email.send({
     to: contactPersonEmail,
+    cc: emailFromContact,
     from: emailFromContact,
     subject,
     ...(text !== undefined ? { text } : {}),

--- a/src/services/notify/events/email-regular-update.ts
+++ b/src/services/notify/events/email-regular-update.ts
@@ -1,6 +1,7 @@
 import { Lang } from "need4deed-sdk";
 import {
   emailFromContact,
+  emailFromNotify,
   emailRegularUpdateManifestUrl,
 } from "../../../config/constants";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
@@ -54,7 +55,7 @@ export async function sendEmailRegularUpdate(
   await email.send({
     to: contactPersonEmail,
     cc: emailFromContact,
-    from: emailFromContact,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),

--- a/src/services/notify/events/email-stale.ts
+++ b/src/services/notify/events/email-stale.ts
@@ -1,5 +1,6 @@
 import { Lang } from "need4deed-sdk";
 import {
+  emailFromNotify,
   emailFromVolunteer,
   emailStaleManifestUrl,
 } from "../../../config/constants";
@@ -49,7 +50,7 @@ export async function sendEmailStale(
   await email.send({
     to: volunteerEmail,
     cc: emailFromVolunteer,
-    from: emailFromVolunteer,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),

--- a/src/services/notify/events/email-stale.ts
+++ b/src/services/notify/events/email-stale.ts
@@ -48,6 +48,7 @@ export async function sendEmailStale(
 
   await email.send({
     to: volunteerEmail,
+    cc: emailFromVolunteer,
     from: emailFromVolunteer,
     subject,
     ...(text !== undefined ? { text } : {}),

--- a/src/services/notify/events/email-suggestion.ts
+++ b/src/services/notify/events/email-suggestion.ts
@@ -61,6 +61,7 @@ export async function sendEmailSuggestion(
 
   await email.send({
     to: volunteerEmail,
+    cc: emailFromVolunteer,
     from: emailFromVolunteer,
     subject,
     ...(text !== undefined ? { text } : {}),

--- a/src/services/notify/events/email-suggestion.ts
+++ b/src/services/notify/events/email-suggestion.ts
@@ -1,5 +1,6 @@
 import { Lang } from "need4deed-sdk";
 import {
+  emailFromNotify,
   emailFromVolunteer,
   emailSuggestionManifestUrl,
 } from "../../../config/constants";
@@ -62,7 +63,7 @@ export async function sendEmailSuggestion(
   await email.send({
     to: volunteerEmail,
     cc: emailFromVolunteer,
-    from: emailFromVolunteer,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),

--- a/src/services/notify/transports/dry-run.ts
+++ b/src/services/notify/transports/dry-run.ts
@@ -13,13 +13,22 @@ export class DryRunEmailTransport implements EmailTransport {
 
   async send(msg: EmailMessage): Promise<void> {
     const originalTo = Array.isArray(msg.to) ? msg.to.join(", ") : msg.to;
+    const originalCc = msg.cc
+      ? Array.isArray(msg.cc)
+        ? msg.cc.join(", ")
+        : msg.cc
+      : undefined;
+    const prefix = originalCc
+      ? `[TO: ${originalTo} CC: ${originalCc}]`
+      : `[TO: ${originalTo}]`;
     const redirected: EmailMessage = {
       ...msg,
       to: DRY_RUN_RECIPIENT,
-      subject: `[TO: ${originalTo}] ${msg.subject}`,
+      cc: undefined,
+      subject: `${prefix} ${msg.subject}`,
     };
     logger.info(
-      `[notify:dry-run] redirecting email to ${DRY_RUN_RECIPIENT} — original to: "${originalTo}", subject: "${msg.subject}"`,
+      `[notify:dry-run] redirecting email to ${DRY_RUN_RECIPIENT} — original to: "${originalTo}"${originalCc ? `, cc: "${originalCc}"` : ""}, subject: "${msg.subject}"`,
     );
     await this.realTransport.send(redirected);
   }

--- a/src/services/notify/transports/email-smtp.ts
+++ b/src/services/notify/transports/email-smtp.ts
@@ -28,6 +28,7 @@ export class SmtpEmailTransport implements EmailTransport {
     await this.transporter.sendMail({
       from: msg.from ?? this.from,
       to: msg.to,
+      ...(msg.cc !== undefined ? { cc: msg.cc } : {}),
       subject: msg.subject,
       text: msg.text,
       html: msg.html,

--- a/src/services/notify/types.ts
+++ b/src/services/notify/types.ts
@@ -1,5 +1,6 @@
 export interface EmailMessage {
   to: string | string[];
+  cc?: string | string[];
   subject: string;
   text?: string;
   html?: string;


### PR DESCRIPTION
## Summary

- Adds `cc?: string | string[]` to `EmailMessage`
- `SmtpEmailTransport` passes it to nodemailer
- `DryRunEmailTransport` strips CC (no real delivery) and appends CC addresses to the `[TO: ... CC: ...]` subject prefix for visibility
- Adds `emailFromAccompanying = "accompanying@need4deed.org"` constant

### CC assignments

| Trigger | to | cc |
|---|---|---|
| `emailSuggestion` | volunteer | `volunteer@` |
| `emailAccompanyMatch` | contact person | `contact@` |
| `emailIntroduction` | volunteer + contact person | `contact@`, `volunteer@` ¹ |
| `emailNewAccompanying` | contact person | `contact@`, `accompanying@` |
| `emailStale` | volunteer | `volunteer@` |
| `emailPostMatchCheckup` | volunteer | `volunteer@` |
| `emailAccompanyNotFound` | contact person | `accompanying@` |
| `emailRegularUpdate` | contact person | `contact@` |

¹ Previously `emailFromVolunteer` was incorrectly appended to `to[]`; moved to `cc`.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn test:run` — all 418 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)