### PR TITLE
fix(bootstrap): copy public assets and seed fixtures into production stage

### DIFF
--- a/data-bootstrap/Dockerfile
+++ b/data-bootstrap/Dockerfile
@@ -10,4 +10,6 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --production=true && yarn cache clean
 COPY --from=builder /app/build ./build
+COPY public ./build/public
+COPY src/data/seeds/fixtures ./build/src/data/seeds/fixtures
 CMD ["node", "build/src/data/seeds/run.js"]


### PR DESCRIPTION
## Summary
- Add `COPY public ./build/public` so language/district/postcode JSON files are available
- Add `COPY src/data/seeds/fixtures ./build/src/data/seeds/fixtures` so agent/opportunity/volunteer seed fixtures are available
- Both are needed because `tsc` only emits `.js` files; static assets must be copied separately

## Test plan
- [x] `docker compose down -v && docker compose up db bootstrap` exits 0 locally
- [x] 48/48 tests pass