### PR TITLE
Validate main-communication language is German, German+English, or none

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -33,6 +33,7 @@ import {
   parseOpportunityLegacy,
 } from "../../../services";
 import { dealParserOpportunityCreate } from "../../../services/dto/parser-deal-opportunity-create";
+import { assertValidMainCommunicationLanguages } from "../../../services/dto/parser-opportunity-patch-data";
 import {
   idParamSchema,
   opportunityCreateBodySchema,
@@ -483,6 +484,11 @@ export default async function opportunityRoutes(
       if (!dealId) {
         throw new Error(`Opportunity id:${id} is lacking a deal.`);
       }
+
+      await assertValidMainCommunicationLanguages(
+        request.body.languagesMain,
+        fastify.db.languageRepository,
+      );
 
       const {
         opportunity: opportunityObj,

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -23,6 +23,15 @@ export async function assertValidMainCommunicationLanguages(
   }
   const ids = [...new Set(languagesMain.map(({ id }) => Number(id)))];
   const languages = await languageRepository.findBy({ id: In(ids) });
+  // Any id that didn't resolve to a real row (stale/bogus reference) must be
+  // rejected outright, not silently dropped — otherwise a request like
+  // [germanId, 999999] would validate as "German only" despite containing
+  // an unresolvable language.
+  if (languages.length !== ids.length) {
+    throw new BadRequestError(
+      "Main communication language must be German, German and English, or none.",
+    );
+  }
   const isoCodes = new Set(languages.map((l) => l.isoCode));
 
   const isGermanOnly = isoCodes.size === 1 && isoCodes.has("de");

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -1,13 +1,40 @@
 import { ApiOpportunityPatch, LangPurpose } from "need4deed-sdk";
+import { In, Repository } from "typeorm";
 import { getNameFields } from "..";
 import { BadRequestError } from "../../config";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../data/entity/opportunity/agent.entity";
+import Language from "../../data/entity/profile/language.entity";
 import { DataId } from "../../server/types";
 import { getEmptyPropsNull } from "../../server/utils/common";
 import { getDateObj } from "../utils";
 
 type LanguagePatchItem = { id: number | string; purpose: LangPurpose };
+
+// The org's main communication language is German; volunteers may additionally
+// read English, so the only valid "main communication" sets are: none, German
+// alone, or German+English together — never English alone or any other language.
+export async function assertValidMainCommunicationLanguages(
+  languagesMain: { id: number | string }[] | undefined,
+  languageRepository: Repository<Language>,
+): Promise<void> {
+  if (!languagesMain?.length) {
+    return;
+  }
+  const ids = [...new Set(languagesMain.map(({ id }) => Number(id)))];
+  const languages = await languageRepository.findBy({ id: In(ids) });
+  const isoCodes = new Set(languages.map((l) => l.isoCode));
+
+  const isGermanOnly = isoCodes.size === 1 && isoCodes.has("de");
+  const isGermanAndEnglish =
+    isoCodes.size === 2 && isoCodes.has("de") && isoCodes.has("en");
+
+  if (!isGermanOnly && !isGermanAndEnglish) {
+    throw new BadRequestError(
+      "Main communication language must be German, German and English, or none.",
+    );
+  }
+}
 
 function dedupeLanguages(items: LanguagePatchItem[]): LanguagePatchItem[] {
   const seen = new Set<string>();

--- a/src/test/services/dto/parser-opportunity-patch-data.test.ts
+++ b/src/test/services/dto/parser-opportunity-patch-data.test.ts
@@ -3,9 +3,14 @@ import {
   LangPurpose,
   TranslatedIntoType,
 } from "need4deed-sdk";
-import { describe, expect, it } from "vitest";
+import { Repository } from "typeorm";
+import { describe, expect, it, vi } from "vitest";
 import { BadRequestError } from "../../../config";
-import { parseOpportunity } from "../../../services/dto/parser-opportunity-patch-data";
+import Language from "../../../data/entity/profile/language.entity";
+import {
+  assertValidMainCommunicationLanguages,
+  parseOpportunity,
+} from "../../../services/dto/parser-opportunity-patch-data";
 
 describe("parseOpportunity", () => {
   it("throws BadRequestError when body is falsy", () => {
@@ -131,5 +136,86 @@ describe("parseOpportunity", () => {
     });
 
     expect(result.agent).toBeNull();
+  });
+});
+
+describe("assertValidMainCommunicationLanguages", () => {
+  const findBy = vi.fn();
+  const languageRepository = { findBy } as unknown as Repository<Language>;
+
+  function mockLanguages(rows: { id: number; isoCode: string }[]) {
+    findBy.mockResolvedValueOnce(rows);
+  }
+
+  it("resolves without querying when languagesMain is undefined", async () => {
+    await expect(
+      assertValidMainCommunicationLanguages(undefined, languageRepository),
+    ).resolves.toBeUndefined();
+    expect(findBy).not.toHaveBeenCalled();
+  });
+
+  it("resolves without querying when languagesMain is empty", async () => {
+    await expect(
+      assertValidMainCommunicationLanguages([], languageRepository),
+    ).resolves.toBeUndefined();
+    expect(findBy).not.toHaveBeenCalled();
+  });
+
+  it("resolves when the selection is German only", async () => {
+    mockLanguages([{ id: 1, isoCode: "de" }]);
+    await expect(
+      assertValidMainCommunicationLanguages([{ id: 1 }], languageRepository),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves when the selection is German and English", async () => {
+    mockLanguages([
+      { id: 1, isoCode: "de" },
+      { id: 2, isoCode: "en" },
+    ]);
+    await expect(
+      assertValidMainCommunicationLanguages(
+        [{ id: 1 }, { id: 2 }],
+        languageRepository,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects English alone", async () => {
+    mockLanguages([{ id: 2, isoCode: "en" }]);
+    await expect(
+      assertValidMainCommunicationLanguages([{ id: 2 }], languageRepository),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it("rejects a language other than German/English", async () => {
+    mockLanguages([{ id: 3, isoCode: "fr" }]);
+    await expect(
+      assertValidMainCommunicationLanguages([{ id: 3 }], languageRepository),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it("rejects when one of the ids doesn't resolve to any language row", async () => {
+    // Only 1 of the 2 requested ids came back — the other is stale/bogus and
+    // must not be silently dropped from the check.
+    mockLanguages([{ id: 1, isoCode: "de" }]);
+    await expect(
+      assertValidMainCommunicationLanguages(
+        [{ id: 1 }, { id: 999999 }],
+        languageRepository,
+      ),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it("dedupes repeated/string-vs-number ids before checking resolution", async () => {
+    // If ids weren't deduped first, findBy returning a single row for a
+    // 3-times-repeated id would look like 2 unresolved ids and wrongly reject.
+    mockLanguages([{ id: 1, isoCode: "de" }]);
+    await expect(
+      assertValidMainCommunicationLanguages(
+        [{ id: 1 }, { id: 1 }, { id: "1" }],
+        languageRepository,
+      ),
+    ).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- The `PATCH /opportunity/:id` endpoint accepted any language combination for `languagesMain` (the GENERAL-purpose "main communication" language on a deal), with no server-side check.
- Adds `assertValidMainCommunicationLanguages` in `parser-opportunity-patch-data.ts`, called from the PATCH handler before any writes, resolving the submitted language ids to isoCodes via `languageRepository` and rejecting anything other than: none, German alone, or German+English (throws `BadRequestError`).
- Note: the separate `POST /opportunity` create endpoint doesn't currently preserve a main/residents distinction at all (everything in `languageIds` is flattened and stored as `LangPurpose.RECIPIENT`), so this validation only applies to the edit/patch path where the GENERAL-purpose distinction actually exists.

Pairs with need4deed-org/fe#829, which restricts the same field's dropdown to German/English and adds equivalent client-side validation.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes on changed files
- [ ] Manual/API check: `PATCH /opportunity/:id` with `languagesMain` containing only an English language id now returns 400; German-only and German+English still succeed