### PR TITLE
ci: fix bootstrap build context to be/ root

### DIFF
--- a/.github/workflows/build-bootstrap.yaml
+++ b/.github/workflows/build-bootstrap.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Build and push bootstrap image
         uses: docker/build-push-action@v6
         with:
-          context: ./data-bootstrap
+          context: .
+          file: data-bootstrap/Dockerfile
           push: true
           tags: ghcr.io/need4deed-org/bootstrap:latest


### PR DESCRIPTION
## Summary

- The `build-bootstrap` workflow was using `context: ./data-bootstrap`, but the new node-based Dockerfile copies `package.json`, `yarn.lock`, and the full source — it requires the `be/` root as build context.
- Added `file: data-bootstrap/Dockerfile` to point Docker at the right Dockerfile within the broader context.

## Test plan

- [ ] CI `build-bootstrap` run passes and pushes `ghcr.io/need4deed-org/bootstrap:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)