### PR TITLE
feat: allow AGENT to update the status of their own opportunity

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -115,7 +115,8 @@ export default async function opportunityRoutes(
   _options: FastifyPluginOptions,
 ) {
   // GETs open to any logged-in user (PII masked per role); writes stay
-  // COORDINATOR-only (re-gated per-route).
+  // COORDINATOR-only (re-gated per-route), except PATCH /:id which also lets
+  // an AGENT update the `statusOpportunity` of their own agent's opportunity.
   fastify.addHook("onRequest", fastify.authenticate());
 
   await fastify.register(opportunityLegacyRoutes, {
@@ -459,7 +460,6 @@ export default async function opportunityRoutes(
   }>(
     "/:id",
     {
-      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiVolunteerOpportunityPatch#" },
@@ -467,6 +467,18 @@ export default async function opportunityRoutes(
       },
     },
     async (request, reply) => {
+      // COORDINATOR/ADMIN may edit the full patch surface; an AGENT may only
+      // flip the status of an opportunity belonging to an agent they're a
+      // member of (checked below, once the opportunity's agentId is known).
+      const role = request.authUser?.role;
+      if (
+        role !== UserRole.COORDINATOR &&
+        role !== UserRole.AGENT &&
+        role !== UserRole.ADMIN
+      ) {
+        throw new UnauthorizedError();
+      }
+
       const id = request.params.id;
 
       const opportunityRepository = fastify.db.opportunityRepository;
@@ -475,6 +487,31 @@ export default async function opportunityRoutes(
       });
       if (!opportunity) {
         throw new NotFoundError(`Opportunity (id:${id}) not found.`);
+      }
+
+      if (role === UserRole.AGENT) {
+        const personId = request.authUser?.personId;
+        const membership = personId
+          ? await fastify.db.agentPersonRepository.findOneBy({
+              agentId: opportunity.agentId,
+              personId,
+            })
+          : null;
+        if (!membership) {
+          throw new UnauthorizedError(
+            "Agents can only update opportunities belonging to their own agent.",
+          );
+        }
+
+        const body = request.body as Record<string, unknown>;
+        const disallowedKeys = Object.keys(body).filter(
+          (key) => key !== "statusOpportunity" && body[key] !== undefined,
+        );
+        if (disallowedKeys.length > 0) {
+          throw new UnauthorizedError(
+            "Agents can only update an opportunity's status.",
+          );
+        }
       }
 
       const dealId = opportunity.dealId;

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -1,0 +1,207 @@
+import { FastifyInstance } from "fastify";
+import {
+  OpportunityStatusType,
+  OpportunityType,
+  UserRole,
+} from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import Deal from "../../../data/entity/deal.entity";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { DealType } from "../../../data/types";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("PATCH /opportunity/:id agent status update", () => {
+  let fastify: FastifyInstance;
+
+  let ownAgent: Agent;
+  let otherAgent: Agent;
+  let ownOpportunity: Opportunity;
+  let otherAgentOpportunity: Opportunity;
+  let ownDeal: Deal;
+  let otherDeal: Deal;
+  let agentPerson: Person;
+  let coordinatorPerson: Person;
+  let agentCookie: string;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    ownAgent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (own) ${suffix}` }),
+    );
+    otherAgent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (other) ${suffix}` }),
+    );
+
+    ownDeal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    otherDeal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+
+    ownOpportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (own) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.NEW,
+        agentId: ownAgent.id,
+        dealId: ownDeal.id,
+      }),
+    );
+    otherAgentOpportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (other) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.NEW,
+        agentId: otherAgent.id,
+        dealId: otherDeal.id,
+      }),
+    );
+
+    agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Agent" }),
+    );
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `agent-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({ agentId: ownAgent.id, personId: agentPerson.id }),
+    );
+
+    const login = async (email: string): Promise<string> => {
+      const res = await fastify.inject({
+        method: "POST",
+        url: "/auth/login",
+        payload: { email, password: PASSWORD },
+      });
+      return getCookie(res.cookies, accessCookieName);
+    };
+
+    agentCookie = await login(`agent-${suffix}@test.need4deed.org`);
+    coordinatorCookie = await login(`coordinator-${suffix}@test.need4deed.org`);
+  });
+
+  afterAll(async () => {
+    await fastify.db.opportunityRepository.delete({ id: ownOpportunity.id });
+    await fastify.db.opportunityRepository.delete({
+      id: otherAgentOpportunity.id,
+    });
+    await fastify.db.agentPersonRepository.delete({
+      agentId: ownAgent.id,
+      personId: agentPerson.id,
+    });
+    await fastify.db.dealRepository.delete({ id: ownDeal.id });
+    await fastify.db.dealRepository.delete({ id: otherDeal.id });
+    await fastify.db.agentRepository.delete({ id: ownAgent.id });
+    await fastify.db.agentRepository.delete({ id: otherAgent.id });
+    await fastify.db.userRepository.delete({ personId: agentPerson.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: agentPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.close();
+  });
+
+  it("lets an agent set the status of their own agent's opportunity", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+      payload: { statusOpportunity: OpportunityStatusType.INACTIVE },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(updated.status).toBe(OpportunityStatusType.INACTIVE);
+  });
+
+  it("403s when an agent tries to update an opportunity of another agent", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${otherAgentOpportunity.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+      payload: { statusOpportunity: OpportunityStatusType.INACTIVE },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("403s when an agent tries to patch fields beyond status", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+      payload: {
+        statusOpportunity: OpportunityStatusType.ACTIVE,
+        title: "Sneaky rename",
+      },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("still lets a coordinator patch the full surface, including status", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        statusOpportunity: OpportunityStatusType.ACTIVE,
+        title: "Coordinator renamed",
+      },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(updated.status).toBe(OpportunityStatusType.ACTIVE);
+    expect(updated.title).toBe("Coordinator renamed");
+  });
+});


### PR DESCRIPTION
## Summary
- `PATCH /opportunity/:id` was COORDINATOR-only; an agent had no way to mark their own opportunity inactive once it's no longer relevant.
- AGENT is now allowed too, gated by `agentPersonRepository` membership on the opportunity's `agentId` (the same ownership check already used on `POST /opportunity/`).
- Restricted to the `statusOpportunity` field only — the full edit surface (contact/agent reassignment, description, etc.) stays COORDINATOR/ADMIN-only, per the security consideration raised in the issue.

Companion FE change (own PR): shows the "Change status" button for an agent viewing their own opportunity.

## Test plan
- [x] `yarn typecheck` passes
- [x] New integration test `src/test/server/routes/opportunity.routes.test.ts` covers: agent updates own opportunity's status (204), agent blocked on another agent's opportunity (403), agent blocked from patching other fields (403), coordinator full-surface patch still works (204)
- [x] Full suite (`yarn test:run`): 439/439 passing, no regressions

Fixes #820