### PR TITLE
🐛 fix: embed role in verification URL for reliable agent redirect

### DIFF
--- a/src/services/notify/events/email-verification.ts
+++ b/src/services/notify/events/email-verification.ts
@@ -1,5 +1,5 @@
 import type { JWT, TokenType } from "@fastify/jwt";
-import { Lang } from "need4deed-sdk";
+import { Lang, UserRole } from "need4deed-sdk";
 import {
   emailVerificationManifestUrl,
   urlEmailVerification,
@@ -53,7 +53,9 @@ export async function sendEmailVerification(
     email: user.email,
     type: "verify" as TokenType,
   });
-  const url = `${urlEmailVerification}/${token}`;
+  const roleParam =
+    user.role === UserRole.AGENT ? `?role=${UserRole.AGENT}` : "";
+  const url = `${urlEmailVerification}/${token}${roleParam}`;
 
   logger.debug(`sendEmailVerification: ${user.email}, url: ${url}`);
 

--- a/src/test/services/notify/email-verification.test.ts
+++ b/src/test/services/notify/email-verification.test.ts
@@ -1,4 +1,4 @@
-import { Lang } from "need4deed-sdk";
+import { Lang, UserRole } from "need4deed-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { urlEmailVerification } from "../../../config/constants";
 import { fetchJsonFromUrl } from "../../../data/utils";
@@ -89,5 +89,30 @@ describe("sendEmailVerification", () => {
     await expect(
       sendEmailVerification(deps, user({ email: undefined })),
     ).rejects.toThrow("User email is required");
+  });
+
+  it("appends ?role=agent to the URL for AGENT users", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendEmailVerification(
+      deps,
+      user({ role: UserRole.AGENT, language: Lang.EN }),
+    );
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.text).toContain(`${expectedUrl}?role=agent`);
+  });
+
+  it("does not append a role param for non-agent users", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
+
+    await sendEmailVerification(
+      deps,
+      user({ role: UserRole.USER, language: Lang.EN }),
+    );
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.text).toContain(expectedUrl);
+    expect(msg.text).not.toContain("?role=");
   });
 });


### PR DESCRIPTION
## Summary

- The verify-email page relied on an `n4d_pending_role` browser cookie to decide whether to redirect to the agent registration form after verification
- The cookie was absent when the link was opened in a different browser/device than the one used to register, causing a redirect to `/dashboard` → `/login` instead
- Fix: append `?role=agent` to the verification URL for AGENT users so the redirect target is encoded in the URL, not browser state

## Test plan

- [ ] 8 email-verification tests pass (2 new: role param appended for AGENT, not for USER)
- [ ] Register as agent → receive email → open link in a **different browser** → lands on the agent profile completion form, not login

🤖 Generated with [Claude Code](https://claude.com/claude-code)