### PR TITLE
fix: allow active AgentPerson members to edit their agent's org details

### DIFF
--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -1,6 +1,15 @@
-import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiAgentPatch, SortOrder, UserRole } from "need4deed-sdk";
-import { BadRequestError, NotFoundError } from "../../../config";
+import { FastifyInstance, FastifyPluginOptions, FastifyRequest } from "fastify";
+import {
+  AgentMembershipStatus,
+  ApiAgentPatch,
+  SortOrder,
+  UserRole,
+} from "need4deed-sdk";
+import {
+  BadRequestError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../../config";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import logger from "../../../logger";
 import {
@@ -38,13 +47,56 @@ import agentContactRoutes from "./contact.routes";
 import agentMembershipRoutes from "./membership.routes";
 import agentRegisterRoutes from "./register.routes";
 
+// Mirrors the role allowlist in contact.routes.ts: only these three roles may
+// reach the membership check. Cheap (no DB), so it runs before the
+// agent-existence check.
+function assertHasOrgEditRole(request: FastifyRequest): void {
+  const role = request.authUser?.role;
+  if (
+    role !== UserRole.COORDINATOR &&
+    role !== UserRole.AGENT &&
+    role !== UserRole.ADMIN
+  ) {
+    throw new UnauthorizedError();
+  }
+}
+
+// Coordinator/admin may edit any agent; an AGENT must be an active member of
+// this specific agent. Run this *after* the 404 check for the agent itself,
+// so a non-member probing a nonexistent agent id still gets 404 rather than
+// a 403 that changes already-established error-code semantics.
+async function assertCanEditOrg(
+  fastify: FastifyInstance,
+  request: FastifyRequest,
+  agentId: number,
+): Promise<void> {
+  const role = request.authUser?.role;
+  if (role === UserRole.COORDINATOR || role === UserRole.ADMIN) {
+    return;
+  }
+
+  const personId = request.authUser?.personId;
+  const membership = personId
+    ? await fastify.db.agentPersonRepository.findOneBy({
+        agentId,
+        personId,
+        status: AgentMembershipStatus.ACTIVE,
+      })
+    : null;
+  if (!membership) {
+    throw new UnauthorizedError(
+      "Only active members of this agent can edit its organization details.",
+    );
+  }
+}
+
 export default async function agentRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
 ) {
   // GETs are open to any logged-in user (PII is masked per role in the
-  // preSerialization hooks below); writes stay COORDINATOR-only (re-gated
-  // per-route).
+  // preSerialization hooks below); writes are re-gated per-route: DELETE
+  // stays COORDINATOR-only, PATCH also allows an active AgentPerson member.
   fastify.addHook("onRequest", fastify.authenticate());
 
   fastify.register(agentRegisterRoutes, { prefix: RoutePrefix.REGISTER });
@@ -170,7 +222,6 @@ export default async function agentRoutes(
   fastify.patch<{ Params: ParamsId; Body: ApiAgentPatch; Reply: null }>(
     "/:id",
     {
-      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
       schema: {
         params: idParamSchema,
         body: { $ref: "ApiAgentPatch#" },
@@ -180,12 +231,17 @@ export default async function agentRoutes(
     async (request, reply) => {
       const { id } = request.params;
       logger.debug(`PATCH /agent/${id}, fields:${Object.keys(request.body)}`);
+
+      assertHasOrgEditRole(request);
+
       const agentRepository = fastify.db.agentRepository;
       const agent = await agentRepository.findOneBy({ id });
 
       if (!agent) {
         throw new NotFoundError(`Agent (id:${id}) not found.`);
       }
+
+      await assertCanEditOrg(fastify, request, id);
 
       const { addressStreet, addressPostcode, languages } = request.body;
 

--- a/src/test/server/routes/agent.routes.test.ts
+++ b/src/test/server/routes/agent.routes.test.ts
@@ -1,0 +1,214 @@
+import { FastifyInstance } from "fastify";
+import { AgentMembershipStatus, AgentRoleType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("PATCH /agent/:id organization details", () => {
+  let fastify: FastifyInstance;
+
+  let agent: Agent;
+  let memberPerson: Person;
+  let pendingPerson: Person;
+
+  let memberCookie: string;
+  let pendingCookie: string;
+  let nonMemberCookie: string;
+  let plainUserCookie: string;
+  let coordinatorCookie: string;
+  let adminCookie: string;
+
+  const personIds: number[] = [];
+
+  async function login(email: string): Promise<string> {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email, password: PASSWORD },
+    });
+    return getCookie(res.cookies, accessCookieName);
+  }
+
+  async function createUser(
+    label: string,
+    role: UserRole,
+    suffix: string,
+  ): Promise<{ person: Person; email: string }> {
+    const person = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: label }),
+    );
+    personIds.push(person.id);
+    const email = `${label.toLowerCase()}-${suffix}@test.need4deed.org`;
+    await fastify.db.userRepository.save(
+      new User({
+        email,
+        password: await hashPassword(PASSWORD),
+        role,
+        isActive: true,
+        personId: person.id,
+      }),
+    );
+    return { person, email };
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent ${suffix}` }),
+    );
+
+    const member = await createUser("Member", UserRole.AGENT, suffix);
+    memberPerson = member.person;
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: agent.id,
+        personId: memberPerson.id,
+        role: AgentRoleType.VOLUNTEER_COORDINATOR,
+        status: AgentMembershipStatus.ACTIVE,
+      }),
+    );
+
+    const pending = await createUser("Pending", UserRole.AGENT, suffix);
+    pendingPerson = pending.person;
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: agent.id,
+        personId: pendingPerson.id,
+        role: AgentRoleType.VOLUNTEER_COORDINATOR,
+        status: AgentMembershipStatus.PENDING,
+      }),
+    );
+
+    const nonMember = await createUser("NonMember", UserRole.AGENT, suffix);
+    const plainUser = await createUser("Plain", UserRole.USER, suffix);
+    const coordinator = await createUser(
+      "Coordinator",
+      UserRole.COORDINATOR,
+      suffix,
+    );
+    const admin = await createUser("Admin", UserRole.ADMIN, suffix);
+
+    memberCookie = await login(member.email);
+    pendingCookie = await login(pending.email);
+    nonMemberCookie = await login(nonMember.email);
+    plainUserCookie = await login(plainUser.email);
+    coordinatorCookie = await login(coordinator.email);
+    adminCookie = await login(admin.email);
+  });
+
+  afterAll(async () => {
+    await fastify.db.agentPersonRepository.delete({ agentId: agent.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    for (const personId of personIds) {
+      await fastify.db.userRepository.delete({ personId });
+      await fastify.db.personRepository.delete({ id: personId });
+    }
+    await fastify.close();
+  });
+
+  it("rejects an unauthenticated request", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      payload: { title: "Nope" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects a plain USER-role caller", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: plainUserCookie },
+      payload: { title: "Nope" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects an AGENT-role caller with no membership at this agent", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: nonMemberCookie },
+      payload: { title: "Nope" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects an AGENT-role caller with only a PENDING membership", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: pendingCookie },
+      payload: { title: "Nope" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("404s for a nonexistent agent id even with a valid AGENT-role caller", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/999999999`,
+      cookies: { [accessCookieName]: memberCookie },
+      payload: { title: "Nope" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("allows an AGENT-role caller with an ACTIVE membership to edit org details", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: memberCookie },
+      payload: { title: `Updated by member ${agent.id}` },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.agentRepository.findOneByOrFail({
+      id: agent.id,
+    });
+    expect(updated.title).toBe(`Updated by member ${agent.id}`);
+  });
+
+  it("allows a COORDINATOR to edit org details regardless of membership", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { title: `Updated by coordinator ${agent.id}` },
+    });
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("allows an ADMIN to edit org details regardless of membership", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: adminCookie },
+      payload: { title: `Updated by admin ${agent.id}` },
+    });
+    expect(res.statusCode).toBe(204);
+  });
+});

--- a/src/test/server/routes/agent.routes.test.ts
+++ b/src/test/server/routes/agent.routes.test.ts
@@ -26,6 +26,7 @@ describe("PATCH /agent/:id organization details", () => {
   let fastify: FastifyInstance;
 
   let agent: Agent;
+  let otherAgent: Agent;
   let memberPerson: Person;
   let pendingPerson: Person;
 
@@ -35,8 +36,11 @@ describe("PATCH /agent/:id organization details", () => {
   let plainUserCookie: string;
   let coordinatorCookie: string;
   let adminCookie: string;
+  let otherAgentMemberCookie: string;
+  let noPersonCookie: string;
 
   const personIds: number[] = [];
+  const orphanUserIds: number[] = [];
 
   async function login(email: string): Promise<string> {
     const res = await fastify.inject({
@@ -67,6 +71,27 @@ describe("PATCH /agent/:id organization details", () => {
       }),
     );
     return { person, email };
+  }
+
+  // AGENT-role user with no linked Person at all (data-integrity edge case,
+  // not something the registration flow produces, but the handler must not
+  // crash and must deny rather than throw).
+  async function createUserWithoutPerson(
+    label: string,
+    role: UserRole,
+    suffix: string,
+  ): Promise<{ email: string }> {
+    const email = `${label.toLowerCase()}-${suffix}@test.need4deed.org`;
+    const user = await fastify.db.userRepository.save(
+      new User({
+        email,
+        password: await hashPassword(PASSWORD),
+        role,
+        isActive: true,
+      }),
+    );
+    orphanUserIds.push(user.id);
+    return { email };
   }
 
   beforeAll(async () => {
@@ -110,20 +135,50 @@ describe("PATCH /agent/:id organization details", () => {
     );
     const admin = await createUser("Admin", UserRole.ADMIN, suffix);
 
+    otherAgent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Other Agent ${suffix}` }),
+    );
+    const otherAgentMember = await createUser(
+      "OtherAgentMember",
+      UserRole.AGENT,
+      suffix,
+    );
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: otherAgent.id,
+        personId: otherAgentMember.person.id,
+        role: AgentRoleType.VOLUNTEER_COORDINATOR,
+        status: AgentMembershipStatus.ACTIVE,
+      }),
+    );
+
+    const noPerson = await createUserWithoutPerson(
+      "NoPerson",
+      UserRole.AGENT,
+      suffix,
+    );
+
     memberCookie = await login(member.email);
     pendingCookie = await login(pending.email);
     nonMemberCookie = await login(nonMember.email);
     plainUserCookie = await login(plainUser.email);
     coordinatorCookie = await login(coordinator.email);
     adminCookie = await login(admin.email);
+    otherAgentMemberCookie = await login(otherAgentMember.email);
+    noPersonCookie = await login(noPerson.email);
   });
 
   afterAll(async () => {
     await fastify.db.agentPersonRepository.delete({ agentId: agent.id });
     await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.db.agentPersonRepository.delete({ agentId: otherAgent.id });
+    await fastify.db.agentRepository.delete({ id: otherAgent.id });
     for (const personId of personIds) {
       await fastify.db.userRepository.delete({ personId });
       await fastify.db.personRepository.delete({ id: personId });
+    }
+    for (const userId of orphanUserIds) {
+      await fastify.db.userRepository.delete({ id: userId });
     }
     await fastify.close();
   });
@@ -162,6 +217,26 @@ describe("PATCH /agent/:id organization details", () => {
       method: "PATCH",
       url: `/agent/${agent.id}`,
       cookies: { [accessCookieName]: pendingCookie },
+      payload: { title: "Nope" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects an AGENT-role caller who is only an ACTIVE member of a different agent", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: otherAgentMemberCookie },
+      payload: { title: "Nope" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects an AGENT-role caller with no linked person", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: noPersonCookie },
       payload: { title: "Nope" },
     });
     expect(res.statusCode).toBe(403);


### PR DESCRIPTION
## Summary
- `PATCH /agent/:id` was gated `role: UserRole.COORDINATOR` only, so an AGENT-role user whose `Person` is m2m-linked (via `AgentPerson`) to that specific center had no way to edit their own org's details.
- Adds a role allow-list (`COORDINATOR | AGENT | ADMIN`) plus an active-membership check (`agentPersonRepository.findOneBy({ agentId, personId, status: ACTIVE })`), mirroring the existing pattern in `contact.routes.ts`. Ordering keeps 404-before-403 so a non-member probing a nonexistent agent id still gets 404.
- `DELETE /agent/:id` is intentionally left COORDINATOR/ADMIN-only — out of scope.

Closes #792

## Test plan
- [x] New `src/test/server/routes/agent.routes.test.ts`: unauthenticated → 401, plain USER → 403, AGENT non-member → 403, AGENT with only PENDING membership → 403, nonexistent agent id → 404, AGENT with ACTIVE membership → 204 (and change persists), COORDINATOR → 204, ADMIN → 204
- [x] `yarn typecheck` — no new errors (pre-existing unrelated errors in `dto-opportunity.test.ts` confirmed present on `develop` too)
- [x] `yarn lint` — no new issues in changed files
- [x] `yarn test:run` — 54 files / 462 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)