### PR TITLE
fix: guard genesis migration PK-adds against already-existing primary keys

### DIFF
--- a/src/data/migrations/1763036250000-genesis-base-schema.ts
+++ b/src/data/migrations/1763036250000-genesis-base-schema.ts
@@ -756,19 +756,39 @@ export class GenesisBaseSchema1763036250000 implements MigrationInterface {
       ["volunteer", "PK_76924da1998b3e07025e04c4d3c", "id"],
     ];
 
+    // A PK-add can't rely on `EXCEPTION WHEN duplicate_object` for idempotency:
+    // Postgres checks "table already has a PK" before it checks "constraint
+    // name already exists", so it raises invalid_table_definition (uncaught
+    // here) rather than duplicate_object whenever the table already has any
+    // primary key, even one with this exact name. Guard explicitly instead.
     for (const [tbl, name, cols] of pks) {
-      await queryRunner.query(
-        `DO $$ BEGIN ALTER TABLE ONLY public.${tbl} ADD CONSTRAINT "${name}" PRIMARY KEY (${cols}); EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
-      );
+      await queryRunner.query(`
+        DO $$ BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint WHERE conrelid = 'public.${tbl}'::regclass AND contype = 'p'
+          ) THEN
+            ALTER TABLE ONLY public.${tbl} ADD CONSTRAINT "${name}" PRIMARY KEY (${cols});
+          END IF;
+        END $$`);
     }
 
     // Composite PKs
-    await queryRunner.query(
-      `DO $$ BEGIN ALTER TABLE ONLY public.post_person ADD CONSTRAINT "PK_2752a498efcea4ce067c3ced8b6" PRIMARY KEY (post_id, person_id); EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
-    );
-    await queryRunner.query(
-      `DO $$ BEGIN ALTER TABLE ONLY public.post_opportunity ADD CONSTRAINT "PK_83c02a05c6699152a7619ca8de2" PRIMARY KEY (post_id, opportunity_id); EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
-    );
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conrelid = 'public.post_person'::regclass AND contype = 'p'
+        ) THEN
+          ALTER TABLE ONLY public.post_person ADD CONSTRAINT "PK_2752a498efcea4ce067c3ced8b6" PRIMARY KEY (post_id, person_id);
+        END IF;
+      END $$`);
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conrelid = 'public.post_opportunity'::regclass AND contype = 'p'
+        ) THEN
+          ALTER TABLE ONLY public.post_opportunity ADD CONSTRAINT "PK_83c02a05c6699152a7619ca8de2" PRIMARY KEY (post_id, opportunity_id);
+        END IF;
+      END $$`);
 
     // ─── UNIQUE CONSTRAINTS ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #768 — a production incident where `GenesisBaseSchema1763036250000` failed on startup with `multiple primary keys for table "accompanying" are not allowed`. Production was rolled back to the pre-incident SHA to restore service; this PR contains the actual fix.

- The PK-add loop guarded against re-runs with `EXCEPTION WHEN duplicate_object THEN NULL`, but Postgres checks "does this table already have a PK" *before* checking "does a constraint with this name already exist" — so it raises `invalid_table_definition` (42P16), not `duplicate_object` (42710), whenever the table already has any PK, even the exact same one. The guard never caught this, so the migration hard-failed on every non-empty DB (i.e. real production), every time it's attempted — and since `RUN_MIGRATIONS` is forced on in prod, that's every deploy or task replacement.
- Replaced the guard with an explicit `pg_constraint` existence check (`contype = 'p'`) for all 41 tables in the `pks` loop, plus the two composite-PK statements (`post_person`, `post_opportunity`).

## Test plan

- [x] Reproduced the exact production error locally: ran the *original* buggy DO block against a local DB where `accompanying` already has this PK — got the identical `multiple primary keys` error.
- [x] Ran the *patched* version against the same table — succeeds as a clean no-op.
- [x] `yarn typecheck` passes.
- [x] `yarn lint` clean on the changed file.
- [ ] Recommend also running the canonical fresh-replay check before merge: `docker compose down -v && RUN_MIGRATIONS=1 docker compose up`, confirming `Migrations completed` with no errors (validates the empty-DB path still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)