### PR TITLE
fix: opportunities created from the dashboard never save activities/skills/languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.126",
+    "need4deed-sdk": "0.0.127",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -32,7 +32,7 @@ import {
   parseOpportunity,
   parseOpportunityLegacy,
 } from "../../../services";
-import { dealParserOpportunity } from "../../../services/dto/parser-deal-opportunity";
+import { dealParserOpportunityCreate } from "../../../services/dto/parser-deal-opportunity-create";
 import {
   idParamSchema,
   opportunityCreateBodySchema,
@@ -367,12 +367,18 @@ export default async function opportunityRoutes(
         }
       }
 
-      // The form is legacy-shaped minus the rac_* fields; the legacy parsers
-      // accept it. deal.postcode comes from the owning agent's address.
-      const legacyBody = body as OpportunityLegacyFormData;
+      // title/opportunity_type/volunteers_number/accomp_* are shared with the
+      // legacy shape, so parseOpportunityLegacy/accompanyingParserOpportunity
+      // (which never touch activities/skills/languages) can still take the
+      // body via this cast — the two SDK types otherwise no longer overlap
+      // enough for a direct cast (activities/skills/languages/districts are
+      // ids here, titles/ISO-codes there), hence the `unknown` hop. The deal
+      // (activities/skills/languages) is resolved separately below, by id —
+      // see dealParserOpportunityCreate.
+      const legacyBody = body as unknown as OpportunityLegacyFormData;
       const opportunity = await parseOpportunityLegacy(legacyBody);
-      opportunity.deal = await dealParserOpportunity(
-        legacyBody,
+      opportunity.deal = await dealParserOpportunityCreate(
+        body,
         agent.address?.postcode?.value,
       );
       opportunity.accompanying =

--- a/src/server/schema/opportunity-create.schema.ts
+++ b/src/server/schema/opportunity-create.schema.ts
@@ -1,9 +1,12 @@
 import { responseErrors } from "./responseErrors";
 
 // Body for POST /opportunity (SDK OpportunityFormDataWithAgentSubmitter): the
-// legacy opportunity form minus the rac_* fields, plus agent_id + the optional
-// submitted_by_id. The form is loosely typed (voidable), so additional
-// properties are allowed; agent_id presence is enforced in the handler.
+// dashboard's typed create-opportunity form, plus agent_id + the optional
+// submitted_by_id. Unlike the legacy opportunity form, activities/skills/
+// languages/districts are numeric option ids from GET /option/*, not
+// free-text titles/ISO-codes — see dealParserOpportunityCreate. The form is
+// loosely typed (voidable), so additional properties are allowed; agent_id
+// presence is enforced in the handler.
 export const opportunityCreateBodySchema = {
   type: "object",
   additionalProperties: true,
@@ -19,10 +22,10 @@ export const opportunityCreateBodySchema = {
     vo_information: { type: "string" },
     category: { type: "string" },
     category_id: { type: ["integer", "string"] },
-    languages: { type: "array", items: { type: "string" } },
-    activities: { type: "array", items: { type: "string" } },
-    skills: { type: "array", items: { type: "string" } },
-    berlin_locations: { type: "array", items: { type: "string" } },
+    languageIds: { type: "array", items: { type: "integer" } },
+    activityIds: { type: "array", items: { type: "integer" } },
+    skillIds: { type: "array", items: { type: "integer" } },
+    districtIds: { type: "array", items: { type: "integer" } },
     timeslots: { type: ["array", "null"] },
     onetime_date_time: { type: "string" },
     accomp_address: { type: "string" },

--- a/src/services/dto/deal-timeslots.ts
+++ b/src/services/dto/deal-timeslots.ts
@@ -1,0 +1,59 @@
+import { OccasionalType } from "need4deed-sdk";
+import { dataSource } from "../../data/data-source";
+import DealTimeslot from "../../data/entity/m2m/deal-timeslot";
+import Timeslot from "../../data/entity/time/timeslot.entity";
+import { getRepository, getRRULE, getStartEnd } from "../../data/utils";
+import logger from "../../logger";
+import { getTimeslot } from "../../server/utils";
+
+// Shared by both dealParserOpportunity (legacy form) and
+// dealParserOpportunityCreate (dashboard form) — the [day, daytime] timeslot
+// tuple and the one-time-event datetime mean the same thing in both shapes.
+export async function buildDealTimeslots(
+  timeslots: [number, string][] | undefined | null,
+  onetimeDateTime: string | undefined | null,
+): Promise<DealTimeslot[]> {
+  const dealTimeslot: DealTimeslot[] = [];
+
+  for (const opportunityTime of timeslots || []) {
+    const [day, daytime] = opportunityTime;
+    let timeframe: { start?: Date; end?: Date } = { start: null, end: null };
+    let rrule: string = null;
+    let occasional: OccasionalType = null;
+    if (day) {
+      timeframe = getStartEnd(daytime as string);
+      const mapDay = [
+        "",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+      ] as const;
+      rrule = getRRULE(mapDay[Number(day)]);
+    } else {
+      occasional = daytime.toLowerCase() as OccasionalType;
+    }
+    const timeslot = await getTimeslot({ rrule, ...timeframe, occasional });
+    dealTimeslot.push(new DealTimeslot({ timeslot }));
+  }
+
+  if (onetimeDateTime) {
+    const timeslotRepository = getRepository(dataSource, Timeslot);
+    const start = new Date(onetimeDateTime);
+    const info = `One-time event on ${onetimeDateTime}`;
+    const timeslot = await getTimeslot({
+      start,
+      info,
+    });
+
+    await timeslotRepository.save(timeslot); // TODO: check if id is undefined before saving
+    logger.debug(`Created one-time timeslot: ${JSON.stringify(timeslot)}`);
+
+    dealTimeslot.push(new DealTimeslot({ timeslot }));
+  }
+
+  return dealTimeslot;
+}

--- a/src/services/dto/parser-deal-opportunity-create.ts
+++ b/src/services/dto/parser-deal-opportunity-create.ts
@@ -1,0 +1,68 @@
+import {
+  LangPurpose,
+  OpportunityFormDataWithAgentSubmitter,
+} from "need4deed-sdk";
+import { In } from "typeorm";
+import { dataSource } from "../../data/data-source";
+import Deal from "../../data/entity/deal.entity";
+import DealActivity from "../../data/entity/m2m/deal-activity";
+import DealLanguage from "../../data/entity/m2m/deal-language";
+import DealSkill from "../../data/entity/m2m/deal-skill";
+import Activity from "../../data/entity/profile/activity.entity";
+import Language from "../../data/entity/profile/language.entity";
+import Skill from "../../data/entity/profile/skill.entity";
+import { DealType } from "../../data/types";
+import { getPostcode, getRepository } from "../../data/utils";
+import { buildDealTimeslots } from "./deal-timeslots";
+
+// Counterpart to dealParserOpportunity(), for POST /opportunity/ (the
+// dashboard's "Create New Opportunity" form) only. That form is a proper
+// typed SPA backed by GET /option/activity|skill|language — it sends numeric
+// option ids, not the free-text titles/ISO-codes the legacy parser expects.
+// Resolving those ids by title (as dealParserOpportunity does) never matches,
+// so activities/skills/languages silently end up empty; resolve by id instead.
+export async function dealParserOpportunityCreate(
+  formData: OpportunityFormDataWithAgentSubmitter,
+  postcodeValue?: string,
+): Promise<Deal> {
+  const postcode = postcodeValue ? await getPostcode(postcodeValue) : null;
+
+  const activityRepository = getRepository(dataSource, Activity);
+  const activities = formData.activityIds?.length
+    ? await activityRepository.findBy({ id: In(formData.activityIds) })
+    : [];
+  const dealActivity = activities.map(
+    (activity) => new DealActivity({ activity }),
+  );
+
+  const skillRepository = getRepository(dataSource, Skill);
+  const skills = formData.skillIds?.length
+    ? await skillRepository.findBy({ id: In(formData.skillIds) })
+    : [];
+  const dealSkill = skills.map((skill) => new DealSkill({ skill }));
+
+  const languageRepository = getRepository(dataSource, Language);
+  const languages = formData.languageIds?.length
+    ? await languageRepository.findBy({ id: In(formData.languageIds) })
+    : [];
+  const dealLanguage = languages.map(
+    (language) =>
+      new DealLanguage({ language, purpose: LangPurpose.RECIPIENT }),
+  );
+
+  const dealTimeslot = await buildDealTimeslots(
+    formData.timeslots,
+    formData.onetime_date_time,
+  );
+
+  const deal = new Deal({
+    type: DealType.VOLUNTEER,
+    dealActivity,
+    dealSkill,
+    dealLanguage,
+    dealTimeslot,
+    postcode,
+  });
+
+  return deal;
+}

--- a/src/services/dto/parser-deal-opportunity.ts
+++ b/src/services/dto/parser-deal-opportunity.ts
@@ -2,34 +2,21 @@ import {
   ApiLanguage,
   EntityTableName,
   LangPurpose,
-  OccasionalType,
   OpportunityLegacyFormData,
 } from "need4deed-sdk";
-import { dataSource } from "../../data/data-source";
 import Deal from "../../data/entity/deal.entity";
 import District from "../../data/entity/location/district.entity";
 import DealActivity from "../../data/entity/m2m/deal-activity";
 import DealDistrict from "../../data/entity/m2m/deal-district";
 import DealLanguage from "../../data/entity/m2m/deal-language";
 import DealSkill from "../../data/entity/m2m/deal-skill";
-import DealTimeslot from "../../data/entity/m2m/deal-timeslot";
 import Activity from "../../data/entity/profile/activity.entity";
 import Language from "../../data/entity/profile/language.entity";
 import Skill from "../../data/entity/profile/skill.entity";
-import Timeslot from "../../data/entity/time/timeslot.entity";
 import { DealType } from "../../data/types";
-import {
-  getPostcode,
-  getRepository,
-  getRRULE,
-  getStartEnd,
-} from "../../data/utils";
-import logger from "../../logger";
-import {
-  getLanguageTitle,
-  getProfileEntityByTitle,
-  getTimeslot,
-} from "../../server/utils";
+import { getPostcode } from "../../data/utils";
+import { getLanguageTitle, getProfileEntityByTitle } from "../../server/utils";
+import { buildDealTimeslots } from "./deal-timeslots";
 
 export async function dealParserOpportunity(
   formData: OpportunityLegacyFormData,
@@ -98,49 +85,10 @@ export async function dealParserOpportunity(
   }
 
   // time
-  const dealTimeslot: DealTimeslot[] = [];
-  const opportunityTimes = formData.timeslots || [];
-  for (const opportunityTime of opportunityTimes) {
-    const [day, daytime] = opportunityTime;
-    let timeframe: { start?: Date; end?: Date } = { start: null, end: null };
-    let rrule: string = null;
-    let occasional: OccasionalType = null;
-    if (day) {
-      timeframe = getStartEnd(daytime as string);
-      const mapDay = [
-        "",
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-        "Sunday",
-      ] as const;
-      rrule = getRRULE(mapDay[Number(day)]);
-    } else {
-      occasional = daytime.toLowerCase() as OccasionalType;
-    }
-    const timeslot = await getTimeslot({ rrule, ...timeframe, occasional });
-    const dealTimeslotEntry = new DealTimeslot({ timeslot });
-    dealTimeslot.push(dealTimeslotEntry);
-  }
-
-  if (formData.onetime_date_time) {
-    const timeslotRepository = getRepository(dataSource, Timeslot);
-    const start = new Date(formData.onetime_date_time);
-    const info = `One-time event on ${formData.onetime_date_time}`;
-    const timeslot = await getTimeslot({
-      start,
-      info,
-    });
-
-    await timeslotRepository.save(timeslot); // TODO: check if id is undefined before saving
-    logger.debug(`Created one-time timeslot: ${JSON.stringify(timeslot)}`);
-
-    const dealTimeslotEntry = new DealTimeslot({ timeslot });
-    dealTimeslot.push(dealTimeslotEntry);
-  }
+  const dealTimeslot = await buildDealTimeslots(
+    formData.timeslots,
+    formData.onetime_date_time,
+  );
 
   // districts
   const dealDistrict: DealDistrict[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.126:
-  version "0.0.126"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.126.tgz#ac87a095bfa7594bc30d58839e10a28abfcedaab"
-  integrity sha512-PqjFTdu5Mo2fuNA4GabjycYOR335fG0pWnm2y+9qQ4PW412oPL220bkCgpsfe645NqQHtFFMKs9aBM4nTO1l6A==
+need4deed-sdk@0.0.127:
+  version "0.0.127"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.127.tgz#44f98dbfee3d1ecb660b4d638b30d6d7a9f552b9"
+  integrity sha512-jnK2I3Q90d2EBAF/3H/zVELxXnYVYr5iOhw17fOOMm10qKsfeCx44Xz/4L0C+ztL5STTyj830cPWQ9Afz9H9qQ==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

Closes #774.

`POST /opportunity/` (the dashboard's "Create New Opportunity" flow) reused `dealParserOpportunity` — the parser built for `POST /opportunity/legacy` — which resolves activities/skills by **title** and languages by **ISO code**. But the dashboard form sends numeric **option ids** (from `GET /option/activity|skill|language`), so every lookup missed and `dealActivity`/`dealSkill`/`dealLanguage` were silently saved empty.

- Bumps `need4deed-sdk` to `0.0.127`, which already defines the dashboard form's own id-based contract (`OpportunityFormDataWithAgentSubmitter` / `OpportunityCreateFormDataProps`: `activityIds`, `skillIds`, `languageIds`, `districtIds`).
- Adds `dealParserOpportunityCreate` (`src/services/dto/parser-deal-opportunity-create.ts`) — resolves those ids directly against their repositories (`In(ids)`), instead of routing through the title/ISO-code lookup path.
- Extracts the timeslot-building logic (identical between the legacy and dashboard form shapes) into a shared `buildDealTimeslots` helper (`src/services/dto/deal-timeslots.ts`), used by both parsers.
- Updates `opportunityCreateBodySchema` to document the real (id-based) field names.
- `dealParserOpportunity`, `getProfileEntityByTitle`, `getLanguageTitle` are untouched — `POST /opportunity/legacy` (the public form) still needs free-text/ISO-code input.

## Test plan

- [x] `yarn typecheck` — passes
- [x] `yarn lint` — no new errors (22 pre-existing errors match the `develop` baseline)
- [x] `yarn test:run` — same result as a clean `develop` checkout (4 test files fail on a pre-existing DB-connection hook timeout in this sandbox, unrelated to this change; 422 tests pass)
- [ ] Manual verification against a running dashboard (create an opportunity with activities/skills/languages selected, confirm they persist on reopen) — not done in this session, recommend before merge

Note: the `fe` dashboard form still needs a follow-up to send `activityIds`/`skillIds`/`languageIds` (it currently sends `activities`/`skills`/`languages` against an older pinned SDK version) — this PR only fixes the `be` side per issue #774's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)