### PR TITLE
fix: resolve dashboard opportunity-create activities/skills/languages by id

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.126",
+    "need4deed-sdk": "0.0.127",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -32,7 +32,7 @@ import {
   parseOpportunity,
   parseOpportunityLegacy,
 } from "../../../services";
-import { dealParserOpportunity } from "../../../services/dto/parser-deal-opportunity";
+import { dealParserOpportunityCreate } from "../../../services/dto/parser-deal-opportunity-create";
 import {
   idParamSchema,
   opportunityCreateBodySchema,
@@ -367,12 +367,14 @@ export default async function opportunityRoutes(
         }
       }
 
-      // The form is legacy-shaped minus the rac_* fields; the legacy parsers
-      // accept it. deal.postcode comes from the owning agent's address.
-      const legacyBody = body as OpportunityLegacyFormData;
+      // Only parseOpportunityLegacy/accompanyingParserOpportunity read the
+      // legacy-shaped fields (title, accomp_*, etc.), which this form still
+      // carries; the deal itself is resolved by numeric option id below
+      // (dealParserOpportunityCreate), not through the legacy title lookup.
+      const legacyBody = body as unknown as OpportunityLegacyFormData;
       const opportunity = await parseOpportunityLegacy(legacyBody);
-      opportunity.deal = await dealParserOpportunity(
-        legacyBody,
+      opportunity.deal = await dealParserOpportunityCreate(
+        body,
         agent.address?.postcode?.value,
       );
       opportunity.accompanying =

--- a/src/server/schema/opportunity-create.schema.ts
+++ b/src/server/schema/opportunity-create.schema.ts
@@ -1,9 +1,11 @@
 import { responseErrors } from "./responseErrors";
 
 // Body for POST /opportunity (SDK OpportunityFormDataWithAgentSubmitter): the
-// legacy opportunity form minus the rac_* fields, plus agent_id + the optional
-// submitted_by_id. The form is loosely typed (voidable), so additional
-// properties are allowed; agent_id presence is enforced in the handler.
+// dashboard's typed create-opportunity form. Unlike /opportunity/legacy,
+// activities/skills/languages/districts are numeric option ids (from
+// GET /option/*), not title/ISO-code strings. The form is loosely typed
+// (voidable), so additional properties are allowed; agent_id presence is
+// enforced in the handler.
 export const opportunityCreateBodySchema = {
   type: "object",
   additionalProperties: true,
@@ -19,10 +21,10 @@ export const opportunityCreateBodySchema = {
     vo_information: { type: "string" },
     category: { type: "string" },
     category_id: { type: ["integer", "string"] },
-    languages: { type: "array", items: { type: "string" } },
-    activities: { type: "array", items: { type: "string" } },
-    skills: { type: "array", items: { type: "string" } },
-    berlin_locations: { type: "array", items: { type: "string" } },
+    languageIds: { type: "array", items: { type: "integer" } },
+    activityIds: { type: "array", items: { type: "integer" } },
+    skillIds: { type: "array", items: { type: "integer" } },
+    districtIds: { type: "array", items: { type: "integer" } },
     timeslots: { type: ["array", "null"] },
     onetime_date_time: { type: "string" },
     accomp_address: { type: "string" },

--- a/src/services/dto/build-deal-timeslots.ts
+++ b/src/services/dto/build-deal-timeslots.ts
@@ -1,0 +1,57 @@
+import { OccasionalType } from "need4deed-sdk";
+import { dataSource } from "../../data/data-source";
+import DealTimeslot from "../../data/entity/m2m/deal-timeslot";
+import Timeslot from "../../data/entity/time/timeslot.entity";
+import { getRepository, getRRULE, getStartEnd } from "../../data/utils";
+import logger from "../../logger";
+import { getTimeslot } from "../../server/utils";
+
+const WEEKDAYS = [
+  "",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
+// Shared by dealParserOpportunity (legacy) and dealParserOpportunityCreate
+// (dashboard): timeslot resolution doesn't depend on the title-vs-id split
+// between those two forms, so both use it as-is.
+export async function buildDealTimeslots(
+  timeslots: [number, string][] | undefined | null,
+  onetimeDateTime: string | undefined | null,
+): Promise<DealTimeslot[]> {
+  const dealTimeslot: DealTimeslot[] = [];
+
+  for (const opportunityTime of timeslots || []) {
+    const [day, daytime] = opportunityTime;
+    let timeframe: { start?: Date; end?: Date } = { start: null, end: null };
+    let rrule: string = null;
+    let occasional: OccasionalType = null;
+    if (day) {
+      timeframe = getStartEnd(daytime as string);
+      rrule = getRRULE(WEEKDAYS[Number(day)]);
+    } else {
+      occasional = daytime.toLowerCase() as OccasionalType;
+    }
+    const timeslot = await getTimeslot({ rrule, ...timeframe, occasional });
+    dealTimeslot.push(new DealTimeslot({ timeslot }));
+  }
+
+  if (onetimeDateTime) {
+    const timeslotRepository = getRepository(dataSource, Timeslot);
+    const start = new Date(onetimeDateTime);
+    const info = `One-time event on ${onetimeDateTime}`;
+    const timeslot = await getTimeslot({ start, info });
+
+    await timeslotRepository.save(timeslot); // TODO: check if id is undefined before saving
+    logger.debug(`Created one-time timeslot: ${JSON.stringify(timeslot)}`);
+
+    dealTimeslot.push(new DealTimeslot({ timeslot }));
+  }
+
+  return dealTimeslot;
+}

--- a/src/services/dto/parser-deal-opportunity-create.ts
+++ b/src/services/dto/parser-deal-opportunity-create.ts
@@ -1,0 +1,107 @@
+import {
+  LangPurpose,
+  OpportunityFormDataWithAgentSubmitter,
+} from "need4deed-sdk";
+import { In } from "typeorm";
+import { dataSource } from "../../data/data-source";
+import Deal from "../../data/entity/deal.entity";
+import District from "../../data/entity/location/district.entity";
+import DealActivity from "../../data/entity/m2m/deal-activity";
+import DealDistrict from "../../data/entity/m2m/deal-district";
+import DealLanguage from "../../data/entity/m2m/deal-language";
+import DealSkill from "../../data/entity/m2m/deal-skill";
+import Activity from "../../data/entity/profile/activity.entity";
+import Language from "../../data/entity/profile/language.entity";
+import Skill from "../../data/entity/profile/skill.entity";
+import { DealType } from "../../data/types";
+import { getPostcode, getRepository } from "../../data/utils";
+import { buildDealTimeslots } from "./build-deal-timeslots";
+
+// Numeric ids from GET /option/* only — de-duped, non-positive/NaN entries
+// dropped (a stray bad id shouldn't 500 the whole create).
+function toIds(ids: number[] | undefined | null): number[] {
+  return [...new Set((ids || []).map(Number))].filter(
+    (id) => Number.isFinite(id) && id > 0,
+  );
+}
+
+async function resolveByIds<
+  E extends new () => { id: number },
+  M extends object,
+>(
+  ids: number[] | undefined | null,
+  entity: E,
+  m2mEntity: new (_args: unknown) => M,
+  key: keyof M,
+): Promise<M[]> {
+  const uniqueIds = toIds(ids);
+  if (!uniqueIds.length) {
+    return [];
+  }
+
+  const repository = getRepository(dataSource, entity);
+  const instances = await repository.findBy({ id: In(uniqueIds) });
+
+  return instances.map((instance) => new m2mEntity({ [key]: instance }));
+}
+
+// Deal parser for POST /opportunity (the dashboard create form). Unlike
+// dealParserOpportunity (POST /opportunity/legacy), which resolves free-text/
+// ISO-code strings by title lookup, this form is a typed SPA form backed by
+// GET /option/activity|skill|language — activities/skills/languages/districts
+// arrive as numeric option ids, so they're resolved by id instead.
+export async function dealParserOpportunityCreate(
+  formData: OpportunityFormDataWithAgentSubmitter,
+  postcodeValue: string,
+): Promise<Deal> {
+  const postcode = postcodeValue ? await getPostcode(postcodeValue) : null;
+
+  const dealActivity = await resolveByIds(
+    formData.activityIds,
+    Activity,
+    DealActivity,
+    "activity",
+  );
+
+  const dealSkill = await resolveByIds(
+    formData.skillIds,
+    Skill,
+    DealSkill,
+    "skill",
+  );
+
+  const languageIds = toIds(formData.languageIds);
+  let dealLanguage: DealLanguage[] = [];
+  if (languageIds.length) {
+    const languageRepository = getRepository(dataSource, Language);
+    const languages = await languageRepository.findBy({ id: In(languageIds) });
+    dealLanguage = languages.map(
+      (language) =>
+        new DealLanguage({ language, purpose: LangPurpose.RECIPIENT }),
+    );
+  }
+
+  const dealDistrict = await resolveByIds(
+    formData.districtIds,
+    District,
+    DealDistrict,
+    "district",
+  );
+
+  const dealTimeslot = await buildDealTimeslots(
+    formData.timeslots,
+    formData.onetime_date_time,
+  );
+
+  const deal = new Deal({
+    type: DealType.VOLUNTEER,
+    dealActivity,
+    dealSkill,
+    dealLanguage,
+    dealTimeslot,
+    dealDistrict,
+    postcode,
+  });
+
+  return deal;
+}

--- a/src/services/dto/parser-deal-opportunity.ts
+++ b/src/services/dto/parser-deal-opportunity.ts
@@ -2,34 +2,21 @@ import {
   ApiLanguage,
   EntityTableName,
   LangPurpose,
-  OccasionalType,
   OpportunityLegacyFormData,
 } from "need4deed-sdk";
-import { dataSource } from "../../data/data-source";
 import Deal from "../../data/entity/deal.entity";
 import District from "../../data/entity/location/district.entity";
 import DealActivity from "../../data/entity/m2m/deal-activity";
 import DealDistrict from "../../data/entity/m2m/deal-district";
 import DealLanguage from "../../data/entity/m2m/deal-language";
 import DealSkill from "../../data/entity/m2m/deal-skill";
-import DealTimeslot from "../../data/entity/m2m/deal-timeslot";
 import Activity from "../../data/entity/profile/activity.entity";
 import Language from "../../data/entity/profile/language.entity";
 import Skill from "../../data/entity/profile/skill.entity";
-import Timeslot from "../../data/entity/time/timeslot.entity";
 import { DealType } from "../../data/types";
-import {
-  getPostcode,
-  getRepository,
-  getRRULE,
-  getStartEnd,
-} from "../../data/utils";
-import logger from "../../logger";
-import {
-  getLanguageTitle,
-  getProfileEntityByTitle,
-  getTimeslot,
-} from "../../server/utils";
+import { getPostcode } from "../../data/utils";
+import { getLanguageTitle, getProfileEntityByTitle } from "../../server/utils";
+import { buildDealTimeslots } from "./build-deal-timeslots";
 
 export async function dealParserOpportunity(
   formData: OpportunityLegacyFormData,
@@ -98,49 +85,10 @@ export async function dealParserOpportunity(
   }
 
   // time
-  const dealTimeslot: DealTimeslot[] = [];
-  const opportunityTimes = formData.timeslots || [];
-  for (const opportunityTime of opportunityTimes) {
-    const [day, daytime] = opportunityTime;
-    let timeframe: { start?: Date; end?: Date } = { start: null, end: null };
-    let rrule: string = null;
-    let occasional: OccasionalType = null;
-    if (day) {
-      timeframe = getStartEnd(daytime as string);
-      const mapDay = [
-        "",
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-        "Sunday",
-      ] as const;
-      rrule = getRRULE(mapDay[Number(day)]);
-    } else {
-      occasional = daytime.toLowerCase() as OccasionalType;
-    }
-    const timeslot = await getTimeslot({ rrule, ...timeframe, occasional });
-    const dealTimeslotEntry = new DealTimeslot({ timeslot });
-    dealTimeslot.push(dealTimeslotEntry);
-  }
-
-  if (formData.onetime_date_time) {
-    const timeslotRepository = getRepository(dataSource, Timeslot);
-    const start = new Date(formData.onetime_date_time);
-    const info = `One-time event on ${formData.onetime_date_time}`;
-    const timeslot = await getTimeslot({
-      start,
-      info,
-    });
-
-    await timeslotRepository.save(timeslot); // TODO: check if id is undefined before saving
-    logger.debug(`Created one-time timeslot: ${JSON.stringify(timeslot)}`);
-
-    const dealTimeslotEntry = new DealTimeslot({ timeslot });
-    dealTimeslot.push(dealTimeslotEntry);
-  }
+  const dealTimeslot = await buildDealTimeslots(
+    formData.timeslots,
+    formData.onetime_date_time,
+  );
 
   // districts
   const dealDistrict: DealDistrict[] = [];

--- a/src/test/server/routes/opportunity-create.routes.test.ts
+++ b/src/test/server/routes/opportunity-create.routes.test.ts
@@ -1,0 +1,154 @@
+import { FastifyInstance } from "fastify";
+import { OpportunityLegacyType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import { dataSource } from "../../../data/data-source";
+import Address from "../../../data/entity/location/address.entity";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import Person from "../../../data/entity/person.entity";
+import Activity from "../../../data/entity/profile/activity.entity";
+import Language from "../../../data/entity/profile/language.entity";
+import Skill from "../../../data/entity/profile/skill.entity";
+import User from "../../../data/entity/user.entity";
+import { getRepository, hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+// Regression test for be#774: POST /opportunity (dashboard create) resolves
+// activities/skills/languages by numeric option id, unlike POST
+// /opportunity/legacy which resolves free-text/ISO-code strings by title.
+describe("POST /opportunity resolves activities/skills/languages by id", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let agent: Agent;
+  let addressId: number;
+  let activity: Activity;
+  let skill: Skill;
+  let language: Language;
+  let createdOpportunityId: number;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const addressRepository = getRepository(dataSource, Address);
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+    const address = await addressRepository.save(
+      new Address({ postcodeId: postcode.id }),
+    );
+    addressId = address.id;
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent ${suffix}`, addressId: address.id }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(res.cookies, accessCookieName);
+
+    activity = await getRepository(dataSource, Activity).save(
+      new Activity({ title: `Test Activity ${suffix}` }),
+    );
+    skill = await getRepository(dataSource, Skill).save(
+      new Skill({ title: `Test Skill ${suffix}` }),
+    );
+    language = await getRepository(dataSource, Language).save(
+      new Language({ isoCode: "xx", title: `Test Language ${suffix}` }),
+    );
+  });
+
+  afterAll(async () => {
+    if (createdOpportunityId) {
+      await fastify.db.opportunityRepository.delete({
+        id: createdOpportunityId,
+      });
+    }
+    await getRepository(dataSource, Activity).delete({ id: activity.id });
+    await getRepository(dataSource, Skill).delete({ id: skill.id });
+    await getRepository(dataSource, Language).delete({ id: language.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await getRepository(dataSource, Address).delete({ id: addressId });
+    await fastify.close();
+  });
+
+  it("saves the deal's activities/skills/languages given numeric option ids", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/opportunity/",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        title: `Test Opportunity ${suffix}`,
+        opportunity_type: OpportunityLegacyType.VOLUNTEERING,
+        volunteers_number: 1,
+        category: "",
+        category_id: "",
+        language: "en",
+        agent_id: agent.id,
+        activityIds: [activity.id],
+        skillIds: [skill.id],
+        languageIds: [language.id],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    createdOpportunityId = res.json().data.id;
+
+    const opportunityRepository = getRepository(dataSource, Opportunity);
+    const saved = await opportunityRepository.findOneOrFail({
+      where: { id: createdOpportunityId },
+      relations: [
+        "deal.dealActivity.activity",
+        "deal.dealSkill.skill",
+        "deal.dealLanguage.language",
+      ],
+    });
+
+    expect(saved.deal.dealActivity.map((da) => da.activity.id)).toEqual([
+      activity.id,
+    ]);
+    expect(saved.deal.dealSkill.map((ds) => ds.skill.id)).toEqual([skill.id]);
+    expect(saved.deal.dealLanguage.map((dl) => dl.language.id)).toEqual([
+      language.id,
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.126:
-  version "0.0.126"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.126.tgz#ac87a095bfa7594bc30d58839e10a28abfcedaab"
-  integrity sha512-PqjFTdu5Mo2fuNA4GabjycYOR335fG0pWnm2y+9qQ4PW412oPL220bkCgpsfe645NqQHtFFMKs9aBM4nTO1l6A==
+need4deed-sdk@0.0.127:
+  version "0.0.127"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.127.tgz#44f98dbfee3d1ecb660b4d638b30d6d7a9f552b9"
+  integrity sha512-jnK2I3Q90d2EBAF/3H/zVELxXnYVYr5iOhw17fOOMm10qKsfeCx44Xz/4L0C+ztL5STTyj830cPWQ9Afz9H9qQ==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
- `POST /opportunity/` (dashboard create form) reused `dealParserOpportunity`, the parser built for `POST /opportunity/legacy`, which resolves activities/skills by title text and languages by ISO code.
- The dashboard's typed create form actually sends numeric option ids (from `GET /option/activity|skill|language`), so every lookup silently returned nothing — created opportunities ended up with **zero** saved activities, skills, and languages (including the accompanying refugee language). Fixes #774.
- `need4deed-sdk@0.0.127` gives `POST /opportunity/` its own id-based contract (`languageIds`/`activityIds`/`skillIds`/`districtIds: number[]`), replacing the `string[]` fields it previously inherited from the legacy form's type.
- Added `dealParserOpportunityCreate`, which resolves those ids directly via `findBy({ id: In(ids) })`. `dealParserOpportunity` / `getProfileEntityByTitle` / `getLanguageTitle` and `POST /opportunity/legacy` are untouched.
- Extracted the timeslot-building logic (shared by both forms, unaffected by this bug) into `buildDealTimeslots` so it isn't duplicated between the two parsers.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (no new errors/warnings vs. base)
- [x] `yarn test:run` — 436/436 passing, including new `opportunity-create.routes.test.ts` covering activities/skills/languages resolved by id end-to-end through the real route + DB
- [x] Manually confirmed `/opportunity/legacy` code paths (title/ISO-code parsers) are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)