### PR TITLE
fix: persist a contact person's agent role via PATCH /person/:id

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.125",
+    "need4deed-sdk": "0.0.126",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/routes/person.routes.ts
+++ b/src/server/routes/person.routes.ts
@@ -1,7 +1,11 @@
 import { validate } from "class-validator";
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiPersonGet, ApiPersonPatch, UserRole } from "need4deed-sdk";
-import { NotFoundError } from "../../config";
+import { ApiPersonGet, ApiRepresentativePatch, UserRole } from "need4deed-sdk";
+import {
+  BadRequestError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../config";
 import Person, { PersonCreateType } from "../../data/entity/person.entity";
 import logger from "../../logger";
 import { dtoParsePerson, dtoSerializePerson } from "../../services";
@@ -11,6 +15,7 @@ import { newPersonSchema, personResponseSchema } from "../schema/person.schema";
 import { responseErrors } from "../schema/responseErrors";
 import { ParamsId, ReplyData } from "../types";
 import { updatePerson } from "../utils";
+import { getAgentPersonRepresentative } from "../utils/data/get-agent-person-representative";
 
 export default async function personRoutes(
   fastify: FastifyInstance,
@@ -108,18 +113,25 @@ export default async function personRoutes(
   fastify.patch<{
     Params: ParamsId;
     Reply: ReplyData<ApiPersonGet>;
-    Body: ApiPersonPatch;
+    Body: ApiRepresentativePatch;
   }>(
     "/:id",
     {
+      onRequest: [fastify.authenticate()],
       schema: {
         params: idParamSchema,
-        body: { $ref: "ApiPersonPatch#" },
+        body: { $ref: "ApiRepresentativePatch#" },
         response: responseSchema("ApiPersonGet#"),
       },
     },
     async (request, reply) => {
       const personId = request.params.id;
+      const authUser = request.authUser!;
+
+      if (authUser.role !== UserRole.ADMIN && authUser.personId !== personId) {
+        throw new UnauthorizedError("Insufficient permissions.");
+      }
+
       const person = await fastify.db.personRepository.findOne({
         where: { id: personId },
         relations: ["address.postcode"],
@@ -129,16 +141,49 @@ export default async function personRoutes(
         throw new NotFoundError(`Person with id ${personId} not found.`);
       }
 
-      const updatedPersonObj = deepMerge(
-        {
-          id: person.id,
-          addressId: person.addressId,
-          address: { postcodeId: person.address.postcodeId },
-        },
-        dtoParsePerson(request.body),
+      // role/agentId aren't person fields — a role-only patch has nothing
+      // for updatePerson to change, and TypeORM throws on an empty SET
+      // clause, so skip it entirely rather than no-op saving.
+      const hasPersonFieldUpdates = Object.keys(request.body).some(
+        (key) => key !== "role" && key !== "agentId",
       );
 
-      const updatedPerson = await updatePerson(updatedPersonObj);
+      const updatedPerson = hasPersonFieldUpdates
+        ? await updatePerson(
+            deepMerge(
+              {
+                id: person.id,
+                addressId: person.addressId,
+                address: { postcodeId: person.address.postcodeId },
+              },
+              dtoParsePerson(request.body),
+            ),
+          )
+        : person;
+
+      // role lives on AgentPerson, not person — agentId disambiguates which
+      // membership to update for a person belonging to more than one agent.
+      if (request.body.role !== undefined) {
+        if (!request.body.agentId) {
+          throw new BadRequestError(
+            "agentId is required to update a representative's role.",
+          );
+        }
+
+        const membership = await getAgentPersonRepresentative(
+          personId,
+          request.body.agentId,
+        );
+
+        if (!membership) {
+          throw new NotFoundError(
+            `No active agent membership found for person ${personId} at agent ${request.body.agentId}.`,
+          );
+        }
+
+        membership.role = request.body.role;
+        await fastify.db.agentPersonRepository.save(membership);
+      }
 
       const data = dtoSerializePerson(updatedPerson);
 

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -286,6 +286,26 @@
       "$id": "ApiPersonPatch",
       "$ref": "ApiPerson#"
     },
+    "ApiRepresentativePatch": {
+      "$id": "ApiRepresentativePatch",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "ApiPerson#"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "role": {
+              "$ref": "AgentRoleType#"
+            },
+            "agentId": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
     "VolunteerStateType": {
       "$id": "VolunteerStateType",
       "type": "string",

--- a/src/server/utils/data/get-agent-person-representative.ts
+++ b/src/server/utils/data/get-agent-person-representative.ts
@@ -5,22 +5,21 @@ import { getRepository } from "../../../data/utils";
 
 export async function getAgentPersonRepresentative(
   personId: number,
+  agentId?: number,
 ): Promise<AgentPerson | null> {
   const agentPersonRepository = getRepository(dataSource, AgentPerson);
+  const baseWhere = {
+    personId,
+    status: AgentMembershipStatus.ACTIVE,
+    ...(agentId ? { agentId } : {}),
+  };
   const representative =
     (await agentPersonRepository.findOne({
-      where: {
-        personId,
-        status: AgentMembershipStatus.ACTIVE,
-        role: AgentRoleType.VOLUNTEER_COORDINATOR,
-      },
+      where: { ...baseWhere, role: AgentRoleType.VOLUNTEER_COORDINATOR },
       order: { id: "ASC" },
     })) ??
     (await agentPersonRepository.findOne({
-      where: {
-        personId,
-        status: AgentMembershipStatus.ACTIVE,
-      },
+      where: baseWhere,
       order: { id: "ASC" },
     }));
 

--- a/src/test/server/routes/person.routes.test.ts
+++ b/src/test/server/routes/person.routes.test.ts
@@ -1,0 +1,229 @@
+import { FastifyInstance } from "fastify";
+import { AgentRoleType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import { dataSource } from "../../../data/data-source";
+import Address from "../../../data/entity/location/address.entity";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { getRepository, hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("PATCH /person/:id representative role", () => {
+  let fastify: FastifyInstance;
+
+  let editorPerson: Person;
+  let otherPerson: Person;
+  let adminPerson: Person;
+  let agent: Agent;
+  let editorCookie: string;
+  let otherCookie: string;
+  let adminCookie: string;
+  let addressId: number;
+
+  async function login(email: string): Promise<string> {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email, password: PASSWORD },
+    });
+    return getCookie(res.cookies, accessCookieName);
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const addressRepository = getRepository(dataSource, Address);
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    const address = await addressRepository.save(
+      new Address({ postcodeId: postcode.id }),
+    );
+    addressId = address.id;
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const pwHash = await hashPassword(PASSWORD);
+
+    editorPerson = await fastify.db.personRepository.save(
+      new Person({
+        firstName: "Test",
+        lastName: "Representative",
+        addressId: address.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `representative-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.USER,
+        isActive: true,
+        personId: editorPerson.id,
+      }),
+    );
+
+    otherPerson = await fastify.db.personRepository.save(
+      new Person({
+        firstName: "Test",
+        lastName: "Bystander",
+        addressId: address.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `bystander-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.USER,
+        isActive: true,
+        personId: otherPerson.id,
+      }),
+    );
+
+    adminPerson = await fastify.db.personRepository.save(
+      new Person({
+        firstName: "Test",
+        lastName: "Admin",
+        addressId: address.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `admin-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.ADMIN,
+        isActive: true,
+        personId: adminPerson.id,
+      }),
+    );
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent ${suffix}` }),
+    );
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: agent.id,
+        personId: editorPerson.id,
+        role: AgentRoleType.VOLUNTEER_COORDINATOR,
+      }),
+    );
+
+    editorCookie = await login(`representative-${suffix}@test.need4deed.org`);
+    otherCookie = await login(`bystander-${suffix}@test.need4deed.org`);
+    adminCookie = await login(`admin-${suffix}@test.need4deed.org`);
+  });
+
+  afterAll(async () => {
+    await fastify.db.agentPersonRepository.delete({ agentId: agent.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.db.userRepository.delete({ personId: editorPerson.id });
+    await fastify.db.userRepository.delete({ personId: otherPerson.id });
+    await fastify.db.userRepository.delete({ personId: adminPerson.id });
+    await fastify.db.personRepository.delete({ id: editorPerson.id });
+    await fastify.db.personRepository.delete({ id: otherPerson.id });
+    await fastify.db.personRepository.delete({ id: adminPerson.id });
+    await getRepository(dataSource, Address).delete({ id: addressId });
+    await fastify.close();
+  });
+
+  it("rejects an unauthenticated request", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/person/${editorPerson.id}`,
+      payload: { firstName: "Nope" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects a non-admin, non-self caller", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/person/${editorPerson.id}`,
+      cookies: { [accessCookieName]: otherCookie },
+      payload: { role: AgentRoleType.MANAGER, agentId: agent.id },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("400s when role is sent without agentId", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/person/${editorPerson.id}`,
+      cookies: { [accessCookieName]: editorCookie },
+      payload: { role: AgentRoleType.MANAGER },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("404s when agentId doesn't match any active membership for the person", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/person/${editorPerson.id}`,
+      cookies: { [accessCookieName]: editorCookie },
+      payload: { role: AgentRoleType.MANAGER, agentId: 999999999 },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("persists a self-edited role change for the given agent membership", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/person/${editorPerson.id}`,
+      cookies: { [accessCookieName]: editorCookie },
+      payload: {
+        firstName: "TestUpdated",
+        role: AgentRoleType.PROJECT_COORDINATOR,
+        agentId: agent.id,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data.firstName).toBe("TestUpdated");
+
+    const membership = await fastify.db.agentPersonRepository.findOneByOrFail({
+      personId: editorPerson.id,
+      agentId: agent.id,
+    });
+    expect(membership.role).toBe(AgentRoleType.PROJECT_COORDINATOR);
+
+    // Survives reload: re-fetching the same row reflects the persisted
+    // value, matching what Agent.representative (and dtoSerializeAgent)
+    // will read on the next GET.
+    const reloaded = await fastify.db.agentPersonRepository.findOneByOrFail({
+      personId: editorPerson.id,
+      agentId: agent.id,
+    });
+    expect(reloaded.role).toBe(AgentRoleType.PROJECT_COORDINATOR);
+  });
+
+  it("lets an admin edit another person's representative role", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/person/${editorPerson.id}`,
+      cookies: { [accessCookieName]: adminCookie },
+      payload: { role: AgentRoleType.SOCIAL_WORKER, agentId: agent.id },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const membership = await fastify.db.agentPersonRepository.findOneByOrFail({
+      personId: editorPerson.id,
+      agentId: agent.id,
+    });
+    expect(membership.role).toBe(AgentRoleType.SOCIAL_WORKER);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.125:
-  version "0.0.125"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.125.tgz#adee2cbc342da82c1f6dedfeebafac2502648d46"
-  integrity sha512-g/7Bwk1zqcyLZYvmgnACeXhuem5TGfDcwexzQVsaxR2HfXQW3zcJ3NHFaKqaKT9p4hOoRqkJR1vtaFOvFOAgfg==
+need4deed-sdk@0.0.126:
+  version "0.0.126"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.126.tgz#ac87a095bfa7594bc30d58839e10a28abfcedaab"
+  integrity sha512-PqjFTdu5Mo2fuNA4GabjycYOR335fG0pWnm2y+9qQ4PW412oPL220bkCgpsfe645NqQHtFFMKs9aBM4nTO1l6A==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

Fixes #767, unblocked by need4deed-org/sdk#158.

`PATCH /person/:id` silently dropped `role` because `dtoParsePerson` only ever handled `Person` columns, and role lives on `AgentPerson` (`agent_person`), not `person`. This wires up the newly-published `ApiRepresentativePatch` contract (`need4deed-sdk@0.0.126`) to actually persist it.

- `Body` type changed from `ApiPersonPatch` to `ApiRepresentativePatch` (`ApiPersonPatch & { role?, agentId? }`). When `role` is present, the handler resolves the matching `AgentPerson` row via `personId` + `agentId` and updates its role.
- `agentId` is required alongside `role` — a person can belong to more than one agent, so the target row can't be inferred from `personId` alone (this was flagged in #767's own analysis).
- `getAgentPersonRepresentative` gained an optional `agentId` parameter (backward compatible — existing personId-only callers in `user.ts`/`post.routes.ts` are unaffected) and is reused here rather than writing a new lookup.
- No changes to the GET/serialize side: `Agent.representative` (the getter already used by `dtoSerializeAgent`) reads from the same `AgentPerson` row this PATCH updates, so the new role value round-trips correctly on the next agent fetch without any DTO changes.

### Also fixed, found while implementing

- **`PATCH /person/:id` had no authentication guard at all** — not `onRequest`, not even an in-handler check. Any request, authenticated or not, could update any person's profile by ID. Added the same self-or-ADMIN authorization `GET /:id` already uses (via the modern `request.authUser` idiom rather than `GET /:id`'s legacy re-query), since this PR adds a more sensitive capability (agent role mutation) on top of this handler and shipping that onto a wide-open endpoint would have made the existing hole worse.
- **A role-only patch body crashed.** `updatePerson` unconditionally calls `personRepository.save()`; when a request contains only `role`/`agentId` (a legitimate case — "just update my role, don't touch my profile"), every `Person` column ends up unchanged and TypeORM throws `UpdateValuesMissingError` on an empty `UPDATE` SET clause. Now the person-field update is skipped entirely when the body carries no actual person fields.

## Test plan

- [x] New test file `src/test/server/routes/person.routes.test.ts` (no prior route-level test existed for this file) — covers: unauthenticated → 401, non-self/non-admin → 403, role without agentId → 400, unknown agentId → 404, self-edit persists role + survives reload (re-read from DB), admin can edit another person's role.
- [x] `yarn typecheck` passes
- [x] `yarn lint` clean on all changed/added files
- [x] Full suite: 433/433 passing (`docker compose exec be yarn test:run`)

## Not in scope for this PR

- Whether `role` should also be directly exposed on `ApiPersonGet`/`dtoSerializePerson` — not needed, since the existing agent-GET path already reads the updated value from the same row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)