### PR TITLE
Fix fuzzy street match missing titles with punctuation-glued names

### DIFF
--- a/src/server/utils/data/get-agent-by-postcode.ts
+++ b/src/server/utils/data/get-agent-by-postcode.ts
@@ -30,7 +30,11 @@ function agentHasPlz(a: Agent, plz: string): boolean {
 
 function streetNameWordRegex(streetName: string): RegExp {
   const escaped = streetName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(?:^|\\s)${escaped}(?:\\s|$)`);
+  // Boundary is "not a letter" rather than literal whitespace, so titles that
+  // glue the street name to the rest with punctuation (e.g. "Demo-Unterkunft")
+  // still match — while a real substring like "ringstr" inside "ostringstr"
+  // still correctly fails (the preceding character there is a letter).
+  return new RegExp(`(?:^|[^\\p{L}])${escaped}(?:[^\\p{L}]|$)`, "u");
 }
 
 export function getAgentByAddress(

--- a/src/test/server/utils/data/get-agent-by-postcode.test.ts
+++ b/src/test/server/utils/data/get-agent-by-postcode.test.ts
@@ -160,6 +160,16 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
     ).toEqual(heerstr110);
   });
 
+  it("matches when the street name is immediately followed by punctuation in the title (e.g. hyphen)", () => {
+    const agent = {
+      id: 8,
+      title: "Demo-Unterkunft Lichtenberg",
+      address: null,
+      agentPostcode: [{ postcode: { value: "10317" } }],
+    } as any;
+    expect(getAgentByAddress([agent], "Demo", "10317")).toEqual(agent);
+  });
+
   it("does not false-match when street name is a substring of a different street in title", () => {
     const agent = {
       id: 4,


### PR DESCRIPTION
## Description

Found this while manually testing the street-prefix picker (be#797/#798): the legacy fuzzy fallback in `getAgentByAddress` never matched agent `Demo-Unterkunft Lichtenberg` for street input `"Demo"`, even with the correct postcode.

Root cause: `streetNameWordRegex` bounds the whole-word match on literal whitespace (`\s`). The title glues the street name directly to the rest with a hyphen (no space), so the closing boundary (`\s|$`) never matches.

## Related Issues
Closes #799

## Changes
- `streetNameWordRegex`: boundary is now "not a letter" (`[^\p{L}]`, Unicode-aware) instead of literal whitespace, so punctuation (hyphens, etc.) counts as a valid word edge too.
- Verified this doesn't reopen the existing substring false-positive guard: `"ringstr"` still correctly fails to match inside `"ostringstr"` (`Ringstraße` vs `Ostringstraße`), since the character immediately preceding that substring is a letter, not a boundary.
- Added a test for the hyphenated-title case.

## Screenshots / Demos
N/A (backend matching logic).

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Tests added/updated
- [ ] Documentation updated
- [x] CI passes (pending)
