### PR TITLE
fix: self-heal genesis migration tracking on dump-bootstrapped databases

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -17,12 +17,30 @@ export const check = {
   },
 };
 
+const GENESIS_NAME = "GenesisBaseSchema1763036250000";
+// Postgres error codes genesis's own DDL guards can fail to catch when its
+// objects already exist: duplicate_object, duplicate_table, and
+// invalid_table_definition (the "table already has a primary key" case).
+// See genesis-base-schema.ts's own comment on the PK guard for the same class
+// of gotcha — the UNIQUE constraint block never got the equivalent guard.
+const ALREADY_EXISTS_CODES = new Set(["42710", "42P07", "42P16"]);
+
 // On a fresh database the migrations table is empty, so TypeORM would try to
 // run all 74 migrations in sequence — but migrations 1-73 conflict with the
 // schema that genesis already created (duplicate enums/tables).
 // This function runs genesis directly and marks all 74 migrations as done
 // BEFORE TypeORM reads the migrations table, so TypeORM sees 0 pending and
-// skips everything. On an existing database (cnt > 0) it is a no-op.
+// skips everything.
+//
+// The same gap also shows up on databases bootstrapped from a raw schema
+// dump/snapshot: migrations 2-N get recorded (by whatever seeded the dump)
+// but genesis's own row never does, since that bookkeeping is normally
+// TypeORM's job after genesis.up() returns. Replaying genesis.up() against a
+// dump that already has its objects hits exactly the guard gaps above. If
+// genesis.up() fails with one of those specific "already exists" codes, we
+// treat that as proof the schema is already there and just backfill genesis's
+// own tracking row instead of re-attempting its DDL — this is the same fix
+// applied manually to the pre/production incidents this covers.
 async function bootstrapFreshDb(): Promise<void> {
   const qr = dataSource.createQueryRunner();
   try {
@@ -34,26 +52,40 @@ async function bootstrapFreshDb(): Promise<void> {
         PRIMARY KEY (id)
       )
     `);
-    const [{ cnt }] = await qr.query(
-      `SELECT COUNT(*)::int AS cnt FROM public.be_migrations`,
+    const [{ tracked }] = await qr.query(
+      `SELECT EXISTS (SELECT 1 FROM public.be_migrations WHERE name = $1) AS tracked`,
+      [GENESIS_NAME],
     );
-    if (cnt > 0) {return;}
+    if (tracked) {
+      return;
+    }
 
-    logger.info("Fresh database detected — running genesis bootstrap");
+    logger.info("Genesis migration untracked — running genesis bootstrap");
     await qr.startTransaction();
     try {
       const genesis = new GenesisBaseSchema1763036250000();
       await genesis.up(qr);
       await qr.query(
-        `INSERT INTO public.be_migrations (timestamp, name)
-         VALUES (1763036250000, 'GenesisBaseSchema1763036250000')`,
+        `INSERT INTO public.be_migrations (timestamp, name) VALUES (1763036250000, $1)`,
+        [GENESIS_NAME],
       );
       await qr.commitTransaction();
+      logger.info("Genesis bootstrap completed — all migrations pre-marked");
     } catch (e) {
       await qr.rollbackTransaction();
-      throw e;
+      if (!ALREADY_EXISTS_CODES.has(e.code)) {
+        throw e;
+      }
+
+      logger.info(
+        "Genesis DDL hit pre-existing objects (dump-bootstrapped schema) — backfilling genesis tracking row only",
+      );
+      await qr.query(
+        `INSERT INTO public.be_migrations (timestamp, name) VALUES (1763036250000, $1)`,
+        [GENESIS_NAME],
+      );
+      logger.info("Genesis tracking row backfilled");
     }
-    logger.info("Genesis bootstrap completed — all migrations pre-marked");
   } finally {
     await qr.release();
   }


### PR DESCRIPTION
## Summary
- `bootstrapFreshDb()` (added in #aadd3aaa) only handled a truly empty `be_migrations` table. On a database restored from a schema dump — `pre`'s snapshot restore, and historically production too — migrations 2-N get recorded, but genesis's own bookkeeping row never does, since that's normally written by TypeORM's executor only after `genesis.up()` returns successfully.
- Every subsequent startup then tried to replay `genesis.up()` against a schema that already has its objects, crashing on whichever DDL statement genesis's own idempotency guards don't cover. This is exactly what took down `pre` (a `UNIQUE` constraint hit `duplicate_table`, uncaught by `EXCEPTION WHEN duplicate_object`) and production (a `PRIMARY KEY` add hit `invalid_table_definition`) — two different environments, two different guard gaps, same root cause. Both required a manual one-row `be_migrations` backfill to resolve.
- This PR makes that self-healing automatic: detect specifically whether genesis is tracked (not just whether the table is empty), and if `genesis.up()` fails with one of the Postgres error codes that mean "this object already exists" (`42710` duplicate_object, `42P07` duplicate_table, `42P16` invalid_table_definition), treat that as proof of a dump-bootstrapped schema and backfill just genesis's tracking row instead of surfacing the crash.

## Test plan
- [x] `yarn typecheck` and `npx eslint src/data/index.ts` clean.
- [x] Reproduced the `pre` incident locally: fully HEAD-migrated DB, `DELETE FROM be_migrations WHERE name LIKE '%Genesis%'`, then ran `initDatabase()` directly — confirmed it hits the exact `UQ_a28a1682ea80f10d1ecc7babaa0 already exists` error, catches it via the new code path, backfills the tracking row, and completes successfully (`No migrations are pending` / `Database initialization completed`).
- [x] Full test suite (`yarn test:run` via the docker network): 50/50 files, 433/433 tests passing.
- [x] Applied the same manual backfill directly to `pre` and production as an immediate fix; this PR is the durable, self-healing version of that fix for any future dump-bootstrapped environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)