### PR TITLE
Match existing agents by street prefix in registration picker

### DIFF
--- a/src/server/routes/agent/register.routes.ts
+++ b/src/server/routes/agent/register.routes.ts
@@ -26,6 +26,7 @@ import {
   classifyRegisterAgentConflict,
   createAgentForPerson,
   getAgentByAddress,
+  getAgentsByStreetPrefix,
   joinAgent,
   resolveJoinStatus,
 } from "../../utils";
@@ -114,10 +115,24 @@ export default async function agentRegisterRoutes(
         })
         .getMany();
 
-      // Reuse the POST /opportunity/legacy picker (strict street+PLZ, then fuzzy
-      // street-name) — returns the single best match (or none).
-      const match = getAgentByAddress(candidates, street, postcode);
-      const data = match ? [{ id: match.id, title: match.title }] : [];
+      // Two complementary sources, deduped by id: the strict/legacy-fuzzy
+      // single-best match shared with POST /opportunity/legacy, plus a street
+      // prefix search so partial input (3+ chars) can surface candidates
+      // before the full street has been typed.
+      const exactMatch = getAgentByAddress(candidates, street, postcode);
+      const prefixMatches = getAgentsByStreetPrefix(
+        candidates,
+        street,
+        postcode,
+      );
+      const matches = new Map(prefixMatches.map((a) => [a.id, a]));
+      if (exactMatch) {
+        matches.set(exactMatch.id, exactMatch);
+      }
+      const data = Array.from(matches.values()).map((a) => ({
+        id: a.id,
+        title: a.title,
+      }));
       return reply
         .status(200)
         .send({ message: `Found ${data.length} matches`, data });

--- a/src/server/routes/agent/register.routes.ts
+++ b/src/server/routes/agent/register.routes.ts
@@ -28,6 +28,7 @@ import {
   getAgentByAddress,
   getAgentsByStreetPrefix,
   joinAgent,
+  mergeAgentMatches,
   resolveJoinStatus,
 } from "../../utils";
 
@@ -115,21 +116,17 @@ export default async function agentRegisterRoutes(
         })
         .getMany();
 
-      // Two complementary sources, deduped by id: the strict/legacy-fuzzy
-      // single-best match shared with POST /opportunity/legacy, plus a street
-      // prefix search so partial input (3+ chars) can surface candidates
-      // before the full street has been typed.
+      // Two complementary sources, merged with the decisive match first: the
+      // strict/legacy-fuzzy single-best match shared with POST
+      // /opportunity/legacy, plus a street prefix search so partial input
+      // (3+ chars) can surface candidates before the full street is typed.
       const exactMatch = getAgentByAddress(candidates, street, postcode);
       const prefixMatches = getAgentsByStreetPrefix(
         candidates,
         street,
         postcode,
       );
-      const matches = new Map(prefixMatches.map((a) => [a.id, a]));
-      if (exactMatch) {
-        matches.set(exactMatch.id, exactMatch);
-      }
-      const data = Array.from(matches.values()).map((a) => ({
+      const data = mergeAgentMatches(exactMatch, prefixMatches).map((a) => ({
         id: a.id,
         title: a.title,
       }));

--- a/src/server/utils/data/get-agent-by-postcode.ts
+++ b/src/server/utils/data/get-agent-by-postcode.ts
@@ -80,6 +80,30 @@ export function getAgentByAddress(
   return fuzzyMatches.length === 1 ? fuzzyMatches[0] : undefined;
 }
 
+// Prefix search for the self-registration picker: agents whose address.street
+// starts with the (normalized) typed value. Deliberately separate from
+// getAgentByAddress — that function's strict/fuzzy paths back the CREATE-path
+// conflict check and the legacy find-or-create flow, both of which need a
+// single decisive match rather than a broadening candidate list.
+export function getAgentsByStreetPrefix(
+  agents: Agent[],
+  street: string,
+  plz?: string,
+): Agent[] {
+  const normStreet = normalizeStreet(street);
+  if (!normStreet) {
+    return [];
+  }
+
+  return agents.filter((a) => {
+    if (plz && a.address?.postcode?.value !== plz) {
+      return false;
+    }
+    const agentStreet = a.address?.street;
+    return !!agentStreet && normalizeStreet(agentStreet).startsWith(normStreet);
+  });
+}
+
 export function getAgentByPostcode(
   agents: Agent[],
   plz: string,

--- a/src/server/utils/data/get-agent-by-postcode.ts
+++ b/src/server/utils/data/get-agent-by-postcode.ts
@@ -104,6 +104,18 @@ export function getAgentsByStreetPrefix(
   });
 }
 
+// Combines the two search picker sources into a single ordered, deduped list:
+// the decisive exact/legacy-fuzzy match (if any) always first, since callers
+// (e.g. the frontend picker) treat the first entry as the best guess, followed
+// by the remaining prefix matches.
+export function mergeAgentMatches(
+  exactMatch: Agent | undefined,
+  prefixMatches: Agent[],
+): Agent[] {
+  const rest = prefixMatches.filter((a) => a.id !== exactMatch?.id);
+  return exactMatch ? [exactMatch, ...rest] : rest;
+}
+
 export function getAgentByPostcode(
   agents: Agent[],
   plz: string,

--- a/src/test/server/utils/data/get-agent-by-postcode.test.ts
+++ b/src/test/server/utils/data/get-agent-by-postcode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAgentByAddress,
   getAgentByPostcode,
+  getAgentsByStreetPrefix,
 } from "../../../../server/utils";
 
 describe("getAgentByPostcode", () => {
@@ -179,5 +180,65 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
     expect(getAgentByAddress(agents, "Hausvaterweg 21 A", plz)).toEqual(
       legacyAgent,
     );
+  });
+});
+
+describe("getAgentsByStreetPrefix", () => {
+  const mueller = {
+    id: 1,
+    address: { postcode: { value: "13353" }, street: "Müllerstraße 48" },
+  } as any;
+  const haupt = {
+    id: 2,
+    address: { postcode: { value: "55555" }, street: "Hauptstr. 10" },
+  } as any;
+  const legacyNoAddress = {
+    id: 3,
+    title: "Refugium Hausvaterweg",
+    address: null,
+    agentPostcode: [{ postcode: { value: "13353" } }],
+  } as any;
+
+  it("matches on a partial (3+ char) prefix of the street", () => {
+    expect(getAgentsByStreetPrefix([mueller, haupt], "Mül")).toEqual([mueller]);
+  });
+
+  it("is case/spelling-insensitive like the strict match (straße/strasse/str.)", () => {
+    expect(getAgentsByStreetPrefix([mueller], "müller str")).toEqual([mueller]);
+    expect(getAgentsByStreetPrefix([mueller], "MÜLLERSTR")).toEqual([mueller]);
+  });
+
+  it("returns all agents matching the prefix, not just one", () => {
+    const muellerTwo = {
+      id: 4,
+      address: { postcode: { value: "13353" }, street: "Müllerstraße 12" },
+    } as any;
+    expect(
+      getAgentsByStreetPrefix([mueller, muellerTwo, haupt], "Müllerstr"),
+    ).toEqual([mueller, muellerTwo]);
+  });
+
+  it("narrows by postcode when provided", () => {
+    const muellerElsewhere = {
+      id: 5,
+      address: { postcode: { value: "99999" }, street: "Müllerstraße 3" },
+    } as any;
+    expect(
+      getAgentsByStreetPrefix([mueller, muellerElsewhere], "Müller", "13353"),
+    ).toEqual([mueller]);
+  });
+
+  it("does not match a different street with a similar prefix", () => {
+    expect(getAgentsByStreetPrefix([haupt], "Müller")).toEqual([]);
+  });
+
+  it("ignores legacy agents with no address.street", () => {
+    expect(getAgentsByStreetPrefix([legacyNoAddress], "Hausvaterweg")).toEqual(
+      [],
+    );
+  });
+
+  it("returns an empty array when the typed value normalizes to empty", () => {
+    expect(getAgentsByStreetPrefix([mueller], "   ")).toEqual([]);
   });
 });

--- a/src/test/server/utils/data/get-agent-by-postcode.test.ts
+++ b/src/test/server/utils/data/get-agent-by-postcode.test.ts
@@ -3,6 +3,7 @@ import {
   getAgentByAddress,
   getAgentByPostcode,
   getAgentsByStreetPrefix,
+  mergeAgentMatches,
 } from "../../../../server/utils";
 
 describe("getAgentByPostcode", () => {
@@ -240,5 +241,37 @@ describe("getAgentsByStreetPrefix", () => {
 
   it("returns an empty array when the typed value normalizes to empty", () => {
     expect(getAgentsByStreetPrefix([mueller], "   ")).toEqual([]);
+  });
+});
+
+describe("mergeAgentMatches", () => {
+  const exact = { id: 1, title: "Exact Match Agent" } as any;
+  const prefixOnly = { id: 2, title: "Prefix Only Agent" } as any;
+  const anotherPrefixOnly = { id: 3, title: "Another Prefix Agent" } as any;
+
+  it("puts the exact match first even when prefix matches precede it in the source list", () => {
+    expect(
+      mergeAgentMatches(exact, [prefixOnly, anotherPrefixOnly, exact]),
+    ).toEqual([exact, prefixOnly, anotherPrefixOnly]);
+  });
+
+  it("does not duplicate the exact match when it also appears in prefix matches", () => {
+    const merged = mergeAgentMatches(exact, [exact, prefixOnly]);
+    expect(merged).toEqual([exact, prefixOnly]);
+    expect(merged.filter((a) => a.id === exact.id)).toHaveLength(1);
+  });
+
+  it("returns just the exact match when there are no prefix matches", () => {
+    expect(mergeAgentMatches(exact, [])).toEqual([exact]);
+  });
+
+  it("returns the prefix matches unchanged when there is no exact match", () => {
+    expect(
+      mergeAgentMatches(undefined, [prefixOnly, anotherPrefixOnly]),
+    ).toEqual([prefixOnly, anotherPrefixOnly]);
+  });
+
+  it("returns an empty array when neither is present", () => {
+    expect(mergeAgentMatches(undefined, [])).toEqual([]);
   });
 });


### PR DESCRIPTION
GET /agent/register/search only offered a match once the full street value matched exactly (or, for legacy agents with no address row, via a fuzzy title match). Add getAgentsByStreetPrefix so partial input (3+ chars) surfaces agents with a real address.street as candidates, unioned with the existing exact/legacy match into the response list.

Closes need4deed-org/be#797

## Description
Describe the change and why it matters (optional).

## Related Issues
Closes #ISSUE_ID (mandatory if applicable)

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

