### PR TITLE
fix: make yarn migration:run self-heal on a fresh database

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typeorm": "typeorm-ts-node-commonjs -d src/data/data-source.ts",
     "migration:generate": "yarn typeorm migration:generate",
     "migration:create": "yarn typeorm-ts-node-commonjs migration:create",
-    "migration:run": "yarn typeorm migration:run",
+    "migration:run": "ts-node src/data/run-migrations.ts",
     "migration:revert": "yarn typeorm migration:revert",
     "migration:show": "yarn typeorm migration:show",
     "build": "tsc",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -41,7 +41,7 @@ const ALREADY_EXISTS_CODES = new Set(["42710", "42P07", "42P16"]);
 // treat that as proof the schema is already there and just backfill genesis's
 // own tracking row instead of re-attempting its DDL — this is the same fix
 // applied manually to the pre/production incidents this covers.
-async function bootstrapFreshDb(): Promise<void> {
+export async function bootstrapFreshDb(): Promise<void> {
   const qr = dataSource.createQueryRunner();
   try {
     await qr.query(`

--- a/src/data/run-migrations.ts
+++ b/src/data/run-migrations.ts
@@ -1,0 +1,33 @@
+import "reflect-metadata";
+import { bootstrapFreshDb } from ".";
+import logger from "../logger";
+import { dataSource } from "./data-source";
+
+// The plain TypeORM CLI (`typeorm migration:run`) reads the list of pending
+// migrations before genesis's self-registration commits, so on a fresh
+// database it still tries to replay migrations genesis already superseded.
+// bootstrapFreshDb() (used by the real app startup path) closes that gap by
+// running first and committing genesis's tracking row before TypeORM looks.
+async function main() {
+  await dataSource.initialize();
+  try {
+    await bootstrapFreshDb();
+    const executed = await dataSource.runMigrations();
+    if (executed.length === 0) {
+      logger.info("No migrations are pending");
+    } else {
+      for (const migration of executed) {
+        logger.info(
+          `Migration ${migration.name} has been executed successfully.`,
+        );
+      }
+    }
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- `yarn migration:run` used the raw TypeORM CLI, which computes the pending-migrations list before genesis's self-registration commits — on a genuinely fresh database it still tries to replay migrations genesis already superseded and fails on the first one after it (`AddConfigDropVolunteerListMv1763036250587`, `type "config_config_key_enum" already exists`).
- `bootstrapFreshDb()` already solves this for the real app startup path (`initDatabase()`), but that logic wasn't reachable from the CLI.
- Exported `bootstrapFreshDb` and added `src/data/run-migrations.ts`, which runs it before `dataSource.runMigrations()`. Repointed the `migration:run` script at this wrapper instead of the bare `typeorm migration:run`.

## Test plan
- [x] Full fresh rebuild (`docker compose down -v && RUN_MIGRATIONS=1 docker compose up`) — genesis self-heals correctly, migrations apply cleanly, seed data populates fully
- [x] `yarn migration:run` verified idempotent on an already-migrated database ("No migrations are pending")
- [x] Full test suite passes: 454/454 (`yarn test:run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)