### PR TITLE
feat: add PATCH /agent/:id/contact/:membershipId, extend create fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.131",
+    "need4deed-sdk": "0.0.132",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/routes/agent/contact.routes.ts
+++ b/src/server/routes/agent/contact.routes.ts
@@ -19,13 +19,10 @@ import { createAgentContact, updateAgentContact } from "../../utils";
 
 // Mirrors the role allowlist on PATCH /opportunity/:id: only these three
 // roles may reach the membership check, regardless of whether a stray
-// AgentPerson row exists for some other role. Coordinator/admin may act on
-// any agent; an AGENT must be an active member of this specific agent.
-async function assertCanManageContacts(
-  fastify: FastifyInstance,
-  request: FastifyRequest,
-  agentId: number,
-): Promise<void> {
+// AgentPerson row exists for some other role. Cheap (no DB), so it runs
+// before the agent-existence check — an unauthenticated/wrong-role caller
+// shouldn't get a DB round trip just to be told "no".
+function assertHasContactManagementRole(request: FastifyRequest): void {
   const role = request.authUser?.role;
   if (
     role !== UserRole.COORDINATOR &&
@@ -34,7 +31,19 @@ async function assertCanManageContacts(
   ) {
     throw new UnauthorizedError();
   }
+}
 
+// Coordinator/admin may act on any agent; an AGENT must be an active member
+// of this specific agent. Run this *after* the 404 check for the agent
+// itself, so a non-member probing a nonexistent agent id still gets 404
+// (matching the rest of the API) rather than a 403 that leaks nothing about
+// existence but changes already-established error-code semantics.
+async function assertCanManageContacts(
+  fastify: FastifyInstance,
+  request: FastifyRequest,
+  agentId: number,
+): Promise<void> {
+  const role = request.authUser?.role;
   if (role === UserRole.COORDINATOR || role === UserRole.ADMIN) {
     return;
   }
@@ -75,7 +84,7 @@ export default function agentContactRoutes(
     async (request, reply) => {
       const agentId = Number(request.params.id);
 
-      await assertCanManageContacts(fastify, request, agentId);
+      assertHasContactManagementRole(request);
 
       const agent = await fastify.db.agentRepository.findOneBy({
         id: agentId,
@@ -83,6 +92,8 @@ export default function agentContactRoutes(
       if (!agent) {
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
       }
+
+      await assertCanManageContacts(fastify, request, agentId);
 
       const agentPerson = await createAgentContact(agentId, request.body);
       agentPerson.agent = agent;
@@ -110,7 +121,7 @@ export default function agentContactRoutes(
       const agentId = Number(request.params.id);
       const membershipId = Number(request.params.membershipId);
 
-      await assertCanManageContacts(fastify, request, agentId);
+      assertHasContactManagementRole(request);
 
       const agent = await fastify.db.agentRepository.findOneBy({
         id: agentId,
@@ -118,6 +129,8 @@ export default function agentContactRoutes(
       if (!agent) {
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
       }
+
+      await assertCanManageContacts(fastify, request, agentId);
 
       const membership = await fastify.db.agentPersonRepository.findOne({
         where: { id: membershipId, agentId },

--- a/src/server/routes/agent/contact.routes.ts
+++ b/src/server/routes/agent/contact.routes.ts
@@ -1,23 +1,64 @@
-import { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { FastifyInstance, FastifyPluginOptions, FastifyRequest } from "fastify";
 import {
   AgentMembershipStatus,
+  ApiAgentContactPatch,
   ApiAgentContactPost,
   UserRole,
 } from "need4deed-sdk";
 import { NotFoundError, UnauthorizedError } from "../../../config";
 import { dtoSerializeAgentMembership } from "../../../services";
 import {
+  agentContactMembershipParamSchema,
+  agentContactPatchBodySchema,
   agentContactPostBodySchema,
   agentContactResponseSchema,
   idParamSchema,
 } from "../../schema";
 import { ParamsId } from "../../types";
-import { createAgentContact } from "../../utils";
+import { createAgentContact, updateAgentContact } from "../../utils";
+
+// Mirrors the role allowlist on PATCH /opportunity/:id: only these three
+// roles may reach the membership check, regardless of whether a stray
+// AgentPerson row exists for some other role. Coordinator/admin may act on
+// any agent; an AGENT must be an active member of this specific agent.
+async function assertCanManageContacts(
+  fastify: FastifyInstance,
+  request: FastifyRequest,
+  agentId: number,
+): Promise<void> {
+  const role = request.authUser?.role;
+  if (
+    role !== UserRole.COORDINATOR &&
+    role !== UserRole.AGENT &&
+    role !== UserRole.ADMIN
+  ) {
+    throw new UnauthorizedError();
+  }
+
+  if (role === UserRole.COORDINATOR || role === UserRole.ADMIN) {
+    return;
+  }
+
+  const personId = request.authUser?.personId;
+  const membership = personId
+    ? await fastify.db.agentPersonRepository.findOneBy({
+        agentId,
+        personId,
+        status: AgentMembershipStatus.ACTIVE,
+      })
+    : null;
+  if (!membership) {
+    throw new UnauthorizedError(
+      "Only active members of this agent can manage its contacts.",
+    );
+  }
+}
 
 // POST /agent/:id/contact — an NGO adding another contact person to their own
-// profile. Any ACTIVE member of the agent may add one (mirrors the ownership
-// check on PATCH /opportunity/:id for AGENT-role status changes);
-// COORDINATOR/ADMIN may add a contact to any agent.
+// profile. PATCH /agent/:id/contact/:membershipId — updating one. Both are
+// distinct from PATCH /person/:id, which is strictly self-only, and from
+// POST /agent/register, which only ever links the authenticated caller's own
+// person.
 export default function agentContactRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
@@ -34,17 +75,7 @@ export default function agentContactRoutes(
     async (request, reply) => {
       const agentId = Number(request.params.id);
 
-      // Mirrors the role allowlist on PATCH /opportunity/:id: only these
-      // three roles may reach the membership check below, regardless of
-      // whether a stray AgentPerson row exists for some other role.
-      const role = request.authUser?.role;
-      if (
-        role !== UserRole.COORDINATOR &&
-        role !== UserRole.AGENT &&
-        role !== UserRole.ADMIN
-      ) {
-        throw new UnauthorizedError();
-      }
+      await assertCanManageContacts(fastify, request, agentId);
 
       const agent = await fastify.db.agentRepository.findOneBy({
         id: agentId,
@@ -53,31 +84,57 @@ export default function agentContactRoutes(
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
       }
 
-      const isCoordinatorOrAdmin =
-        role === UserRole.COORDINATOR || role === UserRole.ADMIN;
-
-      if (!isCoordinatorOrAdmin) {
-        const personId = request.authUser?.personId;
-        const membership = personId
-          ? await fastify.db.agentPersonRepository.findOneBy({
-              agentId,
-              personId,
-              status: AgentMembershipStatus.ACTIVE,
-            })
-          : null;
-        if (!membership) {
-          throw new UnauthorizedError(
-            "Only active members of this agent can add a contact.",
-          );
-        }
-      }
-
       const agentPerson = await createAgentContact(agentId, request.body);
       agentPerson.agent = agent;
 
       return reply.status(201).send({
         message: `Contact added to agent (id:${agentId}).`,
         data: dtoSerializeAgentMembership(agentPerson),
+      });
+    },
+  );
+
+  fastify.patch<{
+    Params: ParamsId & { membershipId: number };
+    Body: ApiAgentContactPatch;
+  }>(
+    "/:membershipId",
+    {
+      schema: {
+        params: agentContactMembershipParamSchema,
+        body: agentContactPatchBodySchema,
+        response: { 200: agentContactResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const agentId = Number(request.params.id);
+      const membershipId = Number(request.params.membershipId);
+
+      await assertCanManageContacts(fastify, request, agentId);
+
+      const agent = await fastify.db.agentRepository.findOneBy({
+        id: agentId,
+      });
+      if (!agent) {
+        throw new NotFoundError(`Agent (id:${agentId}) not found.`);
+      }
+
+      const membership = await fastify.db.agentPersonRepository.findOne({
+        where: { id: membershipId, agentId },
+        relations: ["person.address.postcode"],
+      });
+      if (!membership) {
+        throw new NotFoundError(
+          `Contact (membershipId:${membershipId}) not found for agent (id:${agentId}).`,
+        );
+      }
+
+      const updated = await updateAgentContact(membership, request.body);
+      updated.agent = agent;
+
+      return reply.status(200).send({
+        message: `Contact (membershipId:${membershipId}) updated.`,
+        data: dtoSerializeAgentMembership(updated),
       });
     },
   );

--- a/src/server/schema/agent-contact.schema.ts
+++ b/src/server/schema/agent-contact.schema.ts
@@ -1,7 +1,17 @@
-// Schema for POST /agent/:id/contact — adding an additional contact (Person +
-// AgentPerson) to an existing agent from that agent's own profile. Distinct
-// from POST /agent/register (agent-register.schema.ts), which always links
-// the authenticated caller's own person.
+// Schema for POST /agent/:id/contact and PATCH /agent/:id/contact/:membershipId
+// — adding or updating a contact (Person + AgentPerson) on an existing agent
+// from that agent's own profile. Distinct from POST /agent/register
+// (agent-register.schema.ts), which always links the authenticated caller's
+// own person, and from PATCH /person/:id, which is strictly self-only.
+
+export const agentContactMembershipParamSchema = {
+  type: "object",
+  properties: {
+    id: { type: "integer", minimum: 1 },
+    membershipId: { type: "integer", minimum: 1 },
+  },
+  required: ["id", "membershipId"],
+};
 
 export const agentContactPostBodySchema = {
   type: "object",
@@ -9,10 +19,29 @@ export const agentContactPostBodySchema = {
   additionalProperties: false,
   properties: {
     firstName: { type: "string", minLength: 1 },
+    middleName: { type: "string" },
     lastName: { type: "string", minLength: 1 },
     role: { $ref: "AgentRoleType#" },
     email: { type: "string" },
     phone: { type: "string" },
+    landline: { type: "string" },
+    addressStreet: { type: "string" },
+    addressPostcode: { type: "string" },
+  },
+};
+
+// Every field optional — a partial update of an existing contact.
+export const agentContactPatchBodySchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    firstName: { type: "string", minLength: 1 },
+    middleName: { type: "string" },
+    lastName: { type: "string", minLength: 1 },
+    role: { $ref: "AgentRoleType#" },
+    email: { type: "string" },
+    phone: { type: "string" },
+    landline: { type: "string" },
     addressStreet: { type: "string" },
     addressPostcode: { type: "string" },
   },

--- a/src/server/utils/data/create-agent-contact.ts
+++ b/src/server/utils/data/create-agent-contact.ts
@@ -42,9 +42,11 @@ export async function createAgentContact(
     const person = await personRepository.save(
       new Person({
         firstName: input.firstName,
+        middleName: input.middleName || undefined,
         lastName: input.lastName,
         email: input.email || undefined,
         phone: input.phone || undefined,
+        landline: input.landline || undefined,
         addressId,
       }),
     );

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -18,6 +18,7 @@ export * from "./get-volunteer-where";
 export * from "./is-trusted-domain";
 export * from "./run-w-advisory-lock";
 export * from "./sync-comment-tags";
+export * from "./update-agent-contact";
 export * from "./update-leads";
 export * from "./write-agent-registration";
 export * from "./write-opportunity-contact-comment";

--- a/src/server/utils/data/update-agent-contact.ts
+++ b/src/server/utils/data/update-agent-contact.ts
@@ -1,0 +1,96 @@
+import { ApiAgentContactPatch } from "need4deed-sdk";
+import { dataSource } from "../../../data/data-source";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Person from "../../../data/entity/person.entity";
+import { getRepository } from "../../../data/utils";
+import { createAddress, patchAddress } from "./for-routes";
+
+/**
+ * Updates an existing contact's Person fields and/or their role on this
+ * specific AgentPerson membership. `membership` must already have its
+ * `person` relation loaded (the caller resolves and authorizes the
+ * membership before calling this).
+ *
+ * Only the fields present in `input` are touched — undefined fields leave
+ * the existing value alone (partial update), matching PATCH /person/:id's
+ * behavior. Address is create-or-patch: an existing address is patched in
+ * place, a person with none gets a new one created, mirroring the pattern
+ * PATCH /agent/:id already uses for the agent's own address.
+ */
+export async function updateAgentContact(
+  membership: AgentPerson,
+  input: ApiAgentContactPatch,
+): Promise<AgentPerson> {
+  const personId = membership.person.id;
+
+  await dataSource.manager.transaction(async (manager) => {
+    const personRepository = getRepository(manager, Person);
+    const agentPersonRepository = getRepository(manager, AgentPerson);
+    const person = membership.person;
+
+    if (input.addressStreet || input.addressPostcode) {
+      const addressData = input.addressStreet
+        ? { street: input.addressStreet }
+        : {};
+      const postcodeData = input.addressPostcode
+        ? { value: input.addressPostcode }
+        : {};
+
+      if (person.addressId) {
+        await patchAddress(
+          { id: person.addressId, ...addressData },
+          postcodeData,
+          manager,
+        );
+      } else {
+        const address = await createAddress(addressData, postcodeData, manager);
+        if (address) {
+          await personRepository.update(
+            { id: personId },
+            { addressId: address.id },
+          );
+        }
+      }
+    }
+
+    const personUpdates: Partial<Person> = {};
+    if (input.firstName !== undefined) {
+      personUpdates.firstName = input.firstName;
+    }
+    if (input.middleName !== undefined) {
+      personUpdates.middleName = input.middleName;
+    }
+    if (input.lastName !== undefined) {
+      personUpdates.lastName = input.lastName;
+    }
+    if (input.email !== undefined) {
+      personUpdates.email = input.email;
+    }
+    if (input.phone !== undefined) {
+      personUpdates.phone = input.phone;
+    }
+    if (input.landline !== undefined) {
+      personUpdates.landline = input.landline;
+    }
+
+    if (Object.keys(personUpdates).length > 0) {
+      await personRepository.update({ id: personId }, personUpdates);
+    }
+
+    if (input.role !== undefined) {
+      membership.role = input.role;
+      await agentPersonRepository.save(membership);
+    }
+  });
+
+  const personRepository = getRepository(dataSource, Person);
+  const refreshedPerson = await personRepository.findOne({
+    where: { id: personId },
+    relations: ["address.postcode"],
+  });
+  if (refreshedPerson) {
+    membership.person = refreshedPerson;
+  }
+
+  return membership;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.131:
-  version "0.0.131"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.131.tgz#915b15be5d1e592af0de93070174f51ce7492e3f"
-  integrity sha512-dQWa3Lnwa5xNPzuDWu9ue2+pj/RAiacBo0o0PIrzOQzyMBI4hK5hM6pkvGQccJnaslbMVFAzyLJl1HlRnETr5g==
+need4deed-sdk@0.0.132:
+  version "0.0.132"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.132.tgz#e415934050c077ac37865d6fa6b327b2c21a1516"
+  integrity sha512-1B3dy/X25XSZO96Cw96jWdd39XwB862XLvWHRbNrdQ3zgCfP8TZmlwZljVs7FhPKIZCetgsdDJV2K5mF57Kyeg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
Part of the multi-repo effort for need4deed-org/fe#848 (unify NGO contact rows: every contact — primary and additional — gets identical fields and is individually editable, not just the primary).

- `POST /agent/:id/contact` now also accepts `middleName` and `landline`, matching the primary contact's existing field set (previously "add" and "edit" had different shapes: add had address but no middleName/landline, edit had the reverse).
- New `PATCH /agent/:id/contact/:membershipId` updates an existing contact's Person fields and/or role directly by membership — needed because `PATCH /person/:id` is strictly self-only (`authUser.personId !== personId` → 403 for anyone but ADMIN), so there was no way for an agent to edit a colleague's contact info at all. Authorized the same way `POST` already is: any **ACTIVE** member of that agent, or COORDINATOR/ADMIN for any agent.
- Partial update semantics: only fields present in the body are touched. Address is create-or-patch (an existing address is patched in place, a person with none gets a new one), mirroring the pattern `PATCH /agent/:id` already uses for the agent's own address.
- Extracted the shared role-allowlist + active-membership check (previously duplicated only in the POST handler) into `assertCanManageContacts`, used by both routes.
- Bumped `need4deed-sdk` to `0.0.132` (need4deed-org/sdk#170 — extends `ApiAgentContactPost`, adds `ApiAgentContactPatch`).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — no new issues (22 pre-existing errors, none in files touched here)
- [x] **Live-verified end-to-end** against the real dev DB (`aits.need4deed.org`, via SSH tunnel), as a real agent user:
  - POST with `middleName`/`landline` → 201, both persisted correctly.
  - PATCH with only `{phone}` → only phone changed, every other field (name, email, landline, role) untouched.
  - PATCH with `{role, addressStreet, addressPostcode}` → role updated, new address created (person had none).
  - PATCH with `{addressStreet}` again → same address row patched in place (same id, no duplicate row created).
  - Non-member of the agent → 403 on PATCH.
  - Coordinator, correct agent id → 200 (bypass works).
  - Coordinator, membership under a *different* agent id than the URL → 404 (not silently accepted).
  - `GET /agent/:id` afterward showed the fully accumulated updates correctly in the contacts list.
  - Test data cleaned up afterward; confirmed the dev DB returned to its exact prior state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)