### PR TITLE
fix: pre-populate be_migrations before TypeORM reads it on fresh DB

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,6 +1,7 @@
 import { isProd, shouldRunMigrations } from "../config";
 import logger from "../logger";
 import { dataSource } from "./data-source";
+import { GenesisBaseSchema1763036250000 } from "./migrations/1763036250000-genesis-base-schema";
 
 const lockNumber = 0x639b4e2a1c8d79a9n; // random BIGINT (for PostgreSQL)
 
@@ -16,6 +17,48 @@ export const check = {
   },
 };
 
+// On a fresh database the migrations table is empty, so TypeORM would try to
+// run all 74 migrations in sequence — but migrations 1-73 conflict with the
+// schema that genesis already created (duplicate enums/tables).
+// This function runs genesis directly and marks all 74 migrations as done
+// BEFORE TypeORM reads the migrations table, so TypeORM sees 0 pending and
+// skips everything. On an existing database (cnt > 0) it is a no-op.
+async function bootstrapFreshDb(): Promise<void> {
+  const qr = dataSource.createQueryRunner();
+  try {
+    await qr.query(`
+      CREATE TABLE IF NOT EXISTS public.be_migrations (
+        id   SERIAL         NOT NULL,
+        "timestamp" bigint  NOT NULL,
+        name character varying NOT NULL,
+        PRIMARY KEY (id)
+      )
+    `);
+    const [{ cnt }] = await qr.query(
+      `SELECT COUNT(*)::int AS cnt FROM public.be_migrations`,
+    );
+    if (cnt > 0) {return;}
+
+    logger.info("Fresh database detected — running genesis bootstrap");
+    await qr.startTransaction();
+    try {
+      const genesis = new GenesisBaseSchema1763036250000();
+      await genesis.up(qr);
+      await qr.query(
+        `INSERT INTO public.be_migrations (timestamp, name)
+         VALUES (1763036250000, 'GenesisBaseSchema1763036250000')`,
+      );
+      await qr.commitTransaction();
+    } catch (e) {
+      await qr.rollbackTransaction();
+      throw e;
+    }
+    logger.info("Genesis bootstrap completed — all migrations pre-marked");
+  } finally {
+    await qr.release();
+  }
+}
+
 export async function initDatabase() {
   await dataSource.initialize();
   if (dataSource.isInitialized) {
@@ -25,6 +68,7 @@ export async function initDatabase() {
     try {
       if (isProd || shouldRunMigrations) {
         logger.info("Attempting to run migrations");
+        await bootstrapFreshDb();
         await dataSource.runMigrations();
         logger.info("Migrations completed");
       }


### PR DESCRIPTION
## Problem

After the genesis migration landed (#756), bootstrap still failed:

```
0 migrations already loaded in the database.
74 migrations were found in the source code.
74 migrations are new migrations must be executed.
Migration GenesisBaseSchema1763036250000 has been executed successfully.
query failed: CREATE TYPE "public"."config_config_key_enum" ... type already exists
Migration "UpdateVolunteerListMv1763036250587" failed
```

**Root cause:** TypeORM builds its full migration queue (all 74 migrations) by reading `be_migrations` *once* before running anything. Genesis then creates all enums/tables and inserts 73 records, but TypeORM already has a fixed plan to run every subsequent migration — they conflict with schema genesis just created.

## Fix

Add `bootstrapFreshDb()` in `src/data/index.ts`. It runs **before** `dataSource.runMigrations()`:

1. Creates `be_migrations` table if absent.
2. Counts rows — if `cnt > 0` (existing DB) returns immediately (no-op).
3. On a fresh DB: runs `GenesisBaseSchema1763036250000.up()` directly (creates full schema + inserts 73 migration records), then inserts genesis's own record.

When TypeORM then calls `runMigrations()` it reads 74/74 migrations as already done and runs zero.

## Test plan

- [ ] All 422 tests pass locally ✓
- [ ] Deploy to AITS: `kubectl rollout restart deployment/be -n n4d-dev` → bootstrap pod completes without error
- [ ] Bootstrap logs show "Genesis bootstrap completed" and no migration failures
- [ ] Existing production DB unaffected (bootstrapFreshDb exits immediately when cnt > 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)