### PR TITLE
feat: expose all agent contacts + add POST /agent/:id/contact

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.128",
+    "need4deed-sdk": "0.0.130",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -34,6 +34,7 @@ import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 import agentCommunicationRoutes from "./agent-communication.routes";
 import agentOpportunityRoutes from "./agent-opportunity.routes";
 import agentVolunteerRoutes from "./agent-volunteer.routes";
+import agentContactRoutes from "./contact.routes";
 import agentMembershipRoutes from "./membership.routes";
 import agentRegisterRoutes from "./register.routes";
 
@@ -60,6 +61,10 @@ export default async function agentRoutes(
 
   fastify.register(agentVolunteerRoutes, {
     prefix: `/:id${RoutePrefix.VOLUNTEER_LINKED}`,
+  });
+
+  fastify.register(agentContactRoutes, {
+    prefix: `/:id${RoutePrefix.CONTACT}`,
   });
 
   fastify.get<{

--- a/src/server/routes/agent/contact.routes.ts
+++ b/src/server/routes/agent/contact.routes.ts
@@ -1,0 +1,73 @@
+import { FastifyInstance, FastifyPluginOptions } from "fastify";
+import {
+  AgentMembershipStatus,
+  ApiAgentContactPost,
+  UserRole,
+} from "need4deed-sdk";
+import { NotFoundError, UnauthorizedError } from "../../../config";
+import { dtoSerializeAgentMembership } from "../../../services";
+import {
+  agentContactPostBodySchema,
+  agentContactResponseSchema,
+  idParamSchema,
+} from "../../schema";
+import { ParamsId } from "../../types";
+import { createAgentContact } from "../../utils";
+
+// POST /agent/:id/contact — an NGO adding another contact person to their own
+// profile. Any ACTIVE member of the agent may add one (mirrors the ownership
+// check on PATCH /opportunity/:id for AGENT-role status changes);
+// COORDINATOR/ADMIN may add a contact to any agent.
+export default function agentContactRoutes(
+  fastify: FastifyInstance,
+  _options: FastifyPluginOptions,
+) {
+  fastify.post<{ Params: ParamsId; Body: ApiAgentContactPost }>(
+    "/",
+    {
+      schema: {
+        params: idParamSchema,
+        body: agentContactPostBodySchema,
+        response: { 201: agentContactResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const agentId = Number(request.params.id);
+
+      const agent = await fastify.db.agentRepository.findOneBy({
+        id: agentId,
+      });
+      if (!agent) {
+        throw new NotFoundError(`Agent (id:${agentId}) not found.`);
+      }
+
+      const role = request.authUser?.role;
+      const isCoordinatorOrAdmin =
+        role === UserRole.COORDINATOR || role === UserRole.ADMIN;
+
+      if (!isCoordinatorOrAdmin) {
+        const personId = request.authUser?.personId;
+        const membership = personId
+          ? await fastify.db.agentPersonRepository.findOneBy({
+              agentId,
+              personId,
+              status: AgentMembershipStatus.ACTIVE,
+            })
+          : null;
+        if (!membership) {
+          throw new UnauthorizedError(
+            "Only active members of this agent can add a contact.",
+          );
+        }
+      }
+
+      const agentPerson = await createAgentContact(agentId, request.body);
+      agentPerson.agent = agent;
+
+      return reply.status(201).send({
+        message: `Contact added to agent (id:${agentId}).`,
+        data: dtoSerializeAgentMembership(agentPerson),
+      });
+    },
+  );
+}

--- a/src/server/routes/agent/contact.routes.ts
+++ b/src/server/routes/agent/contact.routes.ts
@@ -34,6 +34,18 @@ export default function agentContactRoutes(
     async (request, reply) => {
       const agentId = Number(request.params.id);
 
+      // Mirrors the role allowlist on PATCH /opportunity/:id: only these
+      // three roles may reach the membership check below, regardless of
+      // whether a stray AgentPerson row exists for some other role.
+      const role = request.authUser?.role;
+      if (
+        role !== UserRole.COORDINATOR &&
+        role !== UserRole.AGENT &&
+        role !== UserRole.ADMIN
+      ) {
+        throw new UnauthorizedError();
+      }
+
       const agent = await fastify.db.agentRepository.findOneBy({
         id: agentId,
       });
@@ -41,7 +53,6 @@ export default function agentContactRoutes(
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
       }
 
-      const role = request.authUser?.role;
       const isCoordinatorOrAdmin =
         role === UserRole.COORDINATOR || role === UserRole.ADMIN;
 

--- a/src/server/schema/agent-contact.schema.ts
+++ b/src/server/schema/agent-contact.schema.ts
@@ -1,0 +1,31 @@
+// Schema for POST /agent/:id/contact — adding an additional contact (Person +
+// AgentPerson) to an existing agent from that agent's own profile. Distinct
+// from POST /agent/register (agent-register.schema.ts), which always links
+// the authenticated caller's own person.
+
+export const agentContactPostBodySchema = {
+  type: "object",
+  required: ["firstName", "lastName", "role"],
+  additionalProperties: false,
+  properties: {
+    firstName: { type: "string", minLength: 1 },
+    lastName: { type: "string", minLength: 1 },
+    role: { $ref: "AgentRoleType#" },
+    email: { type: "string" },
+    phone: { type: "string" },
+    addressStreet: { type: "string" },
+    addressPostcode: { type: "string" },
+  },
+};
+
+// ApiAgentMembership — left open (additionalProperties) so the nested
+// person/address payload is not stripped during serialization, mirroring
+// membershipListResponseSchema (agent-membership.schema.ts).
+export const agentContactResponseSchema = {
+  type: "object",
+  required: ["message", "data"],
+  properties: {
+    message: { type: "string" },
+    data: { type: "object", additionalProperties: true },
+  },
+};

--- a/src/server/schema/index.ts
+++ b/src/server/schema/index.ts
@@ -1,3 +1,4 @@
+export * from "./agent-contact.schema";
 export * from "./agent-membership.schema";
 export * from "./agent-register.schema";
 export * from "./param";

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -1458,6 +1458,10 @@
             "representative": {
               "$ref": "AgentRepresentative#"
             },
+            "contacts": {
+              "type": "array",
+              "items": { "type": "object", "additionalProperties": true }
+            },
             "serviceType": {
               "type": "array",
               "items": {

--- a/src/server/types/enums.ts
+++ b/src/server/types/enums.ts
@@ -5,6 +5,7 @@ export const RoutePrefix = {
   APPRECIATION: "/appreciation",
   COMMENT: "/comment",
   COMMUNICATION: "/communication",
+  CONTACT: "/contact",
   DOC: "/doc",
   HEALTH_CHECK: "/health-check",
   LEGACY: "/legacy",

--- a/src/server/utils/data/create-agent-contact.ts
+++ b/src/server/utils/data/create-agent-contact.ts
@@ -1,0 +1,65 @@
+import { ApiAgentContactPost } from "need4deed-sdk";
+import { dataSource } from "../../../data/data-source";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Person from "../../../data/entity/person.entity";
+import { getRepository } from "../../../data/utils";
+import { createAddress } from "./for-routes";
+
+/**
+ * Adds a brand-new contact (Person + AgentPerson membership) to an existing
+ * agent, from that agent's own profile — distinct from the self-registration
+ * flow (write-agent-registration.ts), which only ever links the
+ * *authenticated caller's own* person. This always creates a new Person; it
+ * does not look one up by email, since the caller is describing someone
+ * else's contact details, not identifying themselves.
+ *
+ * Address is best-effort: if street+postcode are given but the postcode
+ * doesn't resolve to a known Postcode, the contact is still created without
+ * an address rather than failing the whole request. Person + AgentPerson are
+ * written in one transaction so a partial failure can't leave an orphan
+ * Person with no membership.
+ */
+export async function createAgentContact(
+  agentId: number,
+  input: ApiAgentContactPost,
+): Promise<AgentPerson> {
+  let result!: AgentPerson;
+
+  await dataSource.manager.transaction(async (manager) => {
+    const personRepository = getRepository(manager, Person);
+    const agentPersonRepository = getRepository(manager, AgentPerson);
+
+    let addressId: number | undefined;
+    if (input.addressStreet && input.addressPostcode) {
+      const address = await createAddress(
+        { street: input.addressStreet },
+        { value: input.addressPostcode },
+        manager,
+      );
+      addressId = address?.id;
+    }
+
+    const person = await personRepository.save(
+      new Person({
+        firstName: input.firstName,
+        lastName: input.lastName,
+        email: input.email || undefined,
+        phone: input.phone || undefined,
+        addressId,
+      }),
+    );
+
+    const agentPerson = await agentPersonRepository.save(
+      new AgentPerson({
+        agentId,
+        personId: person.id,
+        role: input.role,
+      }),
+    );
+    agentPerson.person = person;
+
+    result = agentPerson;
+  });
+
+  return result;
+}

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -2,6 +2,7 @@ export * from "./add-category-to-deal";
 export * from "./add-comments-entity";
 export * from "./add-district-to-agent";
 export * from "./add-district-to-opp";
+export * from "./create-agent-contact";
 export * from "./for-routes";
 export * from "./get-agent-by-postcode";
 export * from "./get-agent-where";

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -65,6 +65,9 @@ export function dtoAgentGet(
       ...dtoSerializePerson(agent?.representative?.person),
       role: agent?.representative?.role,
     },
+    contacts: (agent.agentPerson ?? []).map((ap) =>
+      dtoSerializeAgentMembership({ ...ap, agent }),
+    ),
     serviceType: agent.services,
     trustLevel: agent.trustLevel,
     statusEngagement: agent.engagementStatus,

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -32,6 +32,22 @@ describe("dtoAgentGet", () => {
         person: { firstName: "John" },
         role: "Manager",
       },
+      agentPerson: [
+        {
+          id: 501,
+          agentId: 1,
+          role: "Manager",
+          status: "active",
+          person: { firstName: "John" },
+        },
+        {
+          id: 502,
+          agentId: 1,
+          role: "Social Worker",
+          status: "pending",
+          person: { firstName: "Jane" },
+        },
+      ],
       services: ["Consulting", "Legal"],
       trustLevel: 5,
       engagementStatus: "Active",
@@ -56,6 +72,27 @@ describe("dtoAgentGet", () => {
       role: "Manager",
     });
 
+    // contacts should list every AgentPerson membership, not just the
+    // collapsed representative
+    expect(result.contacts).toEqual([
+      {
+        id: 501,
+        agentId: 1,
+        agentTitle: "Agent Alpha",
+        person: { name: "John" },
+        role: "Manager",
+        status: "active",
+      },
+      {
+        id: 502,
+        agentId: 1,
+        agentTitle: "Agent Alpha",
+        person: { name: "Jane" },
+        role: "Social Worker",
+        status: "pending",
+      },
+    ]);
+
     // Checking nested agentDetails (via the internal helper)
     expect(result.agentDetails.services).toBe("Consulting, Legal");
     expect(result.agentDetails.clientLanguages[0].title).toBe("English");
@@ -72,6 +109,7 @@ describe("dtoAgentGet", () => {
     expect(result.operator).toBeUndefined();
     expect(result.comments).toBeUndefined();
     expect(result.representative.role).toBeUndefined();
+    expect(result.contacts).toEqual([]);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.128:
-  version "0.0.128"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.128.tgz#b1c0443cb0d6d13b39cf60bb9862fee5a563f4a2"
-  integrity sha512-AczNANHKYaWIp+BweDZFCrlv3hHN1lLZDrFzDhfJD39SicLygCqd1NPMtVyIRH4trh6zZSj+2E1D4gKlIdKDUw==
+need4deed-sdk@0.0.130:
+  version "0.0.130"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.130.tgz#d8258b997c73dea5b123688845ccad1c1e93e2a5"
+  integrity sha512-rQoauUEjo6F0vK+ZH6OmAP+0Nr3kbkaK0VIJX8ctmjPBoqwSeSBipIGvELfg1XMo1c3m2kUR6FCjmDYabVAvLQ==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
Part of the multi-repo effort for need4deed-org/fe#810 (support multiple contact persons on NGO/agent profile). Second step, following need4deed-sdk 0.0.130 (adds `contacts: ApiAgentMembership[]` + `ApiAgentContactPost`) — `fe` consumption is the next repo boundary.

- `dtoAgentGet` now serializes `contacts`: every `AgentPerson` membership for the agent (representative included), reusing the existing `dtoSerializeAgentMembership` helper already used for the membership-moderation endpoints (`GET /agent/membership`). `representative` is untouched — additive, not a breaking change.
- New `POST /agent/:id/contact` creates a brand-new contact (`Person` + `AgentPerson`) on an existing agent — distinct from `POST /agent/register`, which only ever links the *authenticated caller's own* person. This is a genuinely new capability: a contact created this way doesn't need a login of its own.
- Authorization: any **ACTIVE** member of that agent (mirrors the ownership check already used on `PATCH /opportunity/:id` for AGENT-role status changes — same `agentPersonRepository.findOneBy({ agentId, personId })` pattern), or COORDINATOR/ADMIN for any agent.
- Person + AgentPerson are written in one transaction (mirrors `createAgentForPerson` in `write-agent-registration.ts`).
- Address is best-effort: if street+postcode don't resolve to a known Postcode, the contact is still created without an address.
- Bumped `need4deed-sdk` to `0.0.130`.

## Not in this PR
- `fe` UI (next repo boundary — will follow once this is reviewed).
- Edit/remove for existing contacts (issue's own suggestion: "at minimum, adding should work").

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test -- src/test/services/dto/dto-agent.test.ts` — added cases for the new `contacts` field (full-membership-list mapping + empty-array default), all 14 tests pass
- [x] `yarn lint` — no new errors (confirmed the 22 pre-existing errors are unrelated to any file touched here — migrations/eslint.config.js/etc.)
- [ ] No live-DB route/integration test run for the new endpoint — this sandbox's Postgres route-level integration tests (`opportunity.routes.test.ts`, `person.routes.test.ts`, `opportunity-create.routes.test.ts`) hang on `beforeAll`/`createServer()` even on an unmodified `develop` checkout (verified via a throwaway worktree at the same base commit), so this is a pre-existing environment limitation here, not something this change caused — but it also means `POST /agent/:id/contact` itself hasn't been exercised against a real DB in this sandbox. Please run the suite in CI/a working local setup before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)