### PR TITLE
feat: normalize Agent.type/services into translated reference data

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.133",
+    "need4deed-sdk": "0.0.136",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/data/data-source.ts
+++ b/src/data/data-source.ts
@@ -18,6 +18,7 @@ import ActivityLog from "./entity/m2m/activity-log.entity";
 import AgentLanguage from "./entity/m2m/agent-language";
 import AgentPerson from "./entity/m2m/agent-person";
 import AgentPostcode from "./entity/m2m/agent-postcode";
+import AgentService from "./entity/m2m/agent-service";
 import CommentPerson from "./entity/m2m/comment-person";
 import DealActivity from "./entity/m2m/deal-activity";
 import DealDistrict from "./entity/m2m/deal-district";
@@ -35,8 +36,10 @@ import Organization from "./entity/organization.entity";
 import Person from "./entity/person.entity";
 import Post from "./entity/post.entity";
 import Activity from "./entity/profile/activity.entity";
+import AgentType from "./entity/profile/agent-type.entity";
 import Category from "./entity/profile/category.entity";
 import Language from "./entity/profile/language.entity";
+import Service from "./entity/profile/service.entity";
 import Skill from "./entity/profile/skill.entity";
 import Testimonial from "./entity/testimonial.entity";
 import Timeslot from "./entity/time/timeslot.entity";
@@ -68,6 +71,8 @@ export const dataSource = new DataSource({
     AgentLanguage,
     AgentPerson,
     AgentPostcode,
+    AgentService,
+    AgentType,
     Appreciation,
     Category,
     Comment,
@@ -96,6 +101,7 @@ export const dataSource = new DataSource({
     Post,
     Postcode,
     Option,
+    Service,
     Skill,
     Testimonial,
     Timeline,

--- a/src/data/entity/m2m/agent-service.ts
+++ b/src/data/entity/m2m/agent-service.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from "typeorm";
+import Agent from "../opportunity/agent.entity";
+import Service from "../profile/service.entity";
+
+@Entity()
+@Unique(["agentId", "serviceId"])
+export default class AgentService {
+  constructor(agentService?: Partial<AgentService>) {
+    if (agentService) {
+      Object.assign(this, agentService);
+    }
+  }
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Agent, (agent) => agent.agentService, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "agent_id" })
+  agent: Agent;
+
+  @Column()
+  agentId: number;
+
+  @ManyToOne(() => Service, (service) => service.agentService, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "service_id" })
+  service: Service;
+
+  @Column()
+  serviceId: number;
+}

--- a/src/data/entity/opportunity/agent.entity.ts
+++ b/src/data/entity/opportunity/agent.entity.ts
@@ -1,10 +1,8 @@
-import { IsArray, IsEnum, IsOptional, IsString } from "class-validator";
+import { IsOptional, IsString } from "class-validator";
 import {
   AgentEngagementStatusType,
   AgentRoleType,
-  AgentServiceType,
   AgentTrustType,
-  AgentType,
   AgentVolunteerSearchType,
   OpportunityVolunteerStatusType,
 } from "need4deed-sdk";
@@ -23,7 +21,9 @@ import District from "../location/district.entity";
 import AgentLanguage from "../m2m/agent-language";
 import AgentPerson from "../m2m/agent-person";
 import AgentPostcode from "../m2m/agent-postcode";
+import AgentService from "../m2m/agent-service";
 import Organization from "../organization.entity";
+import AgentType from "../profile/agent-type.entity";
 import Opportunity from "./opportunity.entity";
 
 @Entity()
@@ -48,14 +48,12 @@ export default class Agent {
   @IsString()
   website?: string;
 
-  @Column({
-    type: "enum",
-    enum: AgentType,
-    nullable: true,
-  })
-  @IsOptional()
-  @IsEnum(AgentType)
-  type?: AgentType;
+  @ManyToOne(() => AgentType, (agentType) => agentType.agent)
+  @JoinColumn({ name: "agent_type_id" })
+  agentType: AgentType;
+
+  @Column({ nullable: true })
+  agentTypeId?: number;
 
   @Column({
     type: "enum",
@@ -77,20 +75,6 @@ export default class Agent {
     default: AgentEngagementStatusType.NEW,
   })
   engagementStatus: AgentEngagementStatusType;
-
-  @Column({
-    type: "text",
-    array: true,
-    transformer: {
-      to: (value: AgentServiceType[]) => value,
-      from: (value: unknown) => value as AgentServiceType[],
-    },
-    nullable: true,
-  })
-  @IsOptional()
-  @IsArray()
-  @IsEnum(AgentServiceType, { each: true })
-  services: AgentServiceType[];
 
   @CreateDateColumn()
   createdAt: Date;
@@ -130,6 +114,9 @@ export default class Agent {
 
   @OneToMany(() => AgentLanguage, (agentLanguage) => agentLanguage.agent)
   agentLanguage: AgentLanguage[];
+
+  @OneToMany(() => AgentService, (agentService) => agentService.agent)
+  agentService: AgentService[];
 
   get representative(): AgentPerson {
     let representative = this.agentPerson?.find(

--- a/src/data/entity/profile/agent-type.entity.ts
+++ b/src/data/entity/profile/agent-type.entity.ts
@@ -1,0 +1,26 @@
+import { IsNotEmpty, IsString, Length } from "class-validator";
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import Agent from "../opportunity/agent.entity";
+
+@Entity()
+export default class AgentType {
+  constructor(agentType?: Partial<AgentType>) {
+    if (agentType) {
+      Object.assign(this, agentType);
+    }
+  }
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  @IsNotEmpty()
+  @IsString()
+  @Length(100)
+  title: string;
+
+  @OneToMany(() => Agent, (agent) => agent.agentType)
+  agent: Agent[];
+
+  translation: string;
+}

--- a/src/data/entity/profile/agent-type.entity.ts
+++ b/src/data/entity/profile/agent-type.entity.ts
@@ -1,4 +1,5 @@
 import { IsNotEmpty, IsString, Length } from "class-validator";
+import { OptionTitle } from "need4deed-sdk";
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 import Agent from "../opportunity/agent.entity";
 
@@ -22,5 +23,8 @@ export default class AgentType {
   @OneToMany(() => Agent, (agent) => agent.agentType)
   agent: Agent[];
 
-  translation: string;
+  // Populated by getOptionTitleTranslations before serialization — unlike
+  // Skill/Language's single resolved `translation: string`, this needs both
+  // en and de at once to match the OptionById.title shape in a single response.
+  translations?: OptionTitle;
 }

--- a/src/data/entity/profile/service.entity.ts
+++ b/src/data/entity/profile/service.entity.ts
@@ -1,0 +1,26 @@
+import { IsNotEmpty, IsString, Length } from "class-validator";
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import AgentService from "../m2m/agent-service";
+
+@Entity()
+export default class Service {
+  constructor(service?: Partial<Service>) {
+    if (service) {
+      Object.assign(this, service);
+    }
+  }
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  @IsNotEmpty()
+  @IsString()
+  @Length(100)
+  title: string;
+
+  @OneToMany(() => AgentService, (agentService) => agentService.service)
+  agentService: AgentService[];
+
+  translation: string;
+}

--- a/src/data/entity/profile/service.entity.ts
+++ b/src/data/entity/profile/service.entity.ts
@@ -1,4 +1,5 @@
 import { IsNotEmpty, IsString, Length } from "class-validator";
+import { OptionTitle } from "need4deed-sdk";
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 import AgentService from "../m2m/agent-service";
 
@@ -22,5 +23,8 @@ export default class Service {
   @OneToMany(() => AgentService, (agentService) => agentService.service)
   agentService: AgentService[];
 
-  translation: string;
+  // Populated by getOptionTitleTranslations before serialization — see
+  // AgentType.translations for why this differs from Skill/Language's
+  // single resolved `translation: string`.
+  translations?: OptionTitle;
 }

--- a/src/data/migrations/1784898817413-add-agent-type-and-service.ts
+++ b/src/data/migrations/1784898817413-add-agent-type-and-service.ts
@@ -1,22 +1,26 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-// Canonical seed values, snapshotted as literals from need4deed-sdk's
-// AgentTypeKey/AgentServiceType enums at the time this migration was
-// written. Deliberately NOT imported from the SDK — an enum value can change
+// Canonical seed values. The original 10 agent_type / 10 service titles are
+// literals snapshotted from need4deed-sdk's AgentTypeKey/AgentServiceType
+// enums (deliberately NOT imported from the SDK — an enum value can change
 // with a later contract update, which would retroactively alter what this
-// migration emits on a fresh replay.
+// migration emits on a fresh replay). S/U, jobcenter, arzt, health and
+// education are additional categories with no SDK enum equivalent, added
+// directly as reference rows — the point of moving off a fixed enum onto a
+// table is that new categories no longer require an SDK release.
 const sqlSeedAgentType = `
 INSERT INTO "agent_type" ("title") VALUES
   ('AE'), ('GU1'), ('GU2'), ('GU2+'), ('GU3'), ('NU'), ('ASOG'),
+  ('S/U'), ('jobcenter'), ('arzt'),
   ('counseling-center'), ('tandem'), ('multiple-social-support')
 ON CONFLICT ("title") DO NOTHING;
 `;
 
 const sqlSeedService = `
 INSERT INTO "service" ("title") VALUES
-  ('childcare'), ('welfare'), ('consultation'), ('voluntary-support'),
+  ('childcare'), ('welfare'), ('health'), ('consultation'), ('voluntary-support'),
   ('tandem'), ('sport'), ('tutoring'), ('refugee-accommodation'),
-  ('job-coaching'), ('youth')
+  ('job-coaching'), ('youth'), ('education')
 ON CONFLICT ("title") DO NOTHING;
 `;
 
@@ -36,9 +40,10 @@ INNER JOIN "service" ON "service"."title" = "agent_service_title"
 ON CONFLICT ("agent_id", "service_id") DO NOTHING;
 `;
 
-// en/de labels below match what's already shipped in the fe dashboard
-// (AGENT_TYPE_LABELS/AGENT_SERVICE_LABELS + the filters.type/filters.services
-// i18n keys) rather than inventing new copy.
+// en/de labels below are the authoritative copy provided directly by the
+// product owner (not inferred from fe's prior placeholder labels). GU2+ has
+// no row of its own in that source data; per direction, it reuses GU2's
+// translations with "+" appended.
 const sqlSeedAgentTypeTranslations = `
 INSERT INTO "field_translation" (field_name, language_id, entity_type, entity_id, translation)
 SELECT
@@ -48,16 +53,19 @@ SELECT
   agent_type.id,
   CASE lang.iso_code WHEN 'en' THEN v.en_title ELSE v.de_title END
 FROM (VALUES
-  ('AE', 'AE', 'AE'),
-  ('GU1', 'GU1', 'GU1'),
-  ('GU2', 'GU2', 'GU2'),
-  ('GU2+', 'GU2+', 'GU2+'),
-  ('GU3', 'GU3', 'GU3'),
-  ('NU', 'NU', 'NU'),
-  ('ASOG', 'ASOG', 'ASOG'),
-  ('counseling-center', 'Counseling-center', 'Beratungsstelle'),
+  ('AE', 'Reception facility', 'Aufnahmeeinrichtung'),
+  ('GU1', 'shared accommodation 1', 'Gemeinschaftsunterkunft 1'),
+  ('GU2', 'shared accommodation 2', 'Gemeinschaftsunterkunft 2'),
+  ('GU2+', 'shared accommodation 2+', 'Gemeinschaftsunterkunft 2+'),
+  ('GU3', 'shared accommodation 3', 'Gemeinschaftsunterkunft 3'),
+  ('NU', 'Emergency shelter', 'Notunterkunft'),
+  ('ASOG', 'accommodation with no social support', 'ASOG'),
+  ('S/U', 'School', 'Schule/Uni'),
+  ('jobcenter', 'Jobcenter', 'Jobcenter'),
+  ('arzt', 'Doctor', 'Arzt'),
+  ('counseling-center', 'consultation center', 'Beratungsstelle'),
   ('tandem', 'Tandem', 'Tandem'),
-  ('multiple-social-support', 'Multiple-social-support', 'Allgemeine Sozialberatung')
+  ('multiple-social-support', 'multiple social support', 'Mehrere Soziale Leistungen')
 ) AS v(key, en_title, de_title)
 INNER JOIN "agent_type" ON "agent_type"."title" = v.key
 CROSS JOIN "language" lang
@@ -75,16 +83,18 @@ SELECT
   service.id,
   CASE lang.iso_code WHEN 'en' THEN v.en_title ELSE v.de_title END
 FROM (VALUES
-  ('childcare', 'Childcare', 'Kinderbetreuung'),
-  ('welfare', 'Welfare', 'Wohlfahrt'),
-  ('consultation', 'Consultation', 'Beratung'),
-  ('voluntary-support', 'Voluntary-support', 'Ehrenamtliche Unterstützung'),
-  ('tandem', 'Tandem', 'Tandem'),
-  ('sport', 'Sport', 'Sport'),
-  ('tutoring', 'Tutoring', 'Nachhilfe'),
-  ('refugee-accommodation', 'Refugee Accommodation', 'Unterkunft für Geflüchtete'),
-  ('job-coaching', 'Job-coaching', 'Job-Coaching'),
-  ('youth', 'Youth', 'Jugend')
+  ('childcare', 'childcare', 'Kinderbetreuung'),
+  ('welfare', 'welfare', 'Sozialhilfe'),
+  ('health', 'Health', 'Gesundheit'),
+  ('consultation', 'consultation', 'Beratung'),
+  ('voluntary-support', 'voluntary-support', 'Freiwilligenhilfe'),
+  ('tandem', 'tandem', 'Tandem'),
+  ('sport', 'sport', 'Sport'),
+  ('tutoring', 'tutoring', 'Nachhilfe'),
+  ('refugee-accommodation', 'refugee-accommodation', 'Flüchtlingsunterkunft'),
+  ('job-coaching', 'job-coaching', 'Jobcoaching'),
+  ('youth', 'youth', 'Jugendarbeit'),
+  ('education', 'Education', 'Bildung')
 ) AS v(key, en_title, de_title)
 INNER JOIN "service" ON "service"."title" = v.key
 CROSS JOIN "language" lang

--- a/src/data/migrations/1784898817413-add-agent-type-and-service.ts
+++ b/src/data/migrations/1784898817413-add-agent-type-and-service.ts
@@ -1,0 +1,423 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Canonical seed values, snapshotted as literals from need4deed-sdk's
+// AgentTypeKey/AgentServiceType enums at the time this migration was
+// written. Deliberately NOT imported from the SDK — an enum value can change
+// with a later contract update, which would retroactively alter what this
+// migration emits on a fresh replay.
+const sqlSeedAgentType = `
+INSERT INTO "agent_type" ("title") VALUES
+  ('AE'), ('GU1'), ('GU2'), ('GU2+'), ('GU3'), ('NU'), ('ASOG'),
+  ('counseling-center'), ('tandem'), ('multiple-social-support')
+ON CONFLICT ("title") DO NOTHING;
+`;
+
+const sqlSeedService = `
+INSERT INTO "service" ("title") VALUES
+  ('childcare'), ('welfare'), ('consultation'), ('voluntary-support'),
+  ('tandem'), ('sport'), ('tutoring'), ('refugee-accommodation'),
+  ('job-coaching'), ('youth')
+ON CONFLICT ("title") DO NOTHING;
+`;
+
+const sqlBackfillAgentTypeId = `
+UPDATE "agent"
+SET "agent_type_id" = "agent_type"."id"
+FROM "agent_type"
+WHERE "agent_type"."title" = "agent"."type"::text;
+`;
+
+const sqlBackfillAgentService = `
+INSERT INTO "agent_service" ("agent_id", "service_id")
+SELECT DISTINCT "agent"."id", "service"."id"
+FROM "agent"
+CROSS JOIN LATERAL unnest("agent"."services") AS "agent_service_title"
+INNER JOIN "service" ON "service"."title" = "agent_service_title"
+ON CONFLICT ("agent_id", "service_id") DO NOTHING;
+`;
+
+// en/de labels below match what's already shipped in the fe dashboard
+// (AGENT_TYPE_LABELS/AGENT_SERVICE_LABELS + the filters.type/filters.services
+// i18n keys) rather than inventing new copy.
+const sqlSeedAgentTypeTranslations = `
+INSERT INTO "field_translation" (field_name, language_id, entity_type, entity_id, translation)
+SELECT
+  'title'::varchar,
+  lang.id,
+  'agent_type'::field_translation_entity_type_enum,
+  agent_type.id,
+  CASE lang.iso_code WHEN 'en' THEN v.en_title ELSE v.de_title END
+FROM (VALUES
+  ('AE', 'AE', 'AE'),
+  ('GU1', 'GU1', 'GU1'),
+  ('GU2', 'GU2', 'GU2'),
+  ('GU2+', 'GU2+', 'GU2+'),
+  ('GU3', 'GU3', 'GU3'),
+  ('NU', 'NU', 'NU'),
+  ('ASOG', 'ASOG', 'ASOG'),
+  ('counseling-center', 'Counseling-center', 'Beratungsstelle'),
+  ('tandem', 'Tandem', 'Tandem'),
+  ('multiple-social-support', 'Multiple-social-support', 'Allgemeine Sozialberatung')
+) AS v(key, en_title, de_title)
+INNER JOIN "agent_type" ON "agent_type"."title" = v.key
+CROSS JOIN "language" lang
+WHERE lang.iso_code IN ('en', 'de')
+ON CONFLICT (language_id, entity_type, entity_id, field_name)
+DO UPDATE SET translation = EXCLUDED.translation;
+`;
+
+const sqlSeedServiceTranslations = `
+INSERT INTO "field_translation" (field_name, language_id, entity_type, entity_id, translation)
+SELECT
+  'title'::varchar,
+  lang.id,
+  'service'::field_translation_entity_type_enum,
+  service.id,
+  CASE lang.iso_code WHEN 'en' THEN v.en_title ELSE v.de_title END
+FROM (VALUES
+  ('childcare', 'Childcare', 'Kinderbetreuung'),
+  ('welfare', 'Welfare', 'Wohlfahrt'),
+  ('consultation', 'Consultation', 'Beratung'),
+  ('voluntary-support', 'Voluntary-support', 'Ehrenamtliche Unterstützung'),
+  ('tandem', 'Tandem', 'Tandem'),
+  ('sport', 'Sport', 'Sport'),
+  ('tutoring', 'Tutoring', 'Nachhilfe'),
+  ('refugee-accommodation', 'Refugee Accommodation', 'Unterkunft für Geflüchtete'),
+  ('job-coaching', 'Job-coaching', 'Job-Coaching'),
+  ('youth', 'Youth', 'Jugend')
+) AS v(key, en_title, de_title)
+INNER JOIN "service" ON "service"."title" = v.key
+CROSS JOIN "language" lang
+WHERE lang.iso_code IN ('en', 'de')
+ON CONFLICT (language_id, entity_type, entity_id, field_name)
+DO UPDATE SET translation = EXCLUDED.translation;
+`;
+
+// Registers the new reference rows with the generic GET /option list
+// registry, mirroring how the language/activity/district/skill options are
+// registered (see option.seed.ts and the Dari-language fix migration).
+const sqlSeedAgentTypeOptions = `
+INSERT INTO "option" (item_id, item_type)
+SELECT id, 'agent_type' FROM "agent_type";
+`;
+
+const sqlSeedServiceOptions = `
+INSERT INTO "option" (item_id, item_type)
+SELECT id, 'service' FROM "service";
+`;
+
+export class AddAgentTypeAndService1784898817413 implements MigrationInterface {
+  name = "AddAgentTypeAndService1784898817413";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "service" ("id" SERIAL NOT NULL, "title" character varying NOT NULL, CONSTRAINT "UQ_eaae4b7c4571ef8eec883d6202f" UNIQUE ("title"), CONSTRAINT "PK_85a21558c006647cd76fdce044b" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "agent_service" ("id" SERIAL NOT NULL, "agent_id" integer NOT NULL, "service_id" integer NOT NULL, CONSTRAINT "UQ_992b84d11cba2e453a18635d65a" UNIQUE ("agent_id", "service_id"), CONSTRAINT "PK_4b520fc463fe08f2de32b08665f" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "agent_type" ("id" SERIAL NOT NULL, "title" character varying NOT NULL, CONSTRAINT "UQ_e52c57e06e685a88b774e3ed0e1" UNIQUE ("title"), CONSTRAINT "PK_f05cf3538bfe43d6d25dc2181d9" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(`ALTER TABLE "agent" ADD "agent_type_id" integer`);
+
+    // The enum-extension dance below (rename old type, create new type with
+    // agent_type/service added, swap columns over, drop old type) must run
+    // BEFORE any INSERT casts to 'agent_type'/'service' — those values don't
+    // exist on field_translation_entity_type_enum/option_item_type_enum yet.
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_8c3af29493287693cdd82d99c1"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."comment_entity_type_enum" RENAME TO "comment_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."comment_entity_type_enum" AS ENUM('none', 'activity', 'agent', 'agent_type', 'category', 'comment', 'district', 'language', 'lead_from', 'opportunity', 'service', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment" ALTER COLUMN "entity_type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment" ALTER COLUMN "entity_type" TYPE "public"."comment_entity_type_enum" USING "entity_type"::"text"::"public"."comment_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment" ALTER COLUMN "entity_type" SET DEFAULT 'none'`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."comment_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_cd9cbf582b713498a61c626c2d"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."field_translation_entity_type_enum" RENAME TO "field_translation_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."field_translation_entity_type_enum" AS ENUM('none', 'activity', 'agent', 'agent_type', 'category', 'comment', 'district', 'language', 'lead_from', 'opportunity', 'service', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "field_translation" ALTER COLUMN "entity_type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "field_translation" ALTER COLUMN "entity_type" TYPE "public"."field_translation_entity_type_enum" USING "entity_type"::"text"::"public"."field_translation_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "field_translation" ALTER COLUMN "entity_type" SET DEFAULT 'none'`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."field_translation_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."notion_relation_host_type_enum" RENAME TO "notion_relation_host_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."notion_relation_host_type_enum" AS ENUM('none', 'activity', 'agent', 'agent_type', 'category', 'comment', 'district', 'language', 'lead_from', 'opportunity', 'service', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notion_relation" ALTER COLUMN "host_type" TYPE "public"."notion_relation_host_type_enum" USING "host_type"::"text"::"public"."notion_relation_host_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."notion_relation_host_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."notion_relation_tenant_type_enum" RENAME TO "notion_relation_tenant_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."notion_relation_tenant_type_enum" AS ENUM('none', 'activity', 'agent', 'agent_type', 'category', 'comment', 'district', 'language', 'lead_from', 'opportunity', 'service', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notion_relation" ALTER COLUMN "tenant_type" TYPE "public"."notion_relation_tenant_type_enum" USING "tenant_type"::"text"::"public"."notion_relation_tenant_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."notion_relation_tenant_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."option_item_type_enum" RENAME TO "option_item_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."option_item_type_enum" AS ENUM('none', 'activity', 'agent', 'agent_type', 'category', 'comment', 'district', 'language', 'lead_from', 'opportunity', 'service', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "option" ALTER COLUMN "item_type" TYPE "public"."option_item_type_enum" USING "item_type"::"text"::"public"."option_item_type_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."option_item_type_enum_old"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_68fcd3be0d9a16a5b6c8371133"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."timeline_source_entity_type_enum" RENAME TO "timeline_source_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."timeline_source_entity_type_enum" AS ENUM('none', 'activity', 'agent', 'agent_type', 'category', 'comment', 'district', 'language', 'lead_from', 'opportunity', 'service', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "timeline" ALTER COLUMN "source_entity_type" TYPE "public"."timeline_source_entity_type_enum" USING "source_entity_type"::"text"::"public"."timeline_source_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."timeline_source_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."timeline_target_entity_type_enum" RENAME TO "timeline_target_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."timeline_target_entity_type_enum" AS ENUM('none', 'activity', 'agent', 'agent_type', 'category', 'comment', 'district', 'language', 'lead_from', 'opportunity', 'service', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "timeline" ALTER COLUMN "target_entity_type" TYPE "public"."timeline_target_entity_type_enum" USING "target_entity_type"::"text"::"public"."timeline_target_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."timeline_target_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."timeline_content_entity_type_enum" RENAME TO "timeline_content_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."timeline_content_entity_type_enum" AS ENUM('none', 'activity', 'agent', 'agent_type', 'category', 'comment', 'district', 'language', 'lead_from', 'opportunity', 'service', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "timeline" ALTER COLUMN "content_entity_type" TYPE "public"."timeline_content_entity_type_enum" USING "content_entity_type"::"text"::"public"."timeline_content_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."timeline_content_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_8c3af29493287693cdd82d99c1" ON "comment" ("entity_type", "entity_id", "language_id") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_cd9cbf582b713498a61c626c2d" ON "field_translation" ("language_id", "entity_type", "entity_id", "field_name") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_68fcd3be0d9a16a5b6c8371133" ON "timeline" ("target_entity_type", "target_entity_id", "timestamp") `,
+    );
+
+    // Seed the new reference tables + their translations + option-list
+    // registrations, then backfill from the old columns, before dropping them.
+    await queryRunner.query(sqlSeedAgentType);
+    await queryRunner.query(sqlSeedService);
+    await queryRunner.query(sqlBackfillAgentTypeId);
+    await queryRunner.query(sqlBackfillAgentService);
+    await queryRunner.query(sqlSeedAgentTypeTranslations);
+    await queryRunner.query(sqlSeedServiceTranslations);
+    await queryRunner.query(sqlSeedAgentTypeOptions);
+    await queryRunner.query(sqlSeedServiceOptions);
+
+    await queryRunner.query(`ALTER TABLE "agent" DROP COLUMN "type"`);
+    await queryRunner.query(`DROP TYPE "public"."agent_type_enum"`);
+    await queryRunner.query(`ALTER TABLE "agent" DROP COLUMN "services"`);
+
+    await queryRunner.query(
+      `ALTER TABLE "agent_service" ADD CONSTRAINT "FK_151637a73a1caff857a7b6205e6" FOREIGN KEY ("agent_id") REFERENCES "agent"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_service" ADD CONSTRAINT "FK_6369b438fbff3adbac7b0829853" FOREIGN KEY ("service_id") REFERENCES "service"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent" ADD CONSTRAINT "FK_1124c67ba0232c41780f387ca30" FOREIGN KEY ("agent_type_id") REFERENCES "agent_type"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent" DROP CONSTRAINT "FK_1124c67ba0232c41780f387ca30"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_service" DROP CONSTRAINT "FK_6369b438fbff3adbac7b0829853"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_service" DROP CONSTRAINT "FK_151637a73a1caff857a7b6205e6"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_68fcd3be0d9a16a5b6c8371133"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_cd9cbf582b713498a61c626c2d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_8c3af29493287693cdd82d99c1"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."timeline_content_entity_type_enum_old" AS ENUM('none', 'activity', 'agent', 'comment', 'category', 'district', 'language', 'lead_from', 'opportunity', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "timeline" ALTER COLUMN "content_entity_type" TYPE "public"."timeline_content_entity_type_enum_old" USING "content_entity_type"::"text"::"public"."timeline_content_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."timeline_content_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."timeline_content_entity_type_enum_old" RENAME TO "timeline_content_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."timeline_target_entity_type_enum_old" AS ENUM('none', 'activity', 'agent', 'comment', 'category', 'district', 'language', 'lead_from', 'opportunity', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "timeline" ALTER COLUMN "target_entity_type" TYPE "public"."timeline_target_entity_type_enum_old" USING "target_entity_type"::"text"::"public"."timeline_target_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."timeline_target_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."timeline_target_entity_type_enum_old" RENAME TO "timeline_target_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."timeline_source_entity_type_enum_old" AS ENUM('none', 'activity', 'agent', 'comment', 'category', 'district', 'language', 'lead_from', 'opportunity', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "timeline" ALTER COLUMN "source_entity_type" TYPE "public"."timeline_source_entity_type_enum_old" USING "source_entity_type"::"text"::"public"."timeline_source_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."timeline_source_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."timeline_source_entity_type_enum_old" RENAME TO "timeline_source_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_68fcd3be0d9a16a5b6c8371133" ON "timeline" ("target_entity_id", "target_entity_type", "timestamp") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."option_item_type_enum_old" AS ENUM('none', 'activity', 'agent', 'comment', 'category', 'district', 'language', 'lead_from', 'opportunity', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "option" ALTER COLUMN "item_type" TYPE "public"."option_item_type_enum_old" USING "item_type"::"text"::"public"."option_item_type_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."option_item_type_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."option_item_type_enum_old" RENAME TO "option_item_type_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."notion_relation_tenant_type_enum_old" AS ENUM('none', 'activity', 'agent', 'comment', 'category', 'district', 'language', 'lead_from', 'opportunity', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notion_relation" ALTER COLUMN "tenant_type" TYPE "public"."notion_relation_tenant_type_enum_old" USING "tenant_type"::"text"::"public"."notion_relation_tenant_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."notion_relation_tenant_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."notion_relation_tenant_type_enum_old" RENAME TO "notion_relation_tenant_type_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."notion_relation_host_type_enum_old" AS ENUM('none', 'activity', 'agent', 'comment', 'category', 'district', 'language', 'lead_from', 'opportunity', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notion_relation" ALTER COLUMN "host_type" TYPE "public"."notion_relation_host_type_enum_old" USING "host_type"::"text"::"public"."notion_relation_host_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."notion_relation_host_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."notion_relation_host_type_enum_old" RENAME TO "notion_relation_host_type_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."field_translation_entity_type_enum_old" AS ENUM('none', 'activity', 'agent', 'comment', 'category', 'district', 'language', 'lead_from', 'opportunity', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "field_translation" ALTER COLUMN "entity_type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "field_translation" ALTER COLUMN "entity_type" TYPE "public"."field_translation_entity_type_enum_old" USING "entity_type"::"text"::"public"."field_translation_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "field_translation" ALTER COLUMN "entity_type" SET DEFAULT 'none'`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."field_translation_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."field_translation_entity_type_enum_old" RENAME TO "field_translation_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_cd9cbf582b713498a61c626c2d" ON "field_translation" ("entity_id", "entity_type", "field_name", "language_id") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."comment_entity_type_enum_old" AS ENUM('none', 'activity', 'agent', 'comment', 'category', 'district', 'language', 'lead_from', 'opportunity', 'skill', 'volunteer')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment" ALTER COLUMN "entity_type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment" ALTER COLUMN "entity_type" TYPE "public"."comment_entity_type_enum_old" USING "entity_type"::"text"::"public"."comment_entity_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "comment" ALTER COLUMN "entity_type" SET DEFAULT 'none'`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."comment_entity_type_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."comment_entity_type_enum_old" RENAME TO "comment_entity_type_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_8c3af29493287693cdd82d99c1" ON "comment" ("entity_id", "entity_type", "language_id") `,
+    );
+    await queryRunner.query(`ALTER TABLE "agent" DROP COLUMN "agent_type_id"`);
+    await queryRunner.query(`ALTER TABLE "agent" ADD "services" text array`);
+    await queryRunner.query(
+      `CREATE TYPE "public"."agent_type_enum" AS ENUM('AE', 'GU1', 'GU2', 'GU2+', 'GU3', 'NU', 'ASOG', 'counseling-center', 'tandem', 'multiple-social-support')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent" ADD "type" "public"."agent_type_enum"`,
+    );
+    await queryRunner.query(`DROP TABLE "agent_type"`);
+    await queryRunner.query(`DROP TABLE "agent_service"`);
+    await queryRunner.query(`DROP TABLE "service"`);
+  }
+}

--- a/src/data/migrations/1784898817413-add-agent-type-and-service.ts
+++ b/src/data/migrations/1784898817413-add-agent-type-and-service.ts
@@ -10,7 +10,7 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 // table is that new categories no longer require an SDK release.
 const sqlSeedAgentType = `
 INSERT INTO "agent_type" ("title") VALUES
-  ('AE'), ('GU1'), ('GU2'), ('GU2+'), ('GU3'), ('NU'), ('ASOG'),
+  ('AE'), ('GU1'), ('GU2'), ('GU3'), ('NU'), ('ASOG'),
   ('S/U'), ('jobcenter'), ('arzt'),
   ('counseling-center'), ('tandem'), ('multiple-social-support')
 ON CONFLICT ("title") DO NOTHING;
@@ -24,11 +24,17 @@ INSERT INTO "service" ("title") VALUES
 ON CONFLICT ("title") DO NOTHING;
 `;
 
+// GU2+ has no row of its own (merged into GU2, see below) — map it explicitly
+// so any agent previously classified GU2+ backfills onto GU2 instead of
+// being left with a null agent_type_id.
 const sqlBackfillAgentTypeId = `
 UPDATE "agent"
 SET "agent_type_id" = "agent_type"."id"
 FROM "agent_type"
-WHERE "agent_type"."title" = "agent"."type"::text;
+WHERE "agent_type"."title" = CASE
+  WHEN "agent"."type"::text = 'GU2+' THEN 'GU2'
+  ELSE "agent"."type"::text
+END;
 `;
 
 const sqlBackfillAgentService = `
@@ -41,9 +47,8 @@ ON CONFLICT ("agent_id", "service_id") DO NOTHING;
 `;
 
 // en/de labels below are the authoritative copy provided directly by the
-// product owner (not inferred from fe's prior placeholder labels). GU2+ has
-// no row of its own in that source data; per direction, it reuses GU2's
-// translations with "+" appended.
+// product owner (not inferred from fe's prior placeholder labels). GU2+ is
+// not a category of its own — it's merged into GU2 (see the backfill above).
 const sqlSeedAgentTypeTranslations = `
 INSERT INTO "field_translation" (field_name, language_id, entity_type, entity_id, translation)
 SELECT
@@ -56,7 +61,6 @@ FROM (VALUES
   ('AE', 'Reception facility', 'Aufnahmeeinrichtung'),
   ('GU1', 'shared accommodation 1', 'Gemeinschaftsunterkunft 1'),
   ('GU2', 'shared accommodation 2', 'Gemeinschaftsunterkunft 2'),
-  ('GU2+', 'shared accommodation 2+', 'Gemeinschaftsunterkunft 2+'),
   ('GU3', 'shared accommodation 3', 'Gemeinschaftsunterkunft 3'),
   ('NU', 'Emergency shelter', 'Notunterkunft'),
   ('ASOG', 'accommodation with no social support', 'ASOG'),

--- a/src/data/seeds/populate/agent.seed.ts
+++ b/src/data/seeds/populate/agent.seed.ts
@@ -5,8 +5,11 @@ import { tryCatch } from "../../../services/utils";
 import Postcode from "../../entity/location/postcode.entity";
 import AgentPerson from "../../entity/m2m/agent-person";
 import AgentPostcode from "../../entity/m2m/agent-postcode";
+import AgentService from "../../entity/m2m/agent-service";
 import NotionRelation from "../../entity/notion-relation.entity";
 import Agent from "../../entity/opportunity/agent.entity";
+import AgentType from "../../entity/profile/agent-type.entity";
+import Service from "../../entity/profile/service.entity";
 import { fetchJsonFromUrl, getRepository } from "../../utils";
 import {
   getAgentEngagement,
@@ -22,6 +25,9 @@ import { AgentJSON } from "./types";
 
 export async function seedAgents(dataSource: DataSource): Promise<void> {
   const agentRepository = getRepository(dataSource, Agent);
+  const agentTypeRepository = getRepository(dataSource, AgentType);
+  const serviceRepository = getRepository(dataSource, Service);
+  const agentServiceRepository = getRepository(dataSource, AgentService);
 
   const count = await getCount(agentRepository);
   if (count !== 0) {
@@ -38,15 +44,19 @@ export async function seedAgents(dataSource: DataSource): Promise<void> {
   } as AgentJSON);
 
   for (const agentJson of agentsJson ?? []) {
+    const agentTypeKey = getAgentType(agentJson.type);
+    const agentType = agentTypeKey
+      ? await agentTypeRepository.findOneBy({ title: agentTypeKey })
+      : null;
+
     const agentObj = new Agent({
       title: agentJson.title || agentJson.website || "unknown",
       info: agentJson.about,
       website: agentJson.website,
-      type: getAgentType(agentJson.type),
+      agentTypeId: agentType?.id,
       trustLevel: getAgentTrustLevel(agentJson.trustLevel),
       searchStatus: getAgentSearchStatus(agentJson.statusSearch),
       engagementStatus: getAgentEngagement(agentJson.statusEngagement),
-      services: agentJson.services?.map(getAgentService),
     });
     const [agent, error] = await tryCatch(agentRepository.save(agentObj));
 
@@ -56,6 +66,27 @@ export async function seedAgents(dataSource: DataSource): Promise<void> {
         `While creating an agent ${agentJson.nid} occurred: ${error}`,
       );
       continue;
+    }
+
+    const serviceKeys = (agentJson.services ?? []).map(getAgentService);
+    for (const serviceKey of serviceKeys) {
+      const service = await serviceRepository.findOneBy({
+        title: serviceKey,
+      });
+      if (!service) {
+        continue;
+      }
+      const [, error] = await tryCatch(
+        agentServiceRepository.save(
+          new AgentService({ agentId: agent.id, serviceId: service.id }),
+        ),
+      );
+      if (error) {
+        dataSource.logger.log(
+          "warn",
+          `Storing agent-service m2m (agentId:${agent.id}, serviceId:${service.id}) occurred: ${error}`,
+        );
+      }
     }
 
     const agentPostcodeRepository = getRepository(dataSource, AgentPostcode);

--- a/src/data/seeds/populate/agent.seed.ts
+++ b/src/data/seeds/populate/agent.seed.ts
@@ -1,4 +1,4 @@
-import { EntityTableName } from "need4deed-sdk";
+import { AgentTypeKey, EntityTableName } from "need4deed-sdk";
 import { DataSource } from "typeorm";
 import { seedAgentsFile, titleOrphanageAgent } from "../../../config";
 import { tryCatch } from "../../../services/utils";
@@ -45,8 +45,12 @@ export async function seedAgents(dataSource: DataSource): Promise<void> {
 
   for (const agentJson of agentsJson ?? []) {
     const agentTypeKey = getAgentType(agentJson.type);
-    const agentType = agentTypeKey
-      ? await agentTypeRepository.findOneBy({ title: agentTypeKey })
+    // GU2+ is not a category of its own — merged into GU2 (see the
+    // AddAgentTypeAndService migration's backfill for the same mapping).
+    const agentTypeTitle =
+      agentTypeKey === AgentTypeKey.GU2_PLUS ? AgentTypeKey.GU2 : agentTypeKey;
+    const agentType = agentTypeTitle
+      ? await agentTypeRepository.findOneBy({ title: agentTypeTitle })
       : null;
 
     const agentObj = new Agent({

--- a/src/data/seeds/reference/field_translation.seed.ts
+++ b/src/data/seeds/reference/field_translation.seed.ts
@@ -28,38 +28,42 @@ import { getCount } from "../utils";
 // this migration), the migration's insert already did the job and
 // seedFieldTranslation's count!==0 guard skips this entirely.
 const AGENT_TYPE_TRANSLATIONS: Record<string, ContentEnDe> = {
-  AE: { en: "AE", de: "AE" },
-  GU1: { en: "GU1", de: "GU1" },
-  GU2: { en: "GU2", de: "GU2" },
-  "GU2+": { en: "GU2+", de: "GU2+" },
-  GU3: { en: "GU3", de: "GU3" },
-  NU: { en: "NU", de: "NU" },
-  ASOG: { en: "ASOG", de: "ASOG" },
-  "counseling-center": { en: "Counseling-center", de: "Beratungsstelle" },
+  AE: { en: "Reception facility", de: "Aufnahmeeinrichtung" },
+  GU1: { en: "shared accommodation 1", de: "Gemeinschaftsunterkunft 1" },
+  GU2: { en: "shared accommodation 2", de: "Gemeinschaftsunterkunft 2" },
+  // GU2+ has no row of its own in the source data — reuses GU2's
+  // translations with "+" appended, per product direction.
+  "GU2+": { en: "shared accommodation 2+", de: "Gemeinschaftsunterkunft 2+" },
+  GU3: { en: "shared accommodation 3", de: "Gemeinschaftsunterkunft 3" },
+  NU: { en: "Emergency shelter", de: "Notunterkunft" },
+  ASOG: { en: "accommodation with no social support", de: "ASOG" },
+  "S/U": { en: "School", de: "Schule/Uni" },
+  jobcenter: { en: "Jobcenter", de: "Jobcenter" },
+  arzt: { en: "Doctor", de: "Arzt" },
+  "counseling-center": { en: "consultation center", de: "Beratungsstelle" },
   tandem: { en: "Tandem", de: "Tandem" },
   "multiple-social-support": {
-    en: "Multiple-social-support",
-    de: "Allgemeine Sozialberatung",
+    en: "multiple social support",
+    de: "Mehrere Soziale Leistungen",
   },
 };
 
 const SERVICE_TRANSLATIONS: Record<string, ContentEnDe> = {
-  childcare: { en: "Childcare", de: "Kinderbetreuung" },
-  welfare: { en: "Welfare", de: "Wohlfahrt" },
-  consultation: { en: "Consultation", de: "Beratung" },
-  "voluntary-support": {
-    en: "Voluntary-support",
-    de: "Ehrenamtliche Unterstützung",
-  },
-  tandem: { en: "Tandem", de: "Tandem" },
-  sport: { en: "Sport", de: "Sport" },
-  tutoring: { en: "Tutoring", de: "Nachhilfe" },
+  childcare: { en: "childcare", de: "Kinderbetreuung" },
+  welfare: { en: "welfare", de: "Sozialhilfe" },
+  health: { en: "Health", de: "Gesundheit" },
+  consultation: { en: "consultation", de: "Beratung" },
+  "voluntary-support": { en: "voluntary-support", de: "Freiwilligenhilfe" },
+  tandem: { en: "tandem", de: "Tandem" },
+  sport: { en: "sport", de: "Sport" },
+  tutoring: { en: "tutoring", de: "Nachhilfe" },
   "refugee-accommodation": {
-    en: "Refugee Accommodation",
-    de: "Unterkunft für Geflüchtete",
+    en: "refugee-accommodation",
+    de: "Flüchtlingsunterkunft",
   },
-  "job-coaching": { en: "Job-coaching", de: "Job-Coaching" },
-  youth: { en: "Youth", de: "Jugend" },
+  "job-coaching": { en: "job-coaching", de: "Jobcoaching" },
+  youth: { en: "youth", de: "Jugendarbeit" },
+  education: { en: "Education", de: "Bildung" },
 };
 
 const fieldNameTitle = "title";

--- a/src/data/seeds/reference/field_translation.seed.ts
+++ b/src/data/seeds/reference/field_translation.seed.ts
@@ -11,11 +11,56 @@ import logger from "../../../logger";
 import FieldTranslation from "../../entity/field_translation.entity";
 import LeadFrom from "../../entity/lead.entity";
 import Activity from "../../entity/profile/activity.entity";
+import AgentType from "../../entity/profile/agent-type.entity";
 import Category from "../../entity/profile/category.entity";
 import Language from "../../entity/profile/language.entity";
+import Service from "../../entity/profile/service.entity";
 import Skill from "../../entity/profile/skill.entity";
 import { fetchJsonFromUrl, getRepository } from "../../utils";
 import { getCount } from "../utils";
+
+// Same values as the AddAgentTypeAndService migration's field_translation
+// seed — duplicated (not imported/shared) because that migration must stay
+// self-contained. This is the dev/test bootstrap's fallback path: on a fresh
+// DB, migrations run before `language` is seeded, so the migration's own
+// insert seeds 0 rows there; this backfills once `language` definitely
+// exists. On any already-migrated environment (where `language` predates
+// this migration), the migration's insert already did the job and
+// seedFieldTranslation's count!==0 guard skips this entirely.
+const AGENT_TYPE_TRANSLATIONS: Record<string, ContentEnDe> = {
+  AE: { en: "AE", de: "AE" },
+  GU1: { en: "GU1", de: "GU1" },
+  GU2: { en: "GU2", de: "GU2" },
+  "GU2+": { en: "GU2+", de: "GU2+" },
+  GU3: { en: "GU3", de: "GU3" },
+  NU: { en: "NU", de: "NU" },
+  ASOG: { en: "ASOG", de: "ASOG" },
+  "counseling-center": { en: "Counseling-center", de: "Beratungsstelle" },
+  tandem: { en: "Tandem", de: "Tandem" },
+  "multiple-social-support": {
+    en: "Multiple-social-support",
+    de: "Allgemeine Sozialberatung",
+  },
+};
+
+const SERVICE_TRANSLATIONS: Record<string, ContentEnDe> = {
+  childcare: { en: "Childcare", de: "Kinderbetreuung" },
+  welfare: { en: "Welfare", de: "Wohlfahrt" },
+  consultation: { en: "Consultation", de: "Beratung" },
+  "voluntary-support": {
+    en: "Voluntary-support",
+    de: "Ehrenamtliche Unterstützung",
+  },
+  tandem: { en: "Tandem", de: "Tandem" },
+  sport: { en: "Sport", de: "Sport" },
+  tutoring: { en: "Tutoring", de: "Nachhilfe" },
+  "refugee-accommodation": {
+    en: "Refugee Accommodation",
+    de: "Unterkunft für Geflüchtete",
+  },
+  "job-coaching": { en: "Job-coaching", de: "Job-Coaching" },
+  youth: { en: "Youth", de: "Jugend" },
+};
 
 const fieldNameTitle = "title";
 const fieldNameDescription = "description";
@@ -312,6 +357,114 @@ async function seedSkills(
   }
 }
 
+async function seedAgentTypes(
+  fieldTranslationRepository: Repository<FieldTranslation>,
+  agentTypeRepository: Repository<AgentType>,
+  langEN: Language,
+  langDE: Language,
+) {
+  const agentTypes = await agentTypeRepository.find();
+
+  const existingAgentTypeTranslations = await fieldTranslationRepository.find({
+    where: { entityType: EntityTableName.AGENT_TYPE },
+    relations: ["language"],
+  });
+
+  const existingAgentTypeTranslationsSet = new Set(
+    existingAgentTypeTranslations.map(
+      (translation) =>
+        `${translation.language.isoCode}_${translation.entityId}`,
+    ),
+  );
+
+  const translationsForInsert: FieldTranslation[] = [];
+  for (const agentType of agentTypes) {
+    const translation = AGENT_TYPE_TRANSLATIONS[agentType.title];
+    if (!translation) {
+      continue;
+    }
+
+    if (!existingAgentTypeTranslationsSet.has(`${isoCodeEN}_${agentType.id}`)) {
+      const translationEN = new FieldTranslation();
+      translationEN.translation = translation.en;
+      translationEN.entityType = EntityTableName.AGENT_TYPE;
+      translationEN.entityId = agentType.id;
+      translationEN.languageId = langEN.id;
+      translationsForInsert.push(translationEN);
+    }
+
+    if (!existingAgentTypeTranslationsSet.has(`${isoCodeDE}_${agentType.id}`)) {
+      const translationDE = new FieldTranslation();
+      translationDE.translation = translation.de;
+      translationDE.entityType = EntityTableName.AGENT_TYPE;
+      translationDE.entityId = agentType.id;
+      translationDE.languageId = langDE.id;
+      translationsForInsert.push(translationDE);
+    }
+  }
+
+  try {
+    await fieldTranslationRepository.insert(translationsForInsert);
+  } catch (error) {
+    throw new Error(
+      `Error inserting agent type translations: ${error.message}`,
+    );
+  }
+}
+
+async function seedServices(
+  fieldTranslationRepository: Repository<FieldTranslation>,
+  serviceRepository: Repository<Service>,
+  langEN: Language,
+  langDE: Language,
+) {
+  const services = await serviceRepository.find();
+
+  const existingServiceTranslations = await fieldTranslationRepository.find({
+    where: { entityType: EntityTableName.SERVICE },
+    relations: ["language"],
+  });
+
+  const existingServiceTranslationsSet = new Set(
+    existingServiceTranslations.map(
+      (translation) =>
+        `${translation.language.isoCode}_${translation.entityId}`,
+    ),
+  );
+
+  const translationsForInsert: FieldTranslation[] = [];
+  for (const service of services) {
+    const translation = SERVICE_TRANSLATIONS[service.title];
+    if (!translation) {
+      continue;
+    }
+
+    if (!existingServiceTranslationsSet.has(`${isoCodeEN}_${service.id}`)) {
+      const translationEN = new FieldTranslation();
+      translationEN.translation = translation.en;
+      translationEN.entityType = EntityTableName.SERVICE;
+      translationEN.entityId = service.id;
+      translationEN.languageId = langEN.id;
+      translationsForInsert.push(translationEN);
+    }
+
+    if (!existingServiceTranslationsSet.has(`${isoCodeDE}_${service.id}`)) {
+      const translationDE = new FieldTranslation();
+      translationDE.translation = translation.de;
+      translationDE.entityType = EntityTableName.SERVICE;
+      translationDE.entityId = service.id;
+      translationDE.languageId = langDE.id;
+      translationsForInsert.push(translationDE);
+    }
+  }
+
+  try {
+    await fieldTranslationRepository.insert(translationsForInsert);
+  } catch (error) {
+    throw new Error(`Error inserting service translations: ${error.message}`);
+  }
+}
+
 async function seedLeeds(
   fieldTranslationRepository: Repository<FieldTranslation>,
   leadFromRepository: Repository<LeadFrom>,
@@ -436,6 +589,22 @@ export async function seedFieldTranslation(
   await seedLeeds(
     fieldTranslationRepository,
     leadFromRepository,
+    langEN,
+    langDE,
+  );
+
+  const agentTypeRepository = getRepository(dataSource, AgentType);
+  await seedAgentTypes(
+    fieldTranslationRepository,
+    agentTypeRepository,
+    langEN,
+    langDE,
+  );
+
+  const serviceRepository = getRepository(dataSource, Service);
+  await seedServices(
+    fieldTranslationRepository,
+    serviceRepository,
     langEN,
     langDE,
   );

--- a/src/data/seeds/reference/field_translation.seed.ts
+++ b/src/data/seeds/reference/field_translation.seed.ts
@@ -30,10 +30,9 @@ import { getCount } from "../utils";
 const AGENT_TYPE_TRANSLATIONS: Record<string, ContentEnDe> = {
   AE: { en: "Reception facility", de: "Aufnahmeeinrichtung" },
   GU1: { en: "shared accommodation 1", de: "Gemeinschaftsunterkunft 1" },
+  // GU2+ is not a category of its own — merged into GU2 (see the
+  // AddAgentTypeAndService migration's backfill).
   GU2: { en: "shared accommodation 2", de: "Gemeinschaftsunterkunft 2" },
-  // GU2+ has no row of its own in the source data — reuses GU2's
-  // translations with "+" appended, per product direction.
-  "GU2+": { en: "shared accommodation 2+", de: "Gemeinschaftsunterkunft 2+" },
   GU3: { en: "shared accommodation 3", de: "Gemeinschaftsunterkunft 3" },
   NU: { en: "Emergency shelter", de: "Notunterkunft" },
   ASOG: { en: "accommodation with no social support", de: "ASOG" },

--- a/src/data/seeds/utils.ts
+++ b/src/data/seeds/utils.ts
@@ -4,7 +4,7 @@ import {
   AgentRoleType,
   AgentServiceType,
   AgentTrustType,
-  AgentType,
+  AgentTypeKey,
   AgentVolunteerSearchType,
   DocumentStatusType,
   EntityTableName,
@@ -460,7 +460,6 @@ export async function getOrCreateAgent(
 
   const newAgent = new Agent({
     title: agentData.title,
-    type: undefined,
     organizationId: organization.id,
   });
   await agentRepository.save(newAgent);
@@ -710,14 +709,14 @@ export function getAgentTrustLevel(level: string): AgentTrustType {
   return AgentTrustType.UNKNOWN;
 }
 
-export function getAgentType(type: string): AgentType {
-  if (getEnumValue(AgentType, type)) {
-    return type as AgentType;
+export function getAgentType(type: string): AgentTypeKey {
+  if (getEnumValue(AgentTypeKey, type)) {
+    return type as AgentTypeKey;
   }
 
   switch (type) {
     case "Multiple social support":
-      return AgentType.MULTIPLE_SOCIAL_SUPPORT;
+      return AgentTypeKey.MULTIPLE_SOCIAL_SUPPORT;
   }
 
   return null;

--- a/src/data/types/enums.ts
+++ b/src/data/types/enums.ts
@@ -21,16 +21,6 @@ export enum DealType {
   OPPORTUNITY = "opportunity",
 }
 
-export enum AgentOperatorType {
-  ORGANIZATION = "organization",
-  PERSON = "person",
-}
-
-export enum AgentType {
-  RAC = "RAC",
-  NGO = "NGO",
-}
-
 export enum ConfigType {
   SCHEMA = "schema",
   REFERENCE_DATA = "reference_data",

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -38,6 +38,7 @@ import {
   getSkipTake,
   patchAddress,
   updateAgentLanguages,
+  updateAgentServices,
 } from "../../utils";
 import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 import agentCommunicationRoutes from "./agent-communication.routes";
@@ -147,6 +148,7 @@ export default async function agentRoutes(
       const relations = [
         "address.postcode",
         "district",
+        "agentType",
         "opportunity.opportunityVolunteer",
         "agentPerson.person",
         "organization",
@@ -193,6 +195,8 @@ export default async function agentRoutes(
       const relations = [
         "address.postcode",
         "district",
+        "agentType",
+        "agentService.service",
         "opportunity.opportunityVolunteer",
         "organization.address.postcode",
         "agentPerson.person.address.postcode",
@@ -243,7 +247,8 @@ export default async function agentRoutes(
 
       await assertCanEditOrg(fastify, request, id);
 
-      const { addressStreet, addressPostcode, languages } = request.body;
+      const { addressStreet, addressPostcode, languages, serviceIds } =
+        request.body;
 
       // Persist address, scalar fields and languages atomically so a partial
       // failure can't leave the agent half-updated.
@@ -285,6 +290,10 @@ export default async function agentRoutes(
 
         if (languages) {
           await updateAgentLanguages(id, languages, manager);
+        }
+
+        if (serviceIds) {
+          await updateAgentServices(id, serviceIds, manager);
         }
       });
 

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -31,6 +31,7 @@ import {
   RoutePrefix,
 } from "../../types";
 import {
+  addAgentTypeServiceTranslations,
   addComments2Entity,
   createAddress,
   getAgentWhere,
@@ -138,7 +139,7 @@ export default async function agentRoutes(
       logger.debug(`GET /agent: request.query:${Object.keys(request.query)}`);
       const { page, limit, sortOrder, filter } = request.query;
       const [skip, take] = getSkipTake({ page, limit });
-      const where = getAgentWhere(filter);
+      const where = await getAgentWhere(filter);
 
       logger.debug(
         `GET /agent: filters:${JSON.stringify(filter)}, skip:${skip}, take:${take}`,
@@ -165,6 +166,7 @@ export default async function agentRoutes(
 
       const { addDistrictToAgent, updates } = getDistrictToAgentHandler();
       const agentsDistrict = await Promise.all(agents.map(addDistrictToAgent));
+      await addAgentTypeServiceTranslations(agentsDistrict);
 
       if (updates.length > 0) {
         await agentRepository.save(updates);
@@ -210,6 +212,7 @@ export default async function agentRoutes(
       const { addDistrictToAgent, updates } = getDistrictToAgentHandler();
       const agentDistrict = await addDistrictToAgent(agent);
       const agentComments = await addComments2Entity(agentDistrict);
+      await addAgentTypeServiceTranslations([agentComments]);
 
       if (updates.length > 0) {
         await agentRepository.save(updates);

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -151,6 +151,7 @@ export default async function opportunityRoutes(
         "deal.dealTimeslot.timeslot",
         "agent.agentPerson.person.address.postcode",
         "agent.district",
+        "agent.agentType",
         "contactPerson",
         "submittedByPerson.agentPerson",
       ];

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -51,6 +51,7 @@ import {
   RoutePrefix,
 } from "../../types";
 import {
+  addAgentTypeServiceTranslations,
   addComments2Entity,
   getCategoryToDealHandler,
   getDistrictToAgentHandler,
@@ -183,6 +184,7 @@ export default async function opportunityRoutes(
         opportunityComments.agent,
         await addDistrictToAgent(opportunityComments.agent),
       );
+      await addAgentTypeServiceTranslations([opportunityComments.agent]);
 
       if (districtUpdates.length) {
         const agentRepository = fastify.db.agentRepository;

--- a/src/server/schema/agent-register.schema.ts
+++ b/src/server/schema/agent-register.schema.ts
@@ -56,12 +56,12 @@ const registerAgentNewSchema = {
   additionalProperties: false,
   properties: {
     title: { type: "string", minLength: 1 },
-    type: { $ref: "AgentType#" },
+    typeId: { type: "integer" },
     info: { type: "string" },
     website: { type: "string" },
-    services: {
+    serviceIds: {
       type: "array",
-      items: { $ref: "AgentServiceType#" },
+      items: { type: "integer" },
     },
     phone: { type: "string" },
     addressStreet: { type: "string" },

--- a/src/server/schema/option-lists.json
+++ b/src/server/schema/option-lists.json
@@ -29,6 +29,14 @@
         "district": {
           "type": "array",
           "items": { "$ref": "OptionItem#" }
+        },
+        "agent_type": {
+          "type": "array",
+          "items": { "$ref": "OptionItem#" }
+        },
+        "service": {
+          "type": "array",
+          "items": { "$ref": "OptionItem#" }
         }
       },
       "additionalProperties": false

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -1199,19 +1199,8 @@
     },
     "AgentType": {
       "$id": "AgentType",
-      "type": "string",
-      "enum": [
-        "AE",
-        "GU1",
-        "GU2",
-        "GU2+",
-        "GU3",
-        "NU",
-        "ASOG",
-        "counseling-center",
-        "tandem",
-        "multiple-social-support"
-      ]
+      "$ref": "OptionProps#",
+      "required": ["id"]
     },
     "AgentRoleType": {
       "$id": "AgentRoleType",
@@ -1225,22 +1214,6 @@
         "project-staff",
         "childcare-worker",
         "other"
-      ]
-    },
-    "AgentServiceType": {
-      "$id": "AgentServiceType",
-      "type": "string",
-      "enum": [
-        "childcare",
-        "welfare",
-        "consultation",
-        "voluntary-support",
-        "tandem",
-        "sport",
-        "tutoring",
-        "refugee-accommodation",
-        "job-coaching",
-        "youth"
       ]
     },
     "AgentTrustType": {
@@ -1273,21 +1246,10 @@
         "agent-inactive"
       ]
     },
-    "AgentService": {
-      "$id": "AgentService",
-      "type": "string",
-      "enum": [
-        "childcare",
-        "welfare",
-        "consultation",
-        "voluntary-support",
-        "tandem",
-        "sport",
-        "tutoring",
-        "refugee-accommodation",
-        "job-coaching",
-        "youth"
-      ]
+    "Service": {
+      "$id": "Service",
+      "$ref": "OptionProps#",
+      "required": ["id"]
     },
     "AgentDetails": {
       "$id": "AgentDetails",
@@ -1309,13 +1271,16 @@
           "type": "string"
         },
         "organizationType": {
-          "type": "string"
+          "$ref": "AgentType#"
         },
         "operator": {
           "type": "string"
         },
         "services": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "$ref": "Service#"
+          }
         },
         "clientLanguages": {
           "type": "array",
@@ -1400,20 +1365,14 @@
         "title": {
           "type": "string"
         },
-        "type": {
-          "$ref": "AgentType#"
+        "typeId": {
+          "type": "integer"
         },
         "volunteerSearch": {
           "$ref": "AgentVolunteerSearchType#"
         },
         "trustLevel": {
           "$ref": "AgentTrustType#"
-        },
-        "serviceType": {
-          "type": "array",
-          "items": {
-            "$ref": "AgentService#"
-          }
         },
         "statusEngagement": {
           "$ref": "AgentEngagementStatusType#"
@@ -1433,10 +1392,10 @@
         "statusSearch": {
           "$ref": "AgentVolunteerSearchType#"
         },
-        "services": {
+        "serviceIds": {
           "type": "array",
           "items": {
-            "$ref": "AgentService#"
+            "type": "integer"
           }
         },
         "languages": {
@@ -1477,10 +1436,10 @@
               "type": "array",
               "items": { "type": "object", "additionalProperties": true }
             },
-            "serviceType": {
+            "services": {
               "type": "array",
               "items": {
-                "$ref": "AgentService#"
+                "$ref": "Service#"
               }
             },
             "statusEngagement": {

--- a/src/server/utils/data/add-agent-type-service-translations.ts
+++ b/src/server/utils/data/add-agent-type-service-translations.ts
@@ -1,0 +1,84 @@
+import { EntityTableName, OptionTitle } from "need4deed-sdk";
+import { In } from "typeorm";
+import { dataSource } from "../../../data/data-source";
+import FieldTranslation from "../../../data/entity/field_translation.entity";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import { getRepository } from "../../../data/utils";
+
+/**
+ * Resolves real en/de field_translation rows for each agent's agentType and
+ * services, attaching them as agentType.translations / service.translations
+ * (see the AgentType/Service entities) so the DTO can use them instead of
+ * falling back to the raw title. Runs once per request as a batch, before
+ * the preSerialization DTO conversion — mirrors addDistrictToAgent /
+ * addComments2Entity. Expects the agentType and agentService.service
+ * relations to already be loaded.
+ */
+export async function addAgentTypeServiceTranslations(
+  agents: Agent[],
+): Promise<Agent[]> {
+  const agentTypeIds = [
+    ...new Set(
+      agents
+        .map((agent) => agent.agentTypeId)
+        .filter((id): id is number => Boolean(id)),
+    ),
+  ];
+  const serviceIds = [
+    ...new Set(
+      agents.flatMap((agent) =>
+        (agent.agentService ?? []).map(({ serviceId }) => serviceId),
+      ),
+    ),
+  ];
+
+  if (agentTypeIds.length === 0 && serviceIds.length === 0) {
+    return agents;
+  }
+
+  const fieldTranslationRepository = getRepository(
+    dataSource,
+    FieldTranslation,
+  );
+  const rows = await fieldTranslationRepository.find({
+    where: [
+      ...(agentTypeIds.length
+        ? [
+            {
+              entityType: EntityTableName.AGENT_TYPE,
+              entityId: In(agentTypeIds),
+            },
+          ]
+        : []),
+      ...(serviceIds.length
+        ? [{ entityType: EntityTableName.SERVICE, entityId: In(serviceIds) }]
+        : []),
+    ],
+    relations: ["language"],
+  });
+
+  const translationsByKey = new Map<string, OptionTitle>();
+  for (const row of rows) {
+    const key = `${row.entityType}_${row.entityId}`;
+    const entry = translationsByKey.get(key) ?? {};
+    entry[row.language.isoCode as keyof OptionTitle] = row.translation;
+    translationsByKey.set(key, entry);
+  }
+
+  for (const agent of agents) {
+    if (agent.agentType) {
+      agent.agentType.translations = translationsByKey.get(
+        `${EntityTableName.AGENT_TYPE}_${agent.agentTypeId}`,
+      );
+    }
+    for (const agentService of agent.agentService ?? []) {
+      if (agentService.service) {
+        agentService.service.translations = translationsByKey.get(
+          `${EntityTableName.SERVICE}_${agentService.serviceId}`,
+        );
+      }
+    }
+  }
+
+  return agents;
+}

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -33,6 +33,7 @@ import Address from "../../../data/entity/location/address.entity";
 import District from "../../../data/entity/location/district.entity";
 import Postcode from "../../../data/entity/location/postcode.entity";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
+import AgentService from "../../../data/entity/m2m/agent-service";
 import Option from "../../../data/entity/option.entity";
 import Person from "../../../data/entity/person.entity";
 import Language from "../../../data/entity/profile/language.entity";
@@ -246,6 +247,8 @@ export async function getOptions(
         EntityTableName.SKILL,
         EntityTableName.LEAD,
         EntityTableName.CATEGORY,
+        EntityTableName.AGENT_TYPE,
+        EntityTableName.SERVICE,
       ].includes(itemType)
     ) {
       const items = await fieldTranslationRepository.find({
@@ -301,6 +304,8 @@ export async function getOptions(
       [EntityTableName.ACTIVITY]: await getList(EntityTableName.ACTIVITY),
       [EntityTableName.SKILL]: await getList(EntityTableName.SKILL),
       [EntityTableName.LEAD]: await getList(EntityTableName.LEAD),
+      [EntityTableName.AGENT_TYPE]: await getList(EntityTableName.AGENT_TYPE),
+      [EntityTableName.SERVICE]: await getList(EntityTableName.SERVICE),
     };
   }
 
@@ -423,6 +428,40 @@ export async function updateAgentLanguages(
   }
   if (toAdd.length > 0) {
     await agentLanguageRepository.save(toAdd);
+  }
+}
+
+/**
+ * Sync the agent's `agentService` join rows to match `serviceIds`: remove the
+ * de-selected rows and insert the newly selected ones (rows that are unchanged
+ * are left untouched). Mirrors updateAgentLanguages above.
+ *
+ * Runs on the given `manager` so the caller can wrap it in a transaction; pass
+ * the transactional EntityManager to make it atomic with surrounding writes.
+ */
+export async function updateAgentServices(
+  agentId: number,
+  serviceIds: number[],
+  manager: DataSource | EntityManager = dataSource,
+): Promise<void> {
+  const agentServiceRepository = getRepository(manager, AgentService);
+
+  const desiredServiceIds = [...new Set(serviceIds.map(Number))];
+  const current = await agentServiceRepository.find({ where: { agentId } });
+  const currentServiceIds = current.map(({ serviceId }) => serviceId);
+
+  const toRemove = current.filter(
+    ({ serviceId }) => !desiredServiceIds.includes(serviceId),
+  );
+  const toAdd = desiredServiceIds
+    .filter((serviceId) => !currentServiceIds.includes(serviceId))
+    .map((serviceId) => new AgentService({ agentId, serviceId }));
+
+  if (toRemove.length > 0) {
+    await agentServiceRepository.delete(toRemove.map(({ id }) => id));
+  }
+  if (toAdd.length > 0) {
+    await agentServiceRepository.save(toAdd);
   }
 }
 

--- a/src/server/utils/data/get-agent-where.ts
+++ b/src/server/utils/data/get-agent-where.ts
@@ -1,17 +1,21 @@
-import { ArrayOverlap, FindOptionsWhere, ILike } from "typeorm";
+import { FindOptionsWhere, ILike } from "typeorm";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import { QuerystringAgentFiltering } from "../../types";
 import { normalizeStringArrayInput } from "./for-routes";
 
 // SECURITY (#666): `search`/`street` filter on unmasked DB columns, so a
 // non-privileged caller can infer PII masked in the response by probing matches.
+//
+// `type`/`services` now filter by AgentType/Service id (not the old raw enum
+// string), matching how `district` already filters by districtId — a
+// contract change for callers of this querystring, tracked alongside #794.
 export function getAgentWhere(
   filter: QuerystringAgentFiltering["filter"],
 ): FindOptionsWhere<Agent> {
   return {
     ...(filter?.type
       ? {
-          type: normalizeStringArrayInput(filter.type),
+          agentTypeId: normalizeStringArrayInput(filter.type),
         }
       : {}),
     ...(filter?.search
@@ -44,7 +48,9 @@ export function getAgentWhere(
       : {}),
     ...(filter?.services
       ? {
-          services: ArrayOverlap(filter.services),
+          agentService: {
+            serviceId: normalizeStringArrayInput(filter.services),
+          },
         }
       : {}),
   } as FindOptionsWhere<Agent>;

--- a/src/server/utils/data/get-agent-where.ts
+++ b/src/server/utils/data/get-agent-where.ts
@@ -1,5 +1,8 @@
-import { FindOptionsWhere, ILike } from "typeorm";
+import { FindOptionsWhere, ILike, In } from "typeorm";
+import { dataSource } from "../../../data/data-source";
+import AgentService from "../../../data/entity/m2m/agent-service";
 import Agent from "../../../data/entity/opportunity/agent.entity";
+import { getRepository } from "../../../data/utils";
 import { QuerystringAgentFiltering } from "../../types";
 import { normalizeStringArrayInput } from "./for-routes";
 
@@ -9,9 +12,26 @@ import { normalizeStringArrayInput } from "./for-routes";
 // `type`/`services` now filter by AgentType/Service id (not the old raw enum
 // string), matching how `district` already filters by districtId — a
 // contract change for callers of this querystring, tracked alongside #794.
-export function getAgentWhere(
+//
+// `services` resolves matching agent ids in a separate query first rather
+// than filtering via a joined `agentService: { serviceId: In(...) }`
+// condition — that join fans out (one row per matching service), so an
+// agent matching more than one selected service would come back duplicated
+// and inflate findAndCount's total.
+export async function getAgentWhere(
   filter: QuerystringAgentFiltering["filter"],
-): FindOptionsWhere<Agent> {
+): Promise<FindOptionsWhere<Agent>> {
+  let agentIdsForServices: number[] | null = null;
+  if (filter?.services) {
+    const serviceIds = (
+      Array.isArray(filter.services) ? filter.services : [filter.services]
+    ).map(Number);
+    const matches = await getRepository(dataSource, AgentService).find({
+      where: { serviceId: In(serviceIds) },
+    });
+    agentIdsForServices = [...new Set(matches.map(({ agentId }) => agentId))];
+  }
+
   return {
     ...(filter?.type
       ? {
@@ -46,11 +66,9 @@ export function getAgentWhere(
           districtId: normalizeStringArrayInput(filter.district),
         }
       : {}),
-    ...(filter?.services
+    ...(agentIdsForServices
       ? {
-          agentService: {
-            serviceId: normalizeStringArrayInput(filter.services),
-          },
+          id: In(agentIdsForServices.length > 0 ? agentIdsForServices : [-1]),
         }
       : {}),
   } as FindOptionsWhere<Agent>;

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -1,3 +1,4 @@
+export * from "./add-agent-type-service-translations";
 export * from "./add-category-to-deal";
 export * from "./add-comments-entity";
 export * from "./add-district-to-agent";

--- a/src/server/utils/data/write-agent-registration.ts
+++ b/src/server/utils/data/write-agent-registration.ts
@@ -6,6 +6,7 @@ import {
 import { dataSource } from "../../../data/data-source";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
+import AgentService from "../../../data/entity/m2m/agent-service";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Person from "../../../data/entity/person.entity";
 import { createAddress } from "./for-routes";
@@ -79,14 +80,23 @@ export async function createAgentForPerson(
     const agent = await manager.getRepository(Agent).save(
       new Agent({
         title: input.title,
-        type: input.type ?? undefined,
+        agentTypeId: input.typeId ?? undefined,
         info: input.info ?? undefined,
         website: input.website ?? undefined,
-        services: input.services ?? undefined,
         districtId: input.districtId ?? undefined,
         addressId: address?.id,
       }),
     );
+
+    if (input.serviceIds?.length) {
+      await manager
+        .getRepository(AgentService)
+        .save(
+          input.serviceIds.map(
+            (serviceId) => ({ agentId: agent.id, serviceId }) as AgentService,
+          ),
+        );
+    }
 
     await manager.getRepository(AgentPerson).save(
       new AgentPerson({

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -5,6 +5,7 @@ import {
   ApiAgentMembership,
   ApiAgentOpportunity,
   ApiOpportunityAgent,
+  OptionById,
 } from "need4deed-sdk";
 import Comment from "../../data/entity/comment.entity";
 import AgentPerson from "../../data/entity/m2m/agent-person";
@@ -14,6 +15,13 @@ import { serializeAddress } from "./dto-address";
 import { commentSerializer } from "./dto-comment";
 import { dtoSerializePerson } from "./dto-person";
 import { getAvailability, getLanguages } from "./utils";
+
+// Translated reference data (AgentType/Service) isn't resolved per-language
+// here yet — like `district` below, this passes through the loaded title as
+// `de` until field_translation-based resolution is wired in.
+function dtoOptionTitle(id: number | undefined, title?: string): OptionById {
+  return { id, title: { de: title } };
+}
 
 // Serializes an agent<->person membership for the moderation endpoints.
 // Expects the `agent` and `person` relations to be loaded.
@@ -34,7 +42,7 @@ export function dtoAgentGetList(agent: Agent): ApiAgentGetList {
   return {
     id: agent.id,
     title: agent.title,
-    type: agent.type!,
+    type: dtoOptionTitle(agent.agentTypeId, agent.agentType?.title),
     trustLevel: agent.trustLevel,
     volunteerSearch: agent.searchStatus,
     activeVolunteers: agent.activeVolunteers,
@@ -68,7 +76,9 @@ export function dtoAgentGet(
     contacts: (agent.agentPerson ?? []).map((ap) =>
       dtoSerializeAgentMembership({ ...ap, agent }),
     ),
-    serviceType: agent.services,
+    services: (agent.agentService ?? []).map((as) =>
+      dtoOptionTitle(as.serviceId, as.service?.title),
+    ),
     trustLevel: agent.trustLevel,
     statusEngagement: agent.engagementStatus,
     agentDetails: dtoAgentDetails(agent),
@@ -84,7 +94,7 @@ export function dtoAgentGet(
 export function dtoOpportunityAgent(agent: Agent): ApiOpportunityAgent {
   return {
     id: agent.id,
-    type: agent.type,
+    type: dtoOptionTitle(agent.agentTypeId, agent.agentType?.title),
     name: agent.title,
     address: serializeAddress(agent.representative?.person?.address),
     district: {
@@ -104,9 +114,11 @@ function dtoAgentDetails(agent: Agent): AgentDetails & {
     addressStreet: agent.address?.street ?? null,
     addressPostcode: agent.address?.postcode?.value ?? null,
     website: agent.website,
-    organizationType: agent.type,
+    organizationType: dtoOptionTitle(agent.agentTypeId, agent.agentType?.title),
     operator: agent?.organization?.title,
-    services: agent.services?.join(", "),
+    services: (agent.agentService ?? []).map((as) =>
+      dtoOptionTitle(as.serviceId, as.service?.title),
+    ),
     clientLanguages:
       agent.agentLanguage?.map((al) => ({
         id: al.languageId,

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -6,6 +6,7 @@ import {
   ApiAgentOpportunity,
   ApiOpportunityAgent,
   OptionById,
+  OptionTitle,
 } from "need4deed-sdk";
 import Comment from "../../data/entity/comment.entity";
 import AgentPerson from "../../data/entity/m2m/agent-person";
@@ -16,11 +17,16 @@ import { commentSerializer } from "./dto-comment";
 import { dtoSerializePerson } from "./dto-person";
 import { getAvailability, getLanguages } from "./utils";
 
-// Translated reference data (AgentType/Service) isn't resolved per-language
-// here yet — like `district` below, this passes through the loaded title as
-// `de` until field_translation-based resolution is wired in.
-function dtoOptionTitle(id: number | undefined, title?: string): OptionById {
-  return { id, title: { de: title } };
+// Prefers the real en/de field_translation rows resolved by
+// addAgentTypeServiceTranslations onto `ref.translations`; falls back to the
+// raw, untranslated title (like `district` below) when that enrichment step
+// hasn't run — e.g. a caller that loads the entity without going through the
+// GET /agent or GET /opportunity route handlers.
+function dtoOptionTitle(
+  id: number | undefined,
+  ref?: { title?: string; translations?: OptionTitle },
+): OptionById {
+  return { id, title: ref?.translations ?? { de: ref?.title } };
 }
 
 // Serializes an agent<->person membership for the moderation endpoints.
@@ -42,7 +48,7 @@ export function dtoAgentGetList(agent: Agent): ApiAgentGetList {
   return {
     id: agent.id,
     title: agent.title,
-    type: dtoOptionTitle(agent.agentTypeId, agent.agentType?.title),
+    type: dtoOptionTitle(agent.agentTypeId, agent.agentType),
     trustLevel: agent.trustLevel,
     volunteerSearch: agent.searchStatus,
     activeVolunteers: agent.activeVolunteers,
@@ -77,7 +83,7 @@ export function dtoAgentGet(
       dtoSerializeAgentMembership({ ...ap, agent }),
     ),
     services: (agent.agentService ?? []).map((as) =>
-      dtoOptionTitle(as.serviceId, as.service?.title),
+      dtoOptionTitle(as.serviceId, as.service),
     ),
     trustLevel: agent.trustLevel,
     statusEngagement: agent.engagementStatus,
@@ -94,7 +100,7 @@ export function dtoAgentGet(
 export function dtoOpportunityAgent(agent: Agent): ApiOpportunityAgent {
   return {
     id: agent.id,
-    type: dtoOptionTitle(agent.agentTypeId, agent.agentType?.title),
+    type: dtoOptionTitle(agent.agentTypeId, agent.agentType),
     name: agent.title,
     address: serializeAddress(agent.representative?.person?.address),
     district: {
@@ -114,10 +120,10 @@ function dtoAgentDetails(agent: Agent): AgentDetails & {
     addressStreet: agent.address?.street ?? null,
     addressPostcode: agent.address?.postcode?.value ?? null,
     website: agent.website,
-    organizationType: dtoOptionTitle(agent.agentTypeId, agent.agentType?.title),
+    organizationType: dtoOptionTitle(agent.agentTypeId, agent.agentType),
     operator: agent?.organization?.title,
     services: (agent.agentService ?? []).map((as) =>
-      dtoOptionTitle(as.serviceId, as.service?.title),
+      dtoOptionTitle(as.serviceId, as.service),
     ),
     clientLanguages:
       agent.agentLanguage?.map((al) => ({

--- a/src/services/dto/parser-agent.ts
+++ b/src/services/dto/parser-agent.ts
@@ -1,18 +1,19 @@
 import { ApiAgentPatch } from "need4deed-sdk";
 import Agent from "../../data/entity/opportunity/agent.entity";
 
+// serviceIds isn't included here: it's a m2m relation (AgentService), synced
+// separately via updateAgentServices — see agent.routes.ts's PATCH handler.
 export function parseAgentPatch(agent: ApiAgentPatch): Partial<Agent> {
   return {
     title: agent.title,
     info: agent.about,
     website: agent.website,
-    type: agent.type,
+    agentTypeId: agent.typeId,
     trustLevel: agent.trustLevel,
-    // GET emits volunteerSearch/serviceType while PATCH uses statusSearch/services;
-    // accept either so round-tripped fields aren't silently dropped.
+    // GET emits volunteerSearch while PATCH uses statusSearch; accept either
+    // so round-tripped fields aren't silently dropped.
     searchStatus: agent.statusSearch ?? agent.volunteerSearch,
     engagementStatus: agent.statusEngagement,
-    services: agent.services ?? agent.serviceType,
     districtId: agent.districtId,
   };
 }

--- a/src/test/server/utils/data/get-agent-where.test.ts
+++ b/src/test/server/utils/data/get-agent-where.test.ts
@@ -1,0 +1,55 @@
+import { In } from "typeorm";
+import { describe, expect, it, vi } from "vitest";
+import { getAgentWhere } from "../../../../server/utils/data/get-agent-where";
+
+const agentServiceFind = vi.fn();
+
+vi.mock("../../../../data/data-source", () => ({
+  dataSource: {
+    getRepository: () => ({ find: agentServiceFind }),
+  },
+}));
+
+describe("getAgentWhere", () => {
+  it("returns an empty object when no filters are provided", async () => {
+    expect(await getAgentWhere(undefined)).toEqual({});
+  });
+
+  it("filters by agentTypeId for `type`", async () => {
+    const where = await getAgentWhere({ type: ["1", "2"] });
+    expect(where).toEqual({ agentTypeId: In(["1", "2"]) });
+  });
+
+  // Regression test: a naive `agentService: { serviceId: In(...) }` filter
+  // joins agent -> agent_service, so an agent matching more than one
+  // selected service comes back once per match, duplicating it in
+  // findAndCount's results and inflating the total. getAgentWhere resolves
+  // matching agent ids in a separate query instead, so the outer filter is a
+  // plain scalar `id IN (...)` with no join to fan out.
+  it("dedupes an agent that matches more than one selected service into a single id", async () => {
+    agentServiceFind.mockResolvedValue([
+      { agentId: 5, serviceId: 1 },
+      { agentId: 5, serviceId: 2 },
+      { agentId: 7, serviceId: 2 },
+    ]);
+
+    const where = await getAgentWhere({ services: ["1", "2"] });
+
+    expect(agentServiceFind).toHaveBeenCalledWith({
+      where: { serviceId: In([1, 2]) },
+    });
+    expect(where).toEqual({ id: In([5, 7]) });
+  });
+
+  it("filters out every agent (rather than matching none-filtered) when no service matches", async () => {
+    agentServiceFind.mockResolvedValue([]);
+    const where = await getAgentWhere({ services: ["999"] });
+    expect(where).toEqual({ id: In([-1]) });
+  });
+
+  it("combines a services match with other filters at the top level", async () => {
+    agentServiceFind.mockResolvedValue([{ agentId: 3, serviceId: 4 }]);
+    const where = await getAgentWhere({ services: ["4"], district: ["9"] });
+    expect(where).toEqual({ id: In([3]), districtId: In(["9"]) });
+  });
+});

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -48,13 +48,17 @@ describe("dtoAgentGet", () => {
           person: { firstName: "Jane" },
         },
       ],
-      services: ["Consulting", "Legal"],
+      agentService: [
+        { serviceId: 10, service: { title: "Consulting" } },
+        { serviceId: 11, service: { title: "Legal" } },
+      ],
       trustLevel: 5,
       engagementStatus: "Active",
       info: "Bio text",
       address: { street: "Baker St" },
       website: "https://agent.com",
-      type: "NGO",
+      agentTypeId: 3,
+      agentType: { title: "NGO" },
       agentLanguage: [{ languageId: "en", language: { title: "English" } }],
       comments: [{ id: 101, content: "Great service" }],
     };
@@ -94,13 +98,26 @@ describe("dtoAgentGet", () => {
     ]);
 
     // Checking nested agentDetails (via the internal helper)
-    expect(result.agentDetails.services).toBe("Consulting, Legal");
+    expect(result.agentDetails.organizationType).toEqual({
+      id: 3,
+      title: { de: "NGO" },
+    });
+    expect(result.agentDetails.services).toEqual([
+      { id: 10, title: { de: "Consulting" } },
+      { id: 11, title: { de: "Legal" } },
+    ]);
     expect(result.agentDetails.clientLanguages[0].title).toBe("English");
+
+    // Checking the top-level (non-nested) type/services mirror the same data
+    expect(result.type).toEqual({ id: 3, title: { de: "NGO" } });
+    expect(result.services).toEqual([
+      { id: 10, title: { de: "Consulting" } },
+      { id: 11, title: { de: "Legal" } },
+    ]);
   });
 
   it("should handle missing optional nested properties gracefully", () => {
     const minimalAgent = {
-      services: [],
       comments: undefined,
     };
 
@@ -117,7 +134,8 @@ describe("dtoOpportunityAgent", () => {
   it("should map agent to opportunity format with localized district", () => {
     const mockAgent = {
       id: 7,
-      type: "Provider",
+      agentTypeId: 9,
+      agentType: { title: "Provider" },
       title: "Clinic X",
       districtId: "dist_1",
       district: { title: "Mitte" },
@@ -128,7 +146,7 @@ describe("dtoOpportunityAgent", () => {
 
     expect(result).toEqual({
       id: 7,
-      type: "Provider",
+      type: { id: 9, title: { de: "Provider" } },
       name: "Clinic X",
       address: "serialized_address",
       district: {
@@ -140,15 +158,23 @@ describe("dtoOpportunityAgent", () => {
 });
 
 describe("dtoAgentDetails (Internal Logic)", () => {
-  it("should join services into a comma-separated string", () => {
+  it("should map services to an array of translated options", () => {
     const mockAgent = {
-      services: ["A", "B", "C"],
+      agentService: [
+        { serviceId: 1, service: { title: "A" } },
+        { serviceId: 2, service: { title: "B" } },
+        { serviceId: 3, service: { title: "C" } },
+      ],
       agentLanguage: [],
     };
 
     // Since it's a private helper, we test it through dtoAgentGet
     const result = dtoAgentGet(mockAgent as any);
-    expect(result.agentDetails.services).toBe("A, B, C");
+    expect(result.agentDetails.services).toEqual([
+      { id: 1, title: { de: "A" } },
+      { id: 2, title: { de: "B" } },
+      { id: 3, title: { de: "C" } },
+    ]);
   });
 
   it("should return an empty array if agentLanguage is missing", () => {
@@ -179,7 +205,8 @@ describe("dtoAgentGetList", () => {
   const mockAgentBase = {
     id: 1,
     title: "Helping Hands",
-    type: "NGO",
+    agentTypeId: 3,
+    agentType: { title: "NGO" },
     activeVolunteers: 10,
     numOpportunities: 0,
     addressId: 101,
@@ -207,7 +234,7 @@ describe("dtoAgentGetList", () => {
     expect(result).toEqual({
       id: 1,
       title: "Helping Hands",
-      type: "NGO",
+      type: { id: 3, title: { de: "NGO" } },
       trustLevel: AgentTrustType.HIGH,
       activeVolunteers: 10,
       numOpportunities: 2,

--- a/src/test/services/dto/dto-agent.test.ts
+++ b/src/test/services/dto/dto-agent.test.ts
@@ -128,6 +128,30 @@ describe("dtoAgentGet", () => {
     expect(result.representative.role).toBeUndefined();
     expect(result.contacts).toEqual([]);
   });
+
+  // Regression test: service.title is the DB key ("sport", "welfare"), not a
+  // translation — it must never be passed through as `de` once
+  // addAgentTypeServiceTranslations has resolved real translations.
+  it("prefers each service's translations over the raw title once resolved", () => {
+    const mockAgent = {
+      agentService: [
+        {
+          serviceId: 7,
+          service: {
+            title: "sport",
+            translations: { en: "sport", de: "Sport" },
+          },
+        },
+      ],
+      agentLanguage: [],
+    };
+
+    const result = dtoAgentGet(mockAgent as any);
+
+    expect(result.services).toEqual([
+      { id: 7, title: { en: "sport", de: "Sport" } },
+    ]);
+  });
 });
 
 describe("dtoOpportunityAgent", () => {
@@ -265,6 +289,30 @@ describe("dtoAgentGetList", () => {
     // Ensure the mapping from agent.searchStatus to volunteerSearch is correct
     const result = dtoAgentGetList({ ...mockAgentBase } as any);
     expect(result.volunteerSearch).toBe(AgentVolunteerSearchType.SEARCHING);
+  });
+
+  // Regression test: the raw agentType.title is the DB key ("welfare",
+  // "GU2"), not a translation — it must never be passed through as `de`
+  // once addAgentTypeServiceTranslations has resolved real translations.
+  it("prefers agentType.translations over the raw title once resolved", () => {
+    const result = dtoAgentGetList({
+      ...mockAgentBase,
+      agentType: {
+        title: "NGO",
+        translations: {
+          en: "Multiple social support",
+          de: "Mehrere Soziale Leistungen",
+        },
+      },
+    } as any);
+
+    expect(result.type).toEqual({
+      id: 3,
+      title: {
+        en: "Multiple social support",
+        de: "Mehrere Soziale Leistungen",
+      },
+    });
   });
 });
 

--- a/src/test/services/dto/parser-agent.test.ts
+++ b/src/test/services/dto/parser-agent.test.ts
@@ -1,8 +1,6 @@
 import {
   AgentEngagementStatusType,
-  AgentServiceType,
   AgentTrustType,
-  AgentType,
   AgentVolunteerSearchType,
   ApiAgentPatch,
 } from "need4deed-sdk";
@@ -15,11 +13,13 @@ describe("parseAgentPatch", () => {
       title: "Global Relief NGO",
       about: "A non-profit focused on disaster recovery.",
       website: "https://example.org",
-      type: "AE" as AgentType,
+      typeId: 1,
       trustLevel: "unknown" as AgentTrustType,
       statusSearch: "agent-not-needed" as AgentVolunteerSearchType,
       statusEngagement: "agent-new" as AgentEngagementStatusType,
-      services: ["childcare", "refugee-accommodation"] as AgentServiceType[],
+      // serviceIds is a m2m relation synced separately (updateAgentServices),
+      // not part of the Partial<Agent> this returns — asserted below.
+      serviceIds: [1, 2],
     };
 
     const result = parseAgentPatch(mockApiAgent);
@@ -28,12 +28,12 @@ describe("parseAgentPatch", () => {
       title: "Global Relief NGO",
       info: "A non-profit focused on disaster recovery.",
       website: "https://example.org",
-      type: "AE",
+      agentTypeId: 1,
       trustLevel: "unknown",
       searchStatus: "agent-not-needed",
       engagementStatus: "agent-new",
-      services: ["childcare", "refugee-accommodation"],
     });
+    expect(result).not.toHaveProperty("serviceIds");
   });
 
   it("should handle undefined or missing optional fields", () => {
@@ -48,30 +48,25 @@ describe("parseAgentPatch", () => {
     expect(result.searchStatus).toBeUndefined();
   });
 
-  it("falls back to volunteerSearch/serviceType when statusSearch/services are absent", () => {
+  it("falls back to volunteerSearch when statusSearch is absent", () => {
     const agent: ApiAgentPatch = {
       volunteerSearch: "agent-searching" as AgentVolunteerSearchType,
-      serviceType: ["tutoring"] as AgentServiceType[],
     };
 
     const result = parseAgentPatch(agent);
 
     expect(result.searchStatus).toBe("agent-searching");
-    expect(result.services).toEqual(["tutoring"]);
   });
 
-  it("prefers statusSearch/services over volunteerSearch/serviceType when both are set", () => {
+  it("prefers statusSearch over volunteerSearch when both are set", () => {
     const agent: ApiAgentPatch = {
       statusSearch: "agent-not-needed" as AgentVolunteerSearchType,
       volunteerSearch: "agent-searching" as AgentVolunteerSearchType,
-      services: ["childcare"] as AgentServiceType[],
-      serviceType: ["tutoring"] as AgentServiceType[],
     };
 
     const result = parseAgentPatch(agent);
 
     expect(result.searchStatus).toBe("agent-not-needed");
-    expect(result.services).toEqual(["childcare"]);
   });
 
   it("maps districtId", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.133:
-  version "0.0.133"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.133.tgz#b61648c86139474938aac531d16205a4f55a260f"
-  integrity sha512-VewV+N4If/SdpuVpAiHZgil9q8t3Qn4JKoitRibvYetED1oYodQeAsgnFf4XvkC1F1SLx1A7kfHCKRWe00nyKg==
+need4deed-sdk@0.0.136:
+  version "0.0.136"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.136.tgz#331130387c520bffbf55d118e801abd844d95f3d"
+  integrity sha512-OeYBZnAb+d/hMC8FArJ+PD42oXg04BZgj36aqggx61LYGAINtiMb7aE6vG/h5yoTCrTkvG0doQa8HXqfF1tFMw==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
Part of #794. Depends on `need4deed-sdk@0.0.136` (need4deed-org/sdk#177).

- New `AgentType`/`Service` reference entities (mirroring `Skill`'s pattern: id + unique title + non-persisted `translation` prop) and an `AgentService` m2m join entity (mirroring `DealSkill`).
- `Agent.type` (enum column) → `agent.agentTypeId` FK; `Agent.services` (`text[]`) → `agent_service` join rows.
- Migration (`1784898817413-add-agent-type-and-service`):
  - Creates `agent_type`/`service`/`agent_service` tables.
  - Seeds `agent_type`/`service` from literal values snapshotted from the SDK's `AgentTypeKey`/`AgentServiceType` enums — never imported, per the self-contained-migration rule in CLAUDE.md.
  - Backfills `agent_type_id` and `agent_service` from the old columns before dropping them.
  - Seeds `field_translation` (en/de) and registers the new rows with the generic `GET /option` list registry (`option` table), then drops the old `type`/`services` columns.
- Since migrations run *before* the dev/test seed pipeline, `language` rows don't exist yet on a from-scratch bootstrap — the migration's own `field_translation` insert seeds 0 rows there. `seedFieldTranslation` gained `seedAgentTypes`/`seedServices` (mirroring `seedSkills`) as the fallback for that case. On any already-migrated environment (staging/prod, or any dev DB that predates this PR), the migration's insert does the job directly since `language` already exists there.
- `dto-agent.ts`/`parser-agent.ts`/`get-agent-where.ts`/`write-agent-registration.ts` updated for the new relations. Write payloads use `typeId`/`serviceIds` (bare ids), matching the existing `districtId` convention — confirmed with the repo owner before implementing (see sdk#177's resolved open questions).
- `GET /option` now serves `agent_type`/`service` alongside the existing skill/activity/district/etc. lists.
- Removed dead `AgentOperatorType`/`AgentType` enums in `data/types/enums.ts` (unused, and the latter's values didn't even match the real SDK enum).

**Note on translation copy:** the en/de labels seeded here are pulled from what's already shipped in `fe` (`AGENT_TYPE_LABELS`/`AGENT_SERVICE_LABELS` + the `filters.type`/`filters.services` i18n keys), not invented. Flagging in case there's a preferred/updated copy to use instead before merge.

## Test plan
- [x] `yarn typecheck` / `yarn lint` pass
- [x] Full test suite: 54 files / 464 tests pass
- [x] Canonical fresh-replay check (`docker compose down -v && RUN_MIGRATIONS=1 docker compose up`): migration applies cleanly on a genuinely empty DB, seed pipeline backfills translations, no errors
- [x] Verified `GET /option/agent_type` and `GET /option/service` return correctly translated data end-to-end (en and de)
- [ ] `be`/`fe` DTO-level real per-request translation resolution (currently the DTO passes through the loaded relation's raw title as a placeholder, matching the existing `district` shortcut in the same file) — flagged as a known follow-up in the original issue, not part of this slice