### PR TITLE
fix: unmask an agent's own address for that agent's own caller

### DIFF
--- a/src/server/utils/pii/mask.ts
+++ b/src/server/utils/pii/mask.ts
@@ -2,6 +2,7 @@ import { EntityTableName, UserRole } from "need4deed-sdk";
 import Comment from "../../../data/entity/comment.entity";
 import Address from "../../../data/entity/location/address.entity";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
+import Agent from "../../../data/entity/opportunity/agent.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
 import { CallerVisibility } from "./visible-persons";
@@ -80,9 +81,10 @@ function isCommentVisible(comment: Comment, ctx: CallerVisibility): boolean {
  * (the walker still descends them to reach nested PII). A WeakSet guards the
  * entity graph's cycles.
  *
- * Masked: a Person not in `personIds` (and its own Address); a standalone
- * Address (e.g. agent.address); an Opportunity's accompanying when the
- * opportunity isn't visible; a Comment that isn't visible (see isCommentVisible).
+ * Masked: a Person not in `personIds` (and its own Address); an Agent not in
+ * `agentIds` (and its own Address); a standalone Address reached some other
+ * way; an Opportunity's accompanying when the opportunity isn't visible; a
+ * Comment that isn't visible (see isCommentVisible).
  */
 export function maskPii<T>(data: T, ctx: CallerVisibility): T {
   walk(data, ctx, new WeakSet<object>());
@@ -125,8 +127,16 @@ function walk(
       }
       seen.add(node.address);
     }
+  } else if (node instanceof Agent) {
+    const isVisible = ctx.agentIds.has(node.id);
+    // Claim the agent's own Address so the standalone-Address rule below
+    // can't re-mask it when the caller has visibility into this agent.
+    if (isVisible && node.address && typeof node.address === "object") {
+      seen.add(node.address);
+    }
   } else if (node instanceof Address) {
-    // Reached not via a Person (e.g. agent.address) -> standalone PII, mask it.
+    // Reached not via a visible Person/Agent (e.g. another agent's address)
+    // -> standalone PII, mask it.
     maskFields(node as unknown as Record<string, unknown>, ADDRESS_PII_FIELDS);
   } else if (node instanceof Opportunity) {
     // Accompanying (refugee contact) follows its opportunity's visibility.

--- a/src/test/server/utils/pii/mask.test.ts
+++ b/src/test/server/utils/pii/mask.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import Comment from "../../../../data/entity/comment.entity";
 import Address from "../../../../data/entity/location/address.entity";
 import Accompanying from "../../../../data/entity/opportunity/accompanying.entity";
+import Agent from "../../../../data/entity/opportunity/agent.entity";
 import Opportunity from "../../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../../data/entity/person.entity";
 import { maskPii, maskString } from "../../../../server/utils/pii/mask";
@@ -89,7 +90,7 @@ describe("maskPii", () => {
     expect(visible.address.street).toBe("Side 2");
   });
 
-  it("masks a standalone Address (not under a Person) and leaves non-PII fields", () => {
+  it("masks a standalone Address (not under a Person/Agent) and leaves non-PII fields", () => {
     const agentLike = {
       id: 5,
       title: "Center",
@@ -98,6 +99,27 @@ describe("maskPii", () => {
     maskPii(agentLike, ctx({ personIds: [1] }));
     expect(agentLike.address.street).toMatch(MASKED);
     expect(agentLike.title).toBe("Center");
+  });
+
+  it("masks an Agent's address when the caller has no visibility into that agent", () => {
+    const agent = Object.assign(new Agent(), {
+      id: 5,
+      title: "Center",
+      address: makeAddress("Haupt 3"),
+    });
+    maskPii(agent, ctx({ agentIds: [1] }));
+    expect(agent.address.street).toMatch(MASKED);
+    expect(agent.title).toBe("Center");
+  });
+
+  it("leaves an Agent's own address unmasked when the caller has visibility into that agent", () => {
+    const agent = Object.assign(new Agent(), {
+      id: 5,
+      title: "Center",
+      address: makeAddress("Haupt 3"),
+    });
+    maskPii(agent, ctx({ agentIds: [5] }));
+    expect(agent.address.street).toBe("Haupt 3");
   });
 
   it("leaves reference-like objects untouched and recurses to nested PII", () => {


### PR DESCRIPTION
## Summary

- The `maskPii` walker's `Person` branch checks visibility before masking, but the standalone `Address` branch masked unconditionally with no visibility check — and there was no `Agent` branch, so `agent.address` was always reached and masked as a plain standalone `Address`, even when the caller was viewing their own agent profile.
- Added an `Agent` branch to the walker, mirroring the `Person` branch: if `ctx.agentIds.has(node.id)`, the agent's own address is claimed via the `seen` set so the standalone-`Address` fallback doesn't re-mask it. Agents the caller has no visibility into still fall through to the standalone-`Address` branch and get masked as before.

Fixes #752

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn eslint src/server/utils/pii/mask.ts src/test/server/utils/pii/mask.test.ts` — clean
- [x] `yarn test:run -- src/test/server/utils/pii/mask.test.ts` — 18/18 passing (16 existing + 2 new: agent's own address unmasked when `agentIds` contains it, masked otherwise)
- [x] Full suite: 424 passed; the only 3 failures are pre-existing DB-connectivity failures (no reachable local Postgres in this environment), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)