### PR TITLE
fix(bootstrap): compile TypeScript at build time to reduce runtime memory

### DIFF
--- a/data-bootstrap/Dockerfile
+++ b/data-bootstrap/Dockerfile
@@ -1,6 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --production=false
+COPY . .
+RUN yarn build
+
 FROM node:22-alpine
 WORKDIR /app
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
-COPY . .
-CMD ["yarn", "seed"]
+RUN yarn install --frozen-lockfile --production=true && yarn cache clean
+COPY --from=builder /app/build ./build
+CMD ["node", "build/src/data/seeds/run.js"]


### PR DESCRIPTION
## Summary
- Replace `ts-node` runtime execution with pre-compiled JavaScript in the bootstrap container
- Multi-stage Docker build: compile in builder stage, run `node build/src/data/seeds/run.js` in production stage
- Eliminates ~500MB ts-node memory spike that caused VPS OOM on fresh deployments

## Test plan
- [ ] `build-bootstrap` workflow builds and pushes new image on merge to develop
- [ ] Bootstrap initContainer completes without OOM on AITS VPS