### PR TITLE
feat: add coordinator-only DELETE /opportunity/:id and DELETE /volunteer/:id

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -3,6 +3,7 @@ import {
   ApiOpportunityGet,
   ApiOpportunityPatch,
   CommunicationType,
+  EntityTableName,
   OpportunityFormDataWithAgentSubmitter,
   OpportunityLegacyFormData,
   OpportunityLegacyType,
@@ -15,7 +16,9 @@ import {
   NotFoundError,
   UnauthorizedError,
 } from "../../../config";
+import { dataSource } from "../../../data/data-source";
 import Comment from "../../../data/entity/comment.entity";
+import Deal from "../../../data/entity/deal.entity";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
 import DealLanguage from "../../../data/entity/m2m/deal-language";
 import DealSkill from "../../../data/entity/m2m/deal-skill";
@@ -48,6 +51,7 @@ import {
   QuerystringOpportunityList,
   ReplyData,
   ReplyDataCount,
+  ReplyMessage,
   RoutePrefix,
 } from "../../types";
 import {
@@ -805,6 +809,52 @@ export default async function opportunityRoutes(
       }
 
       return reply.status(204).send();
+    },
+  );
+
+  // COORDINATOR-only, hard delete. OpportunityVolunteer (+ its ActivityLog),
+  // Communication, and Appreciation rows all cascade via FK. Comment rows are
+  // polymorphic (entityType/entityId, no real FK) so they're cleaned up
+  // explicitly here; Deal and Accompanying are exclusively owned by one
+  // opportunity each (minted fresh at creation), so they're deleted alongside
+  // rather than left as permanent orphans.
+  fastify.delete<{ Params: ParamsId; Reply: ReplyMessage }>(
+    "/:id",
+    {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
+      schema: {
+        params: idParamSchema,
+        response: responseSchema(""),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const opportunityRepository = fastify.db.opportunityRepository;
+      const opportunity = await opportunityRepository.findOneBy({ id });
+
+      if (!opportunity) {
+        throw new NotFoundError(`Opportunity (id:${id}) not found.`);
+      }
+
+      const { dealId, accompanyingId } = opportunity;
+
+      await dataSource.manager.transaction(async (manager) => {
+        await manager.delete(Comment, {
+          entityType: EntityTableName.OPPORTUNITY,
+          entityId: id,
+        });
+        await manager.delete(Opportunity, { id });
+        if (dealId) {
+          await manager.delete(Deal, { id: dealId });
+        }
+        if (accompanyingId) {
+          await manager.delete(Accompanying, { id: accompanyingId });
+        }
+      });
+
+      return reply.status(200).send({
+        message: `Opportunity (id:${id}) deleted.`,
+      });
     },
   );
 }

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -27,6 +27,7 @@ import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
+import { updateVolunteerMatching } from "../../../data/utils";
 import { getDistrictFromPostcode } from "../../../data/utils/get-district";
 import logger from "../../../logger";
 import {
@@ -838,6 +839,16 @@ export default async function opportunityRoutes(
 
       const { dealId, accompanyingId } = opportunity;
 
+      // OpportunityVolunteer rows cascade at the DB level, which bypasses
+      // TypeORM's @AfterRemove hook (it never loads/removes those entities
+      // via the entity manager) — so each linked volunteer's statusMatch
+      // must be recomputed explicitly, or it's left stale indefinitely.
+      const linkedVolunteerIds = (
+        await fastify.db.opportunityVolunteerRepository.find({
+          where: { opportunityId: id },
+        })
+      ).map((ov) => ov.volunteerId);
+
       await dataSource.manager.transaction(async (manager) => {
         await manager.delete(Comment, {
           entityType: EntityTableName.OPPORTUNITY,
@@ -851,6 +862,10 @@ export default async function opportunityRoutes(
           await manager.delete(Accompanying, { id: accompanyingId });
         }
       });
+
+      await Promise.all(
+        linkedVolunteerIds.map((vId) => updateVolunteerMatching(vId)),
+      );
 
       return reply.status(200).send({
         message: `Opportunity (id:${id}) deleted.`,

--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
   ApiVolunteerGet,
   ApiVolunteerGetList,
+  EntityTableName,
   Id,
   Lang,
   SortOrder,
@@ -10,6 +11,10 @@ import {
   VolunteerPatchBodyData,
 } from "need4deed-sdk";
 import { FindOptionsOrder, FindOptionsWhere, In } from "typeorm";
+import { NotFoundError } from "../../../config";
+import { dataSource } from "../../../data/data-source";
+import Comment from "../../../data/entity/comment.entity";
+import Deal from "../../../data/entity/deal.entity";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
 import DealDistrict from "../../../data/entity/m2m/deal-district";
 import DealLanguage from "../../../data/entity/m2m/deal-language";
@@ -32,7 +37,9 @@ import {
   volunteerListQuerySchema,
 } from "../../schema";
 import {
+  ParamsId,
   QuerystringVolunteerGetList,
+  ReplyMessage,
   RoutePrefix,
   VolunteerListType,
 } from "../../types";
@@ -490,6 +497,49 @@ export default async function volunteerRoutes(
         logger.error(`Error writing volunteer: ${error}`);
         return reply.status(500).send({ message: "Internal server error." });
       }
+    },
+  );
+
+  // COORDINATOR-only, hard delete. OpportunityVolunteer, Document,
+  // Communication, and Appreciation rows all cascade via FK. Comment rows are
+  // polymorphic (entityType/entityId, no real FK) so they're cleaned up
+  // explicitly here; Deal is exclusively owned by one volunteer (minted fresh
+  // at creation), so it's deleted alongside rather than left as a permanent
+  // orphan.
+  fastify.delete<{ Params: ParamsId; Reply: ReplyMessage }>(
+    "/:id",
+    {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
+      schema: {
+        params: idParamSchema,
+        response: responseSchema(""),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const volunteerRepository = fastify.db.volunteerRepository;
+      const volunteer = await volunteerRepository.findOneBy({ id });
+
+      if (!volunteer) {
+        throw new NotFoundError(`Volunteer (id:${id}) not found.`);
+      }
+
+      const { dealId } = volunteer;
+
+      await dataSource.manager.transaction(async (manager) => {
+        await manager.delete(Comment, {
+          entityType: EntityTableName.VOLUNTEER,
+          entityId: id,
+        });
+        await manager.delete(Volunteer, { id });
+        if (dealId) {
+          await manager.delete(Deal, { id: dealId });
+        }
+      });
+
+      return reply.status(200).send({
+        message: `Volunteer (id:${id}) deleted.`,
+      });
     },
   );
 }

--- a/src/server/routes/volunteer/volunteer.routes.ts
+++ b/src/server/routes/volunteer/volunteer.routes.ts
@@ -22,6 +22,7 @@ import DealSkill from "../../../data/entity/m2m/deal-skill";
 import DealTimeslot from "../../../data/entity/m2m/deal-timeslot";
 import Person from "../../../data/entity/person.entity";
 import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
+import { updateOpportunityMatching } from "../../../data/utils";
 import logger from "../../../logger";
 import {
   leadFromParser,
@@ -526,6 +527,16 @@ export default async function volunteerRoutes(
 
       const { dealId } = volunteer;
 
+      // OpportunityVolunteer rows cascade at the DB level, which bypasses
+      // TypeORM's @AfterRemove hook (it never loads/removes those entities
+      // via the entity manager) — so each linked opportunity's statusMatch
+      // must be recomputed explicitly, or it's left stale indefinitely.
+      const linkedOpportunityIds = (
+        await fastify.db.opportunityVolunteerRepository.find({
+          where: { volunteerId: id },
+        })
+      ).map((ov) => ov.opportunityId);
+
       await dataSource.manager.transaction(async (manager) => {
         await manager.delete(Comment, {
           entityType: EntityTableName.VOLUNTEER,
@@ -536,6 +547,10 @@ export default async function volunteerRoutes(
           await manager.delete(Deal, { id: dealId });
         }
       });
+
+      await Promise.all(
+        linkedOpportunityIds.map((oId) => updateOpportunityMatching(oId)),
+      );
 
       return reply.status(200).send({
         message: `Volunteer (id:${id}) deleted.`,

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -1,17 +1,23 @@
 import { FastifyInstance } from "fastify";
 import {
+  EntityTableName,
   OpportunityStatusType,
   OpportunityType,
+  OpportunityVolunteerStatusType,
   UserRole,
 } from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accessCookieName } from "../../../config/constants";
+import Comment from "../../../data/entity/comment.entity";
 import Deal from "../../../data/entity/deal.entity";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
+import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
+import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
 import User from "../../../data/entity/user.entity";
+import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
 import { DealType } from "../../../data/types";
 import { hashPassword } from "../../../data/utils";
 import { createServer } from "../../../server";
@@ -203,5 +209,252 @@ describe("PATCH /opportunity/:id agent status update", () => {
     });
     expect(updated.status).toBe(OpportunityStatusType.ACTIVE);
     expect(updated.title).toBe("Coordinator renamed");
+  });
+
+  // An agent including `agent.id` alongside statusOpportunity would otherwise
+  // silently reach the relink branch — this confirms the existing
+  // disallowedKeys check (which only permits `statusOpportunity`) already
+  // blocks a non-coordinator from moving an opportunity to another agent.
+  it("403s when an agent tries to relink an opportunity to another agent via agent.id", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+      payload: {
+        statusOpportunity: OpportunityStatusType.ACTIVE,
+        agent: { id: otherAgent.id },
+      },
+    });
+    expect(res.statusCode).toBe(403);
+
+    const unchanged = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(unchanged.agentId).toBe(ownAgent.id);
+  });
+
+  it("lets a coordinator relink an opportunity to another agent via agent.id", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { agent: { id: otherAgent.id } },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(updated.agentId).toBe(otherAgent.id);
+
+    // Restore for any later test in this file that assumes ownAgent.
+    await fastify.db.opportunityRepository.update(
+      { id: ownOpportunity.id },
+      { agentId: ownAgent.id },
+    );
+  });
+});
+
+describe("DELETE /opportunity/:id", () => {
+  let fastify: FastifyInstance;
+
+  let agent: Agent;
+  let volunteer: Volunteer;
+  let opportunity: Opportunity;
+  let deal: Deal;
+  let accompanying: Accompanying;
+  let opportunityVolunteer: OpportunityVolunteer;
+  let comment: Comment;
+  let agentPerson: Person;
+  let coordinatorPerson: Person;
+  let agentCookie: string;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (delete) ${suffix}` }),
+    );
+    deal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    accompanying = await fastify.db.accompanyingRepository.save(
+      new Accompanying({
+        address: "Test Address",
+        name: "Test Refugee",
+        date: new Date(),
+      }),
+    );
+    opportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (delete) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.NEW,
+        agentId: agent.id,
+        dealId: deal.id,
+        accompanyingId: accompanying.id,
+      }),
+    );
+
+    const volunteerDeal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.VOLUNTEER, postcodeId: postcode.id }),
+    );
+    const volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    volunteer = await fastify.db.volunteerRepository.save(
+      new Volunteer({ dealId: volunteerDeal.id, personId: volunteerPerson.id }),
+    );
+    opportunityVolunteer = await fastify.db.opportunityVolunteerRepository.save(
+      new OpportunityVolunteer({
+        opportunityId: opportunity.id,
+        volunteerId: volunteer.id,
+        status: OpportunityVolunteerStatusType.MATCHED,
+      }),
+    );
+
+    const language = await fastify.db.languageRepository.findOneOrFail({
+      where: {},
+    });
+    comment = await fastify.db.commentRepository.save(
+      new Comment({
+        text: "Test comment",
+        entityType: EntityTableName.OPPORTUNITY,
+        entityId: opportunity.id,
+        languageId: language.id,
+        userId: 0, // overwritten below once the coordinator user exists
+      }),
+    );
+
+    agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Agent" }),
+    );
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    const coordinatorUser = await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-del-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    await fastify.db.commentRepository.update(
+      { id: comment.id },
+      { userId: coordinatorUser.id },
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `agent-del-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({ agentId: agent.id, personId: agentPerson.id }),
+    );
+
+    const login = async (email: string): Promise<string> => {
+      const res = await fastify.inject({
+        method: "POST",
+        url: "/auth/login",
+        payload: { email, password: PASSWORD },
+      });
+      return getCookie(res.cookies, accessCookieName);
+    };
+
+    agentCookie = await login(`agent-del-${suffix}@test.need4deed.org`);
+    coordinatorCookie = await login(
+      `coordinator-del-${suffix}@test.need4deed.org`,
+    );
+  });
+
+  afterAll(async () => {
+    await fastify.db.agentPersonRepository.delete({
+      agentId: agent.id,
+      personId: agentPerson.id,
+    });
+    await fastify.db.userRepository.delete({ personId: agentPerson.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: agentPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    // opportunity/deal/accompanying/comment/opportunityVolunteer/volunteer are
+    // deleted by the DELETE /opportunity/:id call itself in the tests below;
+    // these are best-effort in case a test fails before reaching that point.
+    await fastify.db.opportunityVolunteerRepository.delete({
+      id: opportunityVolunteer.id,
+    });
+    await fastify.db.commentRepository.delete({ id: comment.id });
+    await fastify.db.opportunityRepository.delete({ id: opportunity.id });
+    await fastify.db.dealRepository.delete({ id: deal.id });
+    await fastify.db.accompanyingRepository.delete({ id: accompanying.id });
+    await fastify.db.volunteerRepository.delete({ id: volunteer.id });
+    await fastify.close();
+  });
+
+  it("403s when a non-coordinator tries to delete an opportunity", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/opportunity/${opportunity.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("404s for a nonexistent opportunity", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/opportunity/999999999`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("lets a coordinator delete an opportunity, cascading its deal, accompanying, comments, and match link", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/opportunity/${opportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    expect(
+      await fastify.db.opportunityRepository.findOneBy({ id: opportunity.id }),
+    ).toBeNull();
+    expect(
+      await fastify.db.dealRepository.findOneBy({ id: deal.id }),
+    ).toBeNull();
+    expect(
+      await fastify.db.accompanyingRepository.findOneBy({
+        id: accompanying.id,
+      }),
+    ).toBeNull();
+    expect(
+      await fastify.db.commentRepository.findOneBy({ id: comment.id }),
+    ).toBeNull();
+    expect(
+      await fastify.db.opportunityVolunteerRepository.findOneBy({
+        id: opportunityVolunteer.id,
+      }),
+    ).toBeNull();
+
+    // The linked volunteer itself is untouched by an opportunity delete.
+    expect(
+      await fastify.db.volunteerRepository.findOneBy({ id: volunteer.id }),
+    ).not.toBeNull();
   });
 });

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -5,6 +5,7 @@ import {
   OpportunityType,
   OpportunityVolunteerStatusType,
   UserRole,
+  VolunteerStateMatchType,
 } from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accessCookieName } from "../../../config/constants";
@@ -319,6 +320,14 @@ describe("DELETE /opportunity/:id", () => {
         status: OpportunityVolunteerStatusType.MATCHED,
       }),
     );
+    // Set deterministically rather than relying on OpportunityVolunteer's
+    // fire-and-forget @AfterInsert hook (updateVolunteerMatching isn't
+    // awaited there), so the "before" state for the recompute assertion
+    // below isn't a race.
+    await fastify.db.volunteerRepository.update(
+      { id: volunteer.id },
+      { statusMatch: VolunteerStateMatchType.MATCHED },
+    );
 
     const language = await fastify.db.languageRepository.findOneOrFail({
       where: {},
@@ -452,9 +461,16 @@ describe("DELETE /opportunity/:id", () => {
       }),
     ).toBeNull();
 
-    // The linked volunteer itself is untouched by an opportunity delete.
-    expect(
-      await fastify.db.volunteerRepository.findOneBy({ id: volunteer.id }),
-    ).not.toBeNull();
+    // The linked volunteer itself is untouched by an opportunity delete, but
+    // its match status is recomputed now that the match link is gone —
+    // confirming the deleted OpportunityVolunteer's cascade (which bypasses
+    // its own @AfterRemove hook) doesn't leave the volunteer stuck at MATCHED.
+    const survivingVolunteer = await fastify.db.volunteerRepository.findOneBy({
+      id: volunteer.id,
+    });
+    expect(survivingVolunteer).not.toBeNull();
+    expect(survivingVolunteer?.statusMatch).toBe(
+      VolunteerStateMatchType.NEEDS_REMATCH,
+    );
   });
 });

--- a/src/test/server/routes/volunteer.routes.test.ts
+++ b/src/test/server/routes/volunteer.routes.test.ts
@@ -1,0 +1,169 @@
+import { FastifyInstance } from "fastify";
+import { EntityTableName, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import Comment from "../../../data/entity/comment.entity";
+import Deal from "../../../data/entity/deal.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
+import { DealType } from "../../../data/types";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("DELETE /volunteer/:id", () => {
+  let fastify: FastifyInstance;
+
+  let deal: Deal;
+  let volunteerPerson: Person;
+  let volunteer: Volunteer;
+  let comment: Comment;
+  let agentPerson: Person;
+  let coordinatorPerson: Person;
+  let agentCookie: string;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+    const language = await fastify.db.languageRepository.findOneOrFail({
+      where: {},
+    });
+
+    deal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.VOLUNTEER, postcodeId: postcode.id }),
+    );
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    volunteer = await fastify.db.volunteerRepository.save(
+      new Volunteer({ dealId: deal.id, personId: volunteerPerson.id }),
+    );
+
+    agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Agent" }),
+    );
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    const coordinatorUser = await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-vol-del-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `agent-vol-del-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
+
+    comment = await fastify.db.commentRepository.save(
+      new Comment({
+        text: "Test comment",
+        entityType: EntityTableName.VOLUNTEER,
+        entityId: volunteer.id,
+        languageId: language.id,
+        userId: coordinatorUser.id,
+      }),
+    );
+
+    const login = async (email: string): Promise<string> => {
+      const res = await fastify.inject({
+        method: "POST",
+        url: "/auth/login",
+        payload: { email, password: PASSWORD },
+      });
+      return getCookie(res.cookies, accessCookieName);
+    };
+
+    agentCookie = await login(`agent-vol-del-${suffix}@test.need4deed.org`);
+    coordinatorCookie = await login(
+      `coordinator-vol-del-${suffix}@test.need4deed.org`,
+    );
+  });
+
+  afterAll(async () => {
+    await fastify.db.userRepository.delete({ personId: agentPerson.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: agentPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    // volunteer/deal/comment are deleted by the DELETE /volunteer/:id call
+    // itself in the tests below; these are best-effort in case a test fails
+    // before reaching that point.
+    await fastify.db.commentRepository.delete({ id: comment.id });
+    await fastify.db.volunteerRepository.delete({ id: volunteer.id });
+    await fastify.db.dealRepository.delete({ id: deal.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.close();
+  });
+
+  it("403s when a non-coordinator tries to delete a volunteer", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/volunteer/${volunteer.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("404s for a nonexistent volunteer", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/volunteer/999999999`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("lets a coordinator delete a volunteer, cascading its deal and comments", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/volunteer/${volunteer.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    expect(
+      await fastify.db.volunteerRepository.findOneBy({ id: volunteer.id }),
+    ).toBeNull();
+    expect(
+      await fastify.db.dealRepository.findOneBy({ id: deal.id }),
+    ).toBeNull();
+    expect(
+      await fastify.db.commentRepository.findOneBy({ id: comment.id }),
+    ).toBeNull();
+
+    // The underlying Person is untouched by a volunteer delete.
+    expect(
+      await fastify.db.personRepository.findOneBy({ id: volunteerPerson.id }),
+    ).not.toBeNull();
+  });
+});

--- a/src/test/server/routes/volunteer.routes.test.ts
+++ b/src/test/server/routes/volunteer.routes.test.ts
@@ -1,9 +1,18 @@
 import { FastifyInstance } from "fastify";
-import { EntityTableName, UserRole } from "need4deed-sdk";
+import {
+  EntityTableName,
+  OpportunityMatchStatusType,
+  OpportunityStatusType,
+  OpportunityType,
+  OpportunityVolunteerStatusType,
+  UserRole,
+} from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accessCookieName } from "../../../config/constants";
 import Comment from "../../../data/entity/comment.entity";
 import Deal from "../../../data/entity/deal.entity";
+import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
 import User from "../../../data/entity/user.entity";
 import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
@@ -31,6 +40,9 @@ describe("DELETE /volunteer/:id", () => {
   let volunteerPerson: Person;
   let volunteer: Volunteer;
   let comment: Comment;
+  let opportunityDeal: Deal;
+  let opportunity: Opportunity;
+  let opportunityVolunteer: OpportunityVolunteer;
   let agentPerson: Person;
   let coordinatorPerson: Person;
   let agentCookie: string;
@@ -56,6 +68,33 @@ describe("DELETE /volunteer/:id", () => {
     );
     volunteer = await fastify.db.volunteerRepository.save(
       new Volunteer({ dealId: deal.id, personId: volunteerPerson.id }),
+    );
+
+    opportunityDeal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    opportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (vol delete) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.NEW,
+        dealId: opportunityDeal.id,
+      }),
+    );
+    opportunityVolunteer = await fastify.db.opportunityVolunteerRepository.save(
+      new OpportunityVolunteer({
+        opportunityId: opportunity.id,
+        volunteerId: volunteer.id,
+        status: OpportunityVolunteerStatusType.MATCHED,
+      }),
+    );
+    // Set deterministically rather than relying on OpportunityVolunteer's
+    // fire-and-forget @AfterInsert hook (updateOpportunityMatching isn't
+    // awaited there), so the "before" state for the recompute assertion
+    // below isn't a race.
+    await fastify.db.opportunityRepository.update(
+      { id: opportunity.id },
+      { statusMatch: OpportunityMatchStatusType.MATCHED },
     );
 
     agentPerson = await fastify.db.personRepository.save(
@@ -115,13 +154,18 @@ describe("DELETE /volunteer/:id", () => {
     await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
     await fastify.db.personRepository.delete({ id: agentPerson.id });
     await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
-    // volunteer/deal/comment are deleted by the DELETE /volunteer/:id call
-    // itself in the tests below; these are best-effort in case a test fails
-    // before reaching that point.
+    // volunteer/deal/comment/opportunityVolunteer are deleted by the
+    // DELETE /volunteer/:id call itself in the tests below; these are
+    // best-effort in case a test fails before reaching that point.
+    await fastify.db.opportunityVolunteerRepository.delete({
+      id: opportunityVolunteer.id,
+    });
     await fastify.db.commentRepository.delete({ id: comment.id });
     await fastify.db.volunteerRepository.delete({ id: volunteer.id });
     await fastify.db.dealRepository.delete({ id: deal.id });
     await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.db.opportunityRepository.delete({ id: opportunity.id });
+    await fastify.db.dealRepository.delete({ id: opportunityDeal.id });
     await fastify.close();
   });
 
@@ -143,7 +187,7 @@ describe("DELETE /volunteer/:id", () => {
     expect(res.statusCode).toBe(404);
   });
 
-  it("lets a coordinator delete a volunteer, cascading its deal and comments", async () => {
+  it("lets a coordinator delete a volunteer, cascading its deal, comments, and match link", async () => {
     const res = await fastify.inject({
       method: "DELETE",
       url: `/volunteer/${volunteer.id}`,
@@ -160,10 +204,28 @@ describe("DELETE /volunteer/:id", () => {
     expect(
       await fastify.db.commentRepository.findOneBy({ id: comment.id }),
     ).toBeNull();
+    expect(
+      await fastify.db.opportunityVolunteerRepository.findOneBy({
+        id: opportunityVolunteer.id,
+      }),
+    ).toBeNull();
 
     // The underlying Person is untouched by a volunteer delete.
     expect(
       await fastify.db.personRepository.findOneBy({ id: volunteerPerson.id }),
     ).not.toBeNull();
+
+    // The linked opportunity's match status is recomputed now that the
+    // match link is gone — confirming the deleted OpportunityVolunteer's
+    // cascade (which bypasses its own @AfterRemove hook) doesn't leave the
+    // opportunity stuck at MATCHED.
+    const survivingOpportunity =
+      await fastify.db.opportunityRepository.findOneBy({
+        id: opportunity.id,
+      });
+    expect(survivingOpportunity).not.toBeNull();
+    expect(survivingOpportunity?.statusMatch).toBe(
+      OpportunityMatchStatusType.NEEDS_REMATCH,
+    );
   });
 });


### PR DESCRIPTION
## Summary
Backend half of [need4deed-org/fe#863](https://github.com/need4deed-org/fe/issues/863) — closes [#787](https://github.com/need4deed-org/be/issues/787).

Adds two new COORDINATOR-only hard-delete routes, mirroring the existing `DELETE /agent/:id`:
- `DELETE /opportunity/:id`
- `DELETE /volunteer/:id`

No SDK change was needed — neither route takes a body, and the response reuses the existing local `ReplyMessage` (`{ message: string }`) shape already used by `DELETE /agent/:id` and other delete routes, not an SDK type.

## Cascade/orphan handling
Traced every FK from `Opportunity`/`Volunteer` before deciding what needs explicit cleanup vs. what the DB already cascades:
- `OpportunityVolunteer` (+ its `ActivityLog`), `Communication`, and `Appreciation` all already have `onDelete: "CASCADE"` — no extra code needed.
- `Comment` is polymorphic (`entityType`/`entityId`, no real FK), so it's **not** covered by any cascade — deleted explicitly in both routes.
- `Deal` is minted fresh per-Opportunity/per-Volunteer at creation (never shared), so it — and, for Opportunity, the associated `Accompanying` row — is deleted alongside in the same transaction rather than left as a permanent orphan. `Deal`'s own m2m children (`DealActivity`/`DealLanguage`/`DealSkill`/`DealTimeslot`/`DealDistrict`) already cascade off `Deal`.
- `Document` (volunteer uploads) already cascades off `Volunteer`; consistent with the existing `DELETE /volunteer/:id/doc` route, no S3 object cleanup is attempted (same as that route today).
- `Person`/`AgentPerson` memberships are intentionally left untouched, consistent with the existing `DELETE /agent/:id` precedent — a Person can be linked to other roles/entities.

## Transfer-to-another-NGO — no backend change
Verified `PATCH /opportunity/:id` with `agent.id` already fully implements "transfer this opportunity to another NGO" (single-column `agentId` update; neither `Deal` nor `OpportunityVolunteer` reference `Agent` directly). Also verified — and added a regression test for — the concern raised in #787: an AGENT can't reach that relink branch by including `agent.id` in their own PATCH payload, because the existing `disallowedKeys` check on that route only permits `statusOpportunity` for non-coordinators. No code change needed there, just test coverage.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — clean on all files touched by this PR (pre-existing lint errors elsewhere in the repo are unrelated)
- [x] New tests added: `DELETE /opportunity/:id` (403 for non-coordinator, 404 for missing id, successful delete + cascade assertions for deal/accompanying/comment/match-link), `DELETE /volunteer/:id` (same shape), plus the agent-relink-authorization regression test
- [ ] Full suite not run in this environment (no local Postgres/Docker available) — all new/modified tests are structurally verified (discovered correctly by vitest, fail only on `ECONNREFUSED 127.0.0.1:5432` in `beforeAll`, no code-level errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)