### PR TITLE
🐛 fix: make PLZ optional in agent address lookup

### DIFF
--- a/src/server/routes/agent/register.routes.ts
+++ b/src/server/routes/agent/register.routes.ts
@@ -91,7 +91,7 @@ export default async function agentRegisterRoutes(
       const street = (request.query.street ?? "").trim();
       const postcode = (request.query.postcode ?? "").trim();
       const domain = request.registrant?.email.split("@").pop()?.toLowerCase();
-      if (street.length < 3 || !postcode || !domain) {
+      if (street.length < 3 || !domain) {
         return reply.status(200).send({ message: "No query", data: [] });
       }
 

--- a/src/server/utils/data/get-agent-by-postcode.ts
+++ b/src/server/utils/data/get-agent-by-postcode.ts
@@ -5,8 +5,8 @@ function normalizeStreet(s: string): string {
     .trim()
     .toLowerCase()
     .replace(/\s*stra(?:ße|sse)\b/g, "str") // straße / strasse → str
-    .replace(/\s*str\./g, "str")             // str.  → str
-    .replace(/\s+str\b/g, "str");            // " str" → str
+    .replace(/\s*str\./g, "str") // str.  → str
+    .replace(/\s+str\b/g, "str"); // " str" → str
 }
 
 const HOUSE_NUMBER_RE = /\s+(\d+[\w-]*(?:\s+[a-z]+)?)$/;
@@ -22,7 +22,7 @@ function extractHouseNumber(s: string): string | undefined {
 }
 
 function agentHasPlz(a: Agent, plz: string): boolean {
-  if (a.address?.postcode?.value === plz) return true;
+  if (a.address?.postcode?.value === plz) {return true;}
   return !!a.agentPostcode?.some((ap) => ap.postcode?.value === plz);
 }
 
@@ -34,34 +34,34 @@ function streetNameWordRegex(streetName: string): RegExp {
 export function getAgentByAddress(
   agents: Agent[],
   street: string,
-  plz: string,
+  plz?: string,
 ): Agent | undefined {
   const normStreet = normalizeStreet(street);
 
   // 1. Strict: agents created via new code have address.street set
   const strict = agents.find(
     (a) =>
-      a.address?.postcode?.value === plz &&
+      (!plz || a.address?.postcode?.value === plz) &&
       normalizeStreet(a.address?.street ?? "") === normStreet,
   );
-  if (strict) return strict;
+  if (strict) {return strict;}
 
   // 2. Fuzzy fallback for legacy agents: street name (no number) found as a
-  //    whole word in agent title + PLZ from either address.postcode or agentPostcode.
+  //    whole word in agent title. PLZ narrows the match when provided.
   //    Number consistency: if the agent title contains a number it must match the
   //    form's number — prevents "Heerstr 10" matching form input "Heerstr 110".
   //    Agents with no number in title (e.g. "Refugium Hausvaterweg") match on
   //    street name alone.
   const streetName = extractStreetName(street);
-  if (!streetName) return undefined;
+  if (!streetName) {return undefined;}
   const streetRegex = streetNameWordRegex(streetName);
   const houseNumber = extractHouseNumber(street);
 
   const fuzzyMatches = agents.filter((a) => {
-    if (!agentHasPlz(a, plz)) return false;
-    if (!streetRegex.test(normalizeStreet(a.title ?? ""))) return false;
+    if (plz && !agentHasPlz(a, plz)) {return false;}
+    if (!streetRegex.test(normalizeStreet(a.title ?? ""))) {return false;}
     const titleNumber = extractHouseNumber(a.title ?? "");
-    if (titleNumber && houseNumber && titleNumber !== houseNumber) return false;
+    if (titleNumber && houseNumber && titleNumber !== houseNumber) {return false;}
     return true;
   });
 

--- a/src/test/server/utils/data/get-agent-by-postcode.test.ts
+++ b/src/test/server/utils/data/get-agent-by-postcode.test.ts
@@ -6,8 +6,14 @@ import {
 
 describe("getAgentByPostcode", () => {
   const agents = [
-    { id: 1, address: { postcode: { value: "12345" }, street: "Müllerstraße 48" } },
-    { id: 2, address: { postcode: { value: "55555" }, street: "Hauptstr. 10" } },
+    {
+      id: 1,
+      address: { postcode: { value: "12345" }, street: "Müllerstraße 48" },
+    },
+    {
+      id: 2,
+      address: { postcode: { value: "55555" }, street: "Hauptstr. 10" },
+    },
   ] as any;
 
   it("returns agent for matching postcode", () => {
@@ -45,11 +51,21 @@ describe("getAgentByAddress — street normalisation", () => {
   });
 
   it("does not match wrong postcode", () => {
-    expect(getAgentByAddress(agents, "Müllerstraße 48", "00000")).toBeUndefined();
+    expect(
+      getAgentByAddress(agents, "Müllerstraße 48", "00000"),
+    ).toBeUndefined();
   });
 
   it("does not match wrong street", () => {
     expect(getAgentByAddress(agents, "Hauptstraße 1", plz)).toBeUndefined();
+  });
+
+  it("matches by street alone when PLZ is omitted", () => {
+    expect(getAgentByAddress(agents, "Müllerstraße 48")).toEqual(agent);
+  });
+
+  it("does not match wrong street when PLZ is omitted", () => {
+    expect(getAgentByAddress(agents, "Hauptstraße 1")).toBeUndefined();
   });
 });
 
@@ -64,11 +80,15 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
   const plz = "13353";
 
   it("matches form address street name against agent title via agentPostcode PLZ", () => {
-    expect(getAgentByAddress(agents, "Hausvaterweg 21", plz)).toEqual(legacyAgent);
+    expect(getAgentByAddress(agents, "Hausvaterweg 21", plz)).toEqual(
+      legacyAgent,
+    );
   });
 
   it("does not match when PLZ differs", () => {
-    expect(getAgentByAddress(agents, "Hausvaterweg 21", "99999")).toBeUndefined();
+    expect(
+      getAgentByAddress(agents, "Hausvaterweg 21", "99999"),
+    ).toBeUndefined();
   });
 
   it("does not match when street name not in title", () => {
@@ -88,8 +108,12 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
       address: null,
       agentPostcode: [{ postcode: { value: "13353" } }],
     } as any;
-    expect(getAgentByAddress([agentAt21, agentAt45], "Hausvaterweg 21", plz)).toEqual(agentAt21);
-    expect(getAgentByAddress([agentAt21, agentAt45], "Hausvaterweg 45", plz)).toEqual(agentAt45);
+    expect(
+      getAgentByAddress([agentAt21, agentAt45], "Hausvaterweg 21", plz),
+    ).toEqual(agentAt21);
+    expect(
+      getAgentByAddress([agentAt21, agentAt45], "Hausvaterweg 45", plz),
+    ).toEqual(agentAt45);
   });
 
   it("returns undefined when multiple agents share street and PLZ and none has the number in title", () => {
@@ -99,7 +123,9 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
       address: null,
       agentPostcode: [{ postcode: { value: "13353" } }],
     } as any;
-    expect(getAgentByAddress([legacyAgent, second], "Hausvaterweg 21", plz)).toBeUndefined();
+    expect(
+      getAgentByAddress([legacyAgent, second], "Hausvaterweg 21", plz),
+    ).toBeUndefined();
   });
 
   it("does not match 'Heerstr 10' when form submits 'Heerstr 110' (number prefix false positive)", () => {
@@ -109,7 +135,9 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
       address: null,
       agentPostcode: [{ postcode: { value: "13353" } }],
     } as any;
-    expect(getAgentByAddress([heerstr10], "Heerstr 110", "13353")).toBeUndefined();
+    expect(
+      getAgentByAddress([heerstr10], "Heerstr 110", "13353"),
+    ).toBeUndefined();
   });
 
   it("matches 'Heerstr 110' agent when form submits 'Heerstr 110'", () => {
@@ -125,7 +153,9 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
       address: null,
       agentPostcode: [{ postcode: { value: "13353" } }],
     } as any;
-    expect(getAgentByAddress([heerstr10, heerstr110], "Heerstr 110", "13353")).toEqual(heerstr110);
+    expect(
+      getAgentByAddress([heerstr10, heerstr110], "Heerstr 110", "13353"),
+    ).toEqual(heerstr110);
   });
 
   it("does not false-match when street name is a substring of a different street in title", () => {
@@ -140,10 +170,14 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
   });
 
   it("matches address with hyphenated house number range", () => {
-    expect(getAgentByAddress(agents, "Hausvaterweg 5-7", plz)).toEqual(legacyAgent);
+    expect(getAgentByAddress(agents, "Hausvaterweg 5-7", plz)).toEqual(
+      legacyAgent,
+    );
   });
 
   it("matches address with space-separated letter suffix (e.g. '21 A')", () => {
-    expect(getAgentByAddress(agents, "Hausvaterweg 21 A", plz)).toEqual(legacyAgent);
+    expect(getAgentByAddress(agents, "Hausvaterweg 21 A", plz)).toEqual(
+      legacyAgent,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `GET /agent/register/search` required `postcode` in the guard, so the lookup never ran when the frontend (correctly) sent only `street`
- `getAgentByAddress` similarly used PLZ as a hard filter in both strict and fuzzy match paths
- Fix: make `plz` optional throughout — when omitted the strict match checks street only, and the fuzzy match skips the `agentHasPlz` filter (PLZ still narrows the result when provided)
- Drop `!postcode` from the route guard; the lookup now fires as soon as `street.length >= 3`

## Test plan

- [ ] 23 existing `getAgentByAddress` tests still pass (PLZ still works when provided)
- [ ] 2 new tests: strict match by street alone, no match on wrong street without PLZ
- [ ] End-to-end: type a street on the agent self-registration form — match banner appears without needing to fill postcode first

🤖 Generated with [Claude Code](https://claude.com/claude-code)