### PR TITLE
fix: use per-migration transactions so fresh DB replay survives

### DIFF
--- a/src/data/data-source.ts
+++ b/src/data/data-source.ts
@@ -58,6 +58,7 @@ export const dataSource = new DataSource({
   schema: process.env.DB_SCHEMA || "public",
   synchronize: false,
   migrationsRun: false,
+  migrationsTransactionMode: "each",
   entities: [
     Accompanying,
     Activity,


### PR DESCRIPTION
## Summary
- Fresh migration replay (empty DB, e.g. CI, a new dev setup, or a rebuilt `pre` environment) was broken: `GenesisBaseSchema1763036250000` marks ~70 older, now-redundant migrations as pre-applied at the end of its `up()` so they get skipped on replay — but the default `migrationsTransactionMode` (`"all"`) wraps the whole pending batch in one transaction, so when a later non-idempotent old migration fails, it rolls back Genesis's commit (and its markers) too, defeating the mechanism entirely.
- Setting `migrationsTransactionMode: "each"` in `src/data/data-source.ts` commits each migration independently. A first `migration:run` still fails on the next old migration, but Genesis's commit and markers now survive; a second `migration:run` sees everything through that cutoff already marked and skips it cleanly.

## Test plan
- [x] `docker compose down -v` to fully wipe the local DB
- [x] `yarn migration:run` (fails as expected on the first old post-Genesis migration, but Genesis + its markers now persist)
- [x] `yarn migration:run` again → `No migrations are pending`
- [x] `yarn seed` to populate reference data
- [x] `yarn test:run` → 52 files / 438 tests passing, run twice to confirm no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)