### PR TITLE
fix: notification emails silently failing across opportunity matching/creation

### DIFF
--- a/src/data/utils/get-opportunity-representative-person.ts
+++ b/src/data/utils/get-opportunity-representative-person.ts
@@ -1,17 +1,24 @@
 import Opportunity from "../entity/opportunity/opportunity.entity";
 import Person from "../entity/person.entity";
 
-// Resolves the single person to notify/contact for an opportunity: the
-// submitter, else the legacy contact person (kept for opportunities that
-// predate `submittedByPerson`), else the opportunity's agent's current
+// Resolves the person to notify/contact for an opportunity: the submitter,
+// else the legacy contact person (kept for opportunities that predate
+// `submittedByPerson`), else the opportunity's agent's current
 // representative. Requires `submittedByPerson`, `contactPerson`, and
 // `agent.agentPerson.person` to be eager-loaded as needed by the caller.
+//
+// Prefers whichever candidate actually has an email over just the first
+// non-null one: a submitter can be a Person with no email of its own (e.g.
+// an internal coordinator account, whose email lives on their User row, not
+// their Person row) — in that case we still want to fall through to a
+// representative we can actually reach.
 export function getOpportunityRepresentativePerson(
   opportunity: Opportunity,
 ): Person | undefined {
-  return (
-    opportunity.submittedByPerson ??
-    opportunity.contactPerson ??
-    opportunity.agent?.representative?.person
-  );
+  const candidates = [
+    opportunity.submittedByPerson,
+    opportunity.contactPerson,
+    opportunity.agent?.representative?.person,
+  ];
+  return candidates.find((person) => person?.email) ?? candidates.find(Boolean);
 }

--- a/src/data/utils/get-opportunity-representative-person.ts
+++ b/src/data/utils/get-opportunity-representative-person.ts
@@ -1,0 +1,17 @@
+import Opportunity from "../entity/opportunity/opportunity.entity";
+import Person from "../entity/person.entity";
+
+// Resolves the single person to notify/contact for an opportunity: the
+// submitter, else the legacy contact person (kept for opportunities that
+// predate `submittedByPerson`), else the opportunity's agent's current
+// representative. Requires `submittedByPerson`, `contactPerson`, and
+// `agent.agentPerson.person` to be eager-loaded as needed by the caller.
+export function getOpportunityRepresentativePerson(
+  opportunity: Opportunity,
+): Person | undefined {
+  return (
+    opportunity.submittedByPerson ??
+    opportunity.contactPerson ??
+    opportunity.agent?.representative?.person
+  );
+}

--- a/src/data/utils/index.ts
+++ b/src/data/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./fetch-json";
 export * from "./get-district";
+export * from "./get-opportunity-representative-person";
 export * from "./get-postcode";
 export * from "./get-repository";
 export * from "./getLoggingForDataSource";

--- a/src/server/routes/m2m/opportunity-volunteer.routes.ts
+++ b/src/server/routes/m2m/opportunity-volunteer.routes.ts
@@ -5,12 +5,73 @@ import {
   ProfileVolunteeringType,
   UserRole,
 } from "need4deed-sdk";
-import { BadRequestError, NotFoundError } from "../../../config";
+import { ConflictError, NotFoundError } from "../../../config";
 import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
 import logger from "../../../logger";
 import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyMessage } from "../../types";
 import { logEmailCommunication } from "../../utils/data/log-email-communication";
+
+// Sends the FIRST_INQUIRY "suggest" email for an OV that is (now) PENDING.
+// Called both right after creation (POST, which can create straight into
+// PENDING) and on a status transition into PENDING via PATCH (e.g. a
+// PENDING→DECLINED→PENDING re-toggle). Fire-and-forget: callers invoke this
+// without awaiting so a DB/send hiccup never affects the HTTP response.
+async function triggerEmailSuggestion(
+  fastify: FastifyInstance,
+  id: number,
+): Promise<void> {
+  const opportunityVolunteerRepository =
+    fastify.db.opportunityVolunteerRepository;
+  const commRepo = fastify.db.communicationRepository;
+
+  try {
+    logger.debug(`emailSuggestion side-effect triggered (ov ${id})`);
+    const ov = await opportunityVolunteerRepository.findOne({
+      where: { id },
+      relations: [
+        "volunteer.person",
+        "volunteer.person.users",
+        "volunteer.deal.postcode",
+        "volunteer.deal.dealTimeslot.timeslot",
+        "opportunity.submittedByPerson",
+        "opportunity.contactPerson",
+      ],
+    });
+    if (!ov) {
+      return;
+    }
+    // Skip if FIRST_INQUIRY already sent (e.g. PENDING→DECLINED→PENDING).
+    const alreadySent = await commRepo.findOne({
+      where: {
+        volunteerId: ov.volunteerId,
+        opportunityId: ov.opportunityId,
+        communicationType: CommunicationType.FIRST_INQUIRY,
+      },
+    });
+    if (alreadySent) {
+      return;
+    }
+    // Log before send; remove the dedup record on failure so the next toggle can retry.
+    const comm = await logEmailCommunication(
+      commRepo,
+      CommunicationType.FIRST_INQUIRY,
+      {
+        volunteerId: ov.volunteerId,
+        opportunityId: ov.opportunityId,
+      },
+    );
+    try {
+      await fastify.notify.emailSuggestion(ov);
+      logger.debug(`emailSuggestion side-effect succeeded (ov ${id})`);
+    } catch (sendErr) {
+      await commRepo.remove(comm).catch(logger.error);
+      throw sendErr;
+    }
+  } catch (err) {
+    logger.error(`emailSuggestion side-effect failed (ov ${id}): ${err}`);
+  }
+}
 
 export default async function m2mOpportunityVolunteerRoutes(
   fastify: FastifyInstance,
@@ -36,8 +97,30 @@ export default async function m2mOpportunityVolunteerRoutes(
       const opportunityVolunteerRepository =
         fastify.db.opportunityVolunteerRepository;
 
+      const { opportunityId, volunteerId } = request.body;
+
+      // Surface the duplicate-pair case as 409 up front (the DB unique
+      // constraint on (opportunityId, volunteerId) remains the ultimate
+      // guard for the rare race).
+      if (
+        await opportunityVolunteerRepository.findOneBy({
+          opportunityId,
+          volunteerId,
+        })
+      ) {
+        throw new ConflictError(
+          `A match already exists for opportunityId:${opportunityId}, volunteerId:${volunteerId}.`,
+        );
+      }
+
       const opportunityVolunteer = new OpportunityVolunteer(request.body);
       await opportunityVolunteerRepository.save(opportunityVolunteer);
+
+      if (
+        opportunityVolunteer.status === OpportunityVolunteerStatusType.PENDING
+      ) {
+        triggerEmailSuggestion(fastify, opportunityVolunteer.id);
+      }
 
       return reply.status(201).send({
         message: `Created M2M opportunityId:${opportunityVolunteer.opportunityId}, volunteerId:${opportunityVolunteer.volunteerId}, status:${opportunityVolunteer.status}.`,
@@ -60,11 +143,6 @@ export default async function m2mOpportunityVolunteerRoutes(
     },
     async (request, reply) => {
       const { id } = request.params;
-      if (id <= 0) {
-        throw new BadRequestError(
-          `Wrong id:${id} param. It must be a positive number`,
-        );
-      }
 
       const opportunityVolunteerRepository =
         fastify.db.opportunityVolunteerRepository;
@@ -91,55 +169,7 @@ export default async function m2mOpportunityVolunteerRoutes(
         const commRepo = fastify.db.communicationRepository;
 
         if (nextStatus === OpportunityVolunteerStatusType.PENDING) {
-          (async () => {
-            try {
-              // findOne inside the IIFE: handler returns 204 immediately;
-              // a DB hiccup here doesn't affect the HTTP response.
-              const ov = await opportunityVolunteerRepository.findOne({
-                where: { id },
-                relations: [
-                  "volunteer.person",
-                  "volunteer.person.users",
-                  "volunteer.deal.postcode",
-                  "volunteer.deal.dealTimeslot.timeslot",
-                  "opportunity",
-                ],
-              });
-              if (!ov) {
-                return;
-              }
-              // Skip if FIRST_INQUIRY already sent (e.g. PENDING→DECLINED→PENDING).
-              const alreadySent = await commRepo.findOne({
-                where: {
-                  volunteerId: ov.volunteerId,
-                  opportunityId: ov.opportunityId,
-                  communicationType: CommunicationType.FIRST_INQUIRY,
-                },
-              });
-              if (alreadySent) {
-                return;
-              }
-              // Log before send; remove the dedup record on failure so the next toggle can retry.
-              const comm = await logEmailCommunication(
-                commRepo,
-                CommunicationType.FIRST_INQUIRY,
-                {
-                  volunteerId: ov.volunteerId,
-                  opportunityId: ov.opportunityId,
-                },
-              );
-              try {
-                await fastify.notify.emailSuggestion(ov);
-              } catch (sendErr) {
-                await commRepo.remove(comm).catch(logger.error);
-                throw sendErr;
-              }
-            } catch (err) {
-              logger.error(
-                `emailSuggestion side-effect failed (ov ${id}): ${err}`,
-              );
-            }
-          })();
+          triggerEmailSuggestion(fastify, id);
         } else if (nextStatus === OpportunityVolunteerStatusType.MATCHED) {
           (async () => {
             try {
@@ -153,9 +183,13 @@ export default async function m2mOpportunityVolunteerRoutes(
                   "volunteer.deal.dealLanguage.language",
                   "volunteer.deal.dealSkill.skill",
                   "volunteer.deal.dealTimeslot.timeslot",
+                  "opportunity.submittedByPerson",
+                  "opportunity.submittedByPerson.users",
                   "opportunity.contactPerson",
                   "opportunity.contactPerson.users",
                   "opportunity.agent.address.postcode",
+                  "opportunity.agent.agentPerson.person",
+                  "opportunity.agent.agentPerson.person.users",
                   "opportunity.accompanying.postcode",
                   "opportunity.district",
                 ],
@@ -237,9 +271,6 @@ export default async function m2mOpportunityVolunteerRoutes(
     },
     async (request, reply) => {
       const { id } = request.params;
-      if (id <= 0) {
-        throw new BadRequestError("Param id must ba a positive number");
-      }
 
       const opportunityVolunteerRepository =
         fastify.db.opportunityVolunteerRepository;

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -339,6 +339,16 @@ export default async function opportunityRoutes(
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
       }
 
+      // This route derives the deal's postcode solely from the agent's
+      // address (the form has no rac_plz fallback, unlike the legacy route).
+      // deal.postcode_id is NOT NULL, so a missing postcode here would
+      // otherwise reach the DB as an unhandled constraint violation.
+      if (!agent.address?.postcode?.value) {
+        throw new BadRequestError(
+          `Agent (id:${agentId}) has no postcode on its address; set one before creating an opportunity for it.`,
+        );
+      }
+
       // An AGENT may only create opportunities for an agent they belong to;
       // COORDINATOR/ADMIN may create for any agent.
       if (role === UserRole.AGENT) {

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -390,7 +390,14 @@ export default async function opportunityRoutes(
             await sendNewOpportunityEmail(
               fastify,
               id,
-              ["contactPerson", "contactPerson.users"],
+              [
+                "submittedByPerson",
+                "submittedByPerson.users",
+                "contactPerson",
+                "contactPerson.users",
+                "agent.agentPerson.person",
+                "agent.agentPerson.person.users",
+              ],
               (opp) => fastify.notify.emailNewRegular(opp),
               "emailNewRegular",
             );
@@ -409,8 +416,12 @@ export default async function opportunityRoutes(
               [
                 "accompanying",
                 "accompanying.postcode",
+                "submittedByPerson",
+                "submittedByPerson.users",
                 "contactPerson",
                 "contactPerson.users",
+                "agent.agentPerson.person",
+                "agent.agentPerson.person.users",
                 "district",
               ],
               (opp) => fastify.notify.emailNewAccompanying(opp),

--- a/src/services/notify/events/email-accompany-match.ts
+++ b/src/services/notify/events/email-accompany-match.ts
@@ -5,6 +5,7 @@ import {
   emailFromNotify,
 } from "../../../config/constants";
 import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
+import { getOpportunityRepresentativePerson } from "../../../data/utils";
 import { getLanguages } from "../../dto/utils";
 import {
   createManifestLoader,
@@ -55,7 +56,8 @@ export async function sendEmailAccompanyMatch(
   email: EmailTransport,
   ov: OpportunityVolunteer,
 ): Promise<void> {
-  const contactPersonEmail = ov.opportunity?.contactPerson?.email;
+  const contactPerson = getOpportunityRepresentativePerson(ov.opportunity);
+  const contactPersonEmail = contactPerson?.email;
   if (!contactPersonEmail) {
     throw new Error(
       `sendEmailAccompanyMatch: missing contact email for opportunity ${ov.opportunityId}`,
@@ -80,7 +82,7 @@ export async function sendEmailAccompanyMatch(
   const volunteerName = volunteer.person.name;
   const volunteerEmail = volunteer.person.email ?? "";
   const volunteerPhone = volunteer.person.phone ?? "";
-  const contactpersonName = opportunity.contactPerson!.name;
+  const contactpersonName = contactPerson.name;
 
   const volunteerLanguage = getLanguages(volunteer.deal?.dealLanguage ?? [])
     .map((l) => l.title)
@@ -98,7 +100,7 @@ export async function sendEmailAccompanyMatch(
   const appointmentDistrict =
     opportunity.district?.title ?? accompanying?.postcode?.value ?? "";
 
-  const locale = resolveLocale(opportunity.contactPerson?.users?.[0]?.language);
+  const locale = resolveLocale(contactPerson.users?.[0]?.language);
   const contactSharing = resolveContactSharing(
     volunteer.shareContact ?? true,
     volunteerName,

--- a/src/services/notify/events/email-introduction.ts
+++ b/src/services/notify/events/email-introduction.ts
@@ -6,6 +6,7 @@ import {
   emailIntroductionManifestUrl,
 } from "../../../config/constants";
 import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
+import { getOpportunityRepresentativePerson } from "../../../data/utils";
 import { getLanguages, getOptionItems, getTitles } from "../../dto/utils";
 import {
   createManifestLoader,
@@ -85,7 +86,8 @@ export async function sendEmailIntroduction(
   ov: OpportunityVolunteer,
 ): Promise<void> {
   const volunteerEmail = ov.volunteer?.person?.email;
-  const contactPersonEmail = ov.opportunity?.contactPerson?.email;
+  const contactPerson = getOpportunityRepresentativePerson(ov.opportunity);
+  const contactPersonEmail = contactPerson?.email;
 
   if (!volunteerEmail || !contactPersonEmail) {
     throw new Error(
@@ -98,7 +100,7 @@ export async function sendEmailIntroduction(
   const locale = resolveLocale(volunteer.person?.users?.[0]?.language);
 
   const volunteerName = volunteer.person.name;
-  const contactpersonName = opportunity.contactPerson!.name;
+  const contactpersonName = contactPerson.name;
   const volunteeringopportunityName = opportunity.title;
 
   const volunteerLanguage = getLanguages(volunteer.deal?.dealLanguage ?? [])
@@ -145,7 +147,7 @@ export async function sendEmailIntroduction(
     volunteerEmail,
     volunteerPhone: volunteer.person.phone ?? "",
     contactpersonEmail: contactPersonEmail,
-    contactpersonPhone: opportunity.contactPerson!.phone ?? "",
+    contactpersonPhone: contactPerson.phone ?? "",
     agentAddress,
     statmentOnCertificates,
   });

--- a/src/services/notify/events/email-new-accompanying.ts
+++ b/src/services/notify/events/email-new-accompanying.ts
@@ -6,6 +6,7 @@ import {
   emailNewAccompanyingManifestUrl,
 } from "../../../config/constants";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import { getOpportunityRepresentativePerson } from "../../../data/utils";
 import {
   createManifestLoader,
   fillTemplate,
@@ -38,7 +39,8 @@ export async function sendEmailNewAccompanying(
   email: EmailTransport,
   opportunity: Opportunity,
 ): Promise<void> {
-  const contactPersonEmail = opportunity.contactPerson?.email;
+  const contactPerson = getOpportunityRepresentativePerson(opportunity);
+  const contactPersonEmail = contactPerson?.email;
   if (!contactPersonEmail) {
     throw new Error(
       `sendEmailNewAccompanying: missing contact email for opportunity ${opportunity.id}`,
@@ -46,7 +48,7 @@ export async function sendEmailNewAccompanying(
   }
 
   const accompanying = opportunity.accompanying;
-  const contactpersonName = opportunity.contactPerson!.name;
+  const contactpersonName = contactPerson.name;
   const appointmentDate = accompanying?.date
     ? new Date(accompanying.date).toLocaleDateString("de-DE", {
         timeZone: "Europe/Berlin",
@@ -66,7 +68,7 @@ export async function sendEmailNewAccompanying(
   const accompaniedpersonPhone = accompanying?.phone ?? "";
   const appointmentComment = opportunity.info ?? "";
 
-  const locale = resolveLocale(opportunity.contactPerson?.users?.[0]?.language);
+  const locale = resolveLocale(contactPerson.users?.[0]?.language);
   const content = resolveContent(await loader.load(), locale, BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,

--- a/src/services/notify/events/email-new-regular.ts
+++ b/src/services/notify/events/email-new-regular.ts
@@ -4,6 +4,7 @@ import {
   emailNewRegularManifestUrl,
 } from "../../../config/constants";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import { getOpportunityRepresentativePerson } from "../../../data/utils";
 import {
   createManifestLoader,
   fillTemplate,
@@ -34,17 +35,18 @@ export async function sendEmailNewRegular(
   email: EmailTransport,
   opportunity: Opportunity,
 ): Promise<void> {
-  const contactPersonEmail = opportunity.contactPerson?.email;
+  const contactPerson = getOpportunityRepresentativePerson(opportunity);
+  const contactPersonEmail = contactPerson?.email;
   if (!contactPersonEmail) {
     throw new Error(
       `sendEmailNewRegular: missing contact email for opportunity ${opportunity.id}`,
     );
   }
 
-  const contactpersonName = opportunity.contactPerson!.name;
+  const contactpersonName = contactPerson.name;
   const volunteeringopportunityName = opportunity.title;
 
-  const locale = resolveLocale(opportunity.contactPerson?.users?.[0]?.language);
+  const locale = resolveLocale(contactPerson.users?.[0]?.language);
   const content = resolveContent(await loader.load(), locale, BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,

--- a/src/services/notify/events/email-new-regular.ts
+++ b/src/services/notify/events/email-new-regular.ts
@@ -1,6 +1,7 @@
 import { Lang } from "need4deed-sdk";
 import {
   emailFromContact,
+  emailFromNotify,
   emailNewRegularManifestUrl,
 } from "../../../config/constants";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
@@ -55,7 +56,8 @@ export async function sendEmailNewRegular(
 
   await email.send({
     to: contactPersonEmail,
-    from: emailFromContact,
+    cc: emailFromContact,
+    from: emailFromNotify,
     subject,
     ...(text !== undefined ? { text } : {}),
     ...(html !== undefined ? { html } : {}),


### PR DESCRIPTION
## Summary

- "Suggest" email never sent on `OpportunityVolunteer` creation — the FE creates it via a single `POST` already at `status: opp-pending`, but the send side-effect only lived in the `PATCH` transition handler. Extracted into `triggerEmailSuggestion()`, now called from both `POST` and `PATCH`.
- "Matched"/accompanying-matched emails (`email-introduction.ts`, `email-accompany-match.ts`) threw on `opportunity.contactPerson!.name`/`.phone` whenever `contactPerson` was null but `submittedByPerson` was set — a valid, common state post-`submitted_by_person` backfill. Failures were swallowed into `logger.error` after the HTTP response already returned, so they were invisible.
- New-opportunity confirmation emails (`email-new-regular.ts`, `email-new-accompanying.ts`) **always** threw, since the modern (non-legacy) opportunity-creation route never sets `contactPersonId` at all — only `submittedByPersonId`.
- Added `getOpportunityRepresentativePerson()` (`submittedByPerson → contactPerson → agent.representative.person`) and wired it into all four notify events, replacing inconsistent ad-hoc fallbacks. Updated the relations loaded before each send so the fallback chain actually has data.
- Added a pre-check + `409 ConflictError` for duplicate `(opportunityId, volunteerId)` suggestions on `POST` (previously an unhandled `500` from the DB unique constraint).
- Removed a redundant `if (id <= 0)` param check in the m2m route — already enforced by `idParamSchema`'s `minimum: 1`.

Fixes #764.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean on touched files
- [x] `yarn test:run` — 427/427 passing
- [x] Manually verified end-to-end against local `docker compose` stack: created an OV via POST (suggest) → `first-inquiry-sent` communication logged; flipped to `opp-matched` → `matched` communication logged
- [x] Verified duplicate-suggest now returns `409` instead of an unhandled `500`