### PR TITLE
Redesign agent-search picker: drop postcode, address-prefix/title-contains matching

### DIFF
--- a/src/server/routes/agent/register.routes.ts
+++ b/src/server/routes/agent/register.routes.ts
@@ -25,11 +25,9 @@ import {
   AgentAddressConflictError,
   classifyRegisterAgentConflict,
   createAgentForPerson,
-  getAgentByAddress,
-  getAgentsByStreetPrefix,
   joinAgent,
-  mergeAgentMatches,
   resolveJoinStatus,
+  searchAgentCandidates,
 } from "../../utils";
 
 // Authorizes the registration routes via the email-verification JWT carried in
@@ -77,7 +75,7 @@ export default async function agentRegisterRoutes(
   // self-registration picker, so a registrant can JOIN their org instead of
   // creating a duplicate. Token-gated (not the COORDINATOR-only GET /agent).
   fastify.get<{
-    Querystring: { token: string; street?: string; postcode?: string };
+    Querystring: { token: string; street?: string };
   }>(
     "/search",
     {
@@ -91,42 +89,20 @@ export default async function agentRegisterRoutes(
     },
     async (request, reply) => {
       const street = (request.query.street ?? "").trim();
-      const postcode = (request.query.postcode ?? "").trim();
-      const domain = request.registrant?.email.split("@").pop()?.toLowerCase();
-      if (street.length < 3 || !domain) {
+      if (street.length < 3) {
         return reply.status(200).send({ message: "No query", data: [] });
       }
 
-      // Candidates: only agents the registrant is tied to by email domain — an
-      // existing member shares their domain (Person.email, falling back to the
-      // linked User.email). Keeps the picker to orgs they can join (mirrors
-      // resolveJoinStatus, so a picked agent auto-approves to ACTIVE) and
-      // narrows enumeration. Load the relations getAgentByAddress reads.
+      // No membership/domain scoping here — matching is purely on
+      // agent.address.street (or agent.title when there's no address).
+      // Whether a picked agent auto-approves (ACTIVE) or needs review
+      // (PENDING) is decided later, at JOIN time, by resolveJoinStatus.
       const candidates = await fastify.db.agentRepository
         .createQueryBuilder("agent")
         .leftJoinAndSelect("agent.address", "address")
-        .leftJoinAndSelect("address.postcode", "postcode")
-        .leftJoinAndSelect("agent.agentPostcode", "agentPostcode")
-        .leftJoinAndSelect("agentPostcode.postcode", "agentPostcodePostcode")
-        .innerJoin("agent.agentPerson", "ap")
-        .innerJoin("ap.person", "person")
-        .leftJoin("person.users", "usr")
-        .where("(person.email ILIKE :suffix OR usr.email ILIKE :suffix)", {
-          suffix: `%@${domain}`,
-        })
         .getMany();
 
-      // Two complementary sources, merged with the decisive match first: the
-      // strict/legacy-fuzzy single-best match shared with POST
-      // /opportunity/legacy, plus a street prefix search so partial input
-      // (3+ chars) can surface candidates before the full street is typed.
-      const exactMatch = getAgentByAddress(candidates, street, postcode);
-      const prefixMatches = getAgentsByStreetPrefix(
-        candidates,
-        street,
-        postcode,
-      );
-      const data = mergeAgentMatches(exactMatch, prefixMatches).map((a) => ({
+      const data = searchAgentCandidates(candidates, street).map((a) => ({
         id: a.id,
         title: a.title,
       }));

--- a/src/server/schema/agent-register.schema.ts
+++ b/src/server/schema/agent-register.schema.ts
@@ -26,7 +26,6 @@ export const registerSearchQuerySchema = {
   properties: {
     token: { type: "string", minLength: 1 },
     street: { type: "string" },
-    postcode: { type: "string" },
   },
 };
 

--- a/src/server/utils/data/get-agent-by-postcode.ts
+++ b/src/server/utils/data/get-agent-by-postcode.ts
@@ -80,15 +80,18 @@ export function getAgentByAddress(
   return fuzzyMatches.length === 1 ? fuzzyMatches[0] : undefined;
 }
 
-// Prefix search for the self-registration picker: agents whose address.street
-// starts with the (normalized) typed value. Deliberately separate from
-// getAgentByAddress — that function's strict/fuzzy paths back the CREATE-path
-// conflict check and the legacy find-or-create flow, both of which need a
-// single decisive match rather than a broadening candidate list.
-export function getAgentsByStreetPrefix(
+// Candidate search for the self-registration picker: returns every matching
+// agent (not a single best guess) so the registrant can pick from a list.
+// Deliberately separate from getAgentByAddress — that function's strict/fuzzy
+// paths back the CREATE-path conflict check and the legacy find-or-create
+// flow, both of which need a single decisive answer, no postcode narrowing
+// here, and no house-number/word-boundary disambiguation: once a real
+// address.street exists, a plain prefix match is enough; once it doesn't
+// (legacy agents), a plain substring match against the title is enough, since
+// ambiguity is resolved by the human picking from the list, not by the code.
+export function searchAgentCandidates(
   agents: Agent[],
   street: string,
-  plz?: string,
 ): Agent[] {
   const normStreet = normalizeStreet(street);
   if (!normStreet) {
@@ -96,24 +99,11 @@ export function getAgentsByStreetPrefix(
   }
 
   return agents.filter((a) => {
-    if (plz && a.address?.postcode?.value !== plz) {
-      return false;
+    if (a.address) {
+      return normalizeStreet(a.address.street ?? "").startsWith(normStreet);
     }
-    const agentStreet = a.address?.street;
-    return !!agentStreet && normalizeStreet(agentStreet).startsWith(normStreet);
+    return normalizeStreet(a.title ?? "").includes(normStreet);
   });
-}
-
-// Combines the two search picker sources into a single ordered, deduped list:
-// the decisive exact/legacy-fuzzy match (if any) always first, since callers
-// (e.g. the frontend picker) treat the first entry as the best guess, followed
-// by the remaining prefix matches.
-export function mergeAgentMatches(
-  exactMatch: Agent | undefined,
-  prefixMatches: Agent[],
-): Agent[] {
-  const rest = prefixMatches.filter((a) => a.id !== exactMatch?.id);
-  return exactMatch ? [exactMatch, ...rest] : rest;
 }
 
 export function getAgentByPostcode(

--- a/src/test/server/utils/data/get-agent-by-postcode.test.ts
+++ b/src/test/server/utils/data/get-agent-by-postcode.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAgentByAddress,
   getAgentByPostcode,
-  getAgentsByStreetPrefix,
-  mergeAgentMatches,
+  searchAgentCandidates,
 } from "../../../../server/utils";
 
 describe("getAgentByPostcode", () => {
@@ -184,94 +183,74 @@ describe("getAgentByAddress — fuzzy fallback for legacy agents", () => {
   });
 });
 
-describe("getAgentsByStreetPrefix", () => {
+describe("searchAgentCandidates", () => {
   const mueller = {
     id: 1,
-    address: { postcode: { value: "13353" }, street: "Müllerstraße 48" },
+    address: { street: "Müllerstraße 48" },
+    title: "Müller Wohnheim",
   } as any;
   const haupt = {
     id: 2,
-    address: { postcode: { value: "55555" }, street: "Hauptstr. 10" },
+    address: { street: "Hauptstr. 10" },
+    title: "Haupt Wohnheim",
   } as any;
-  const legacyNoAddress = {
+  const legacyDemo = {
     id: 3,
-    title: "Refugium Hausvaterweg",
+    title: "Demo-Unterkunft Lichtenberg",
     address: null,
-    agentPostcode: [{ postcode: { value: "13353" } }],
   } as any;
 
-  it("matches on a partial (3+ char) prefix of the street", () => {
-    expect(getAgentsByStreetPrefix([mueller, haupt], "Mül")).toEqual([mueller]);
+  it("matches agents with a real address on a partial (3+ char) street prefix", () => {
+    expect(searchAgentCandidates([mueller, haupt], "Mül")).toEqual([mueller]);
   });
 
-  it("is case/spelling-insensitive like the strict match (straße/strasse/str.)", () => {
-    expect(getAgentsByStreetPrefix([mueller], "müller str")).toEqual([mueller]);
-    expect(getAgentsByStreetPrefix([mueller], "MÜLLERSTR")).toEqual([mueller]);
+  it("is case/spelling-insensitive on the street prefix (straße/strasse/str.)", () => {
+    expect(searchAgentCandidates([mueller], "müller str")).toEqual([mueller]);
+    expect(searchAgentCandidates([mueller], "MÜLLERSTR")).toEqual([mueller]);
   });
 
-  it("returns all agents matching the prefix, not just one", () => {
+  it("returns every agent matching the street prefix, not just one", () => {
     const muellerTwo = {
       id: 4,
-      address: { postcode: { value: "13353" }, street: "Müllerstraße 12" },
+      address: { street: "Müllerstraße 12" },
+      title: "Müller Wohnheim 2",
     } as any;
     expect(
-      getAgentsByStreetPrefix([mueller, muellerTwo, haupt], "Müllerstr"),
+      searchAgentCandidates([mueller, muellerTwo, haupt], "Müllerstr"),
     ).toEqual([mueller, muellerTwo]);
   });
 
-  it("narrows by postcode when provided", () => {
-    const muellerElsewhere = {
-      id: 5,
-      address: { postcode: { value: "99999" }, street: "Müllerstraße 3" },
-    } as any;
-    expect(
-      getAgentsByStreetPrefix([mueller, muellerElsewhere], "Müller", "13353"),
-    ).toEqual([mueller]);
-  });
-
   it("does not match a different street with a similar prefix", () => {
-    expect(getAgentsByStreetPrefix([haupt], "Müller")).toEqual([]);
+    expect(searchAgentCandidates([haupt], "Müller")).toEqual([]);
   });
 
-  it("ignores legacy agents with no address.street", () => {
-    expect(getAgentsByStreetPrefix([legacyNoAddress], "Hausvaterweg")).toEqual(
-      [],
-    );
+  it("matches legacy agents (no address) on a title substring, not just a prefix", () => {
+    expect(searchAgentCandidates([legacyDemo], "Demo")).toEqual([legacyDemo]);
+    expect(searchAgentCandidates([legacyDemo], "Lichtenberg")).toEqual([
+      legacyDemo,
+    ]);
+  });
+
+  it("is case-insensitive on the title substring match", () => {
+    expect(searchAgentCandidates([legacyDemo], "lichtenberg")).toEqual([
+      legacyDemo,
+    ]);
+  });
+
+  it("does not match an agent's title when it has a real address (address always wins)", () => {
+    const mismatched = {
+      id: 5,
+      address: { street: "Elsewhere 1" },
+      title: "Demo Mismatch",
+    } as any;
+    expect(searchAgentCandidates([mismatched], "Demo")).toEqual([]);
+  });
+
+  it("does not match a legacy agent whose title lacks the search term", () => {
+    expect(searchAgentCandidates([legacyDemo], "Kreuzberg")).toEqual([]);
   });
 
   it("returns an empty array when the typed value normalizes to empty", () => {
-    expect(getAgentsByStreetPrefix([mueller], "   ")).toEqual([]);
-  });
-});
-
-describe("mergeAgentMatches", () => {
-  const exact = { id: 1, title: "Exact Match Agent" } as any;
-  const prefixOnly = { id: 2, title: "Prefix Only Agent" } as any;
-  const anotherPrefixOnly = { id: 3, title: "Another Prefix Agent" } as any;
-
-  it("puts the exact match first even when prefix matches precede it in the source list", () => {
-    expect(
-      mergeAgentMatches(exact, [prefixOnly, anotherPrefixOnly, exact]),
-    ).toEqual([exact, prefixOnly, anotherPrefixOnly]);
-  });
-
-  it("does not duplicate the exact match when it also appears in prefix matches", () => {
-    const merged = mergeAgentMatches(exact, [exact, prefixOnly]);
-    expect(merged).toEqual([exact, prefixOnly]);
-    expect(merged.filter((a) => a.id === exact.id)).toHaveLength(1);
-  });
-
-  it("returns just the exact match when there are no prefix matches", () => {
-    expect(mergeAgentMatches(exact, [])).toEqual([exact]);
-  });
-
-  it("returns the prefix matches unchanged when there is no exact match", () => {
-    expect(
-      mergeAgentMatches(undefined, [prefixOnly, anotherPrefixOnly]),
-    ).toEqual([prefixOnly, anotherPrefixOnly]);
-  });
-
-  it("returns an empty array when neither is present", () => {
-    expect(mergeAgentMatches(undefined, [])).toEqual([]);
+    expect(searchAgentCandidates([mueller, legacyDemo], "   ")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Description

Redoes the `GET /agent/register/search` picker from #797/#798. That version required a postcode before it would search, only ever surfaced a single "decisive" best-guess match, and its legacy fallback used word-boundary regex + house-number disambiguation. Manual testing surfaced real gaps (missed a hyphenated legacy title — fixed separately in #799/#800 before this redo; and agents with no linked person at all were silently excluded from candidates entirely, which is unrelated to street/title matching and looked like a bug rather than intended access control).

Redone with simpler, more predictable rules per direct feedback:

## Related Issues
Closes #801

## Changes
- **Dropped `postcode` entirely** — gone from `registerSearchQuerySchema`, the route querystring, and the matching logic.
- **Dropped the email-domain/`agent_person` scoping on the candidate query** — it excluded any agent with no linked person at all, which is a real gap (not intentional narrowing). JOIN-time approval (ACTIVE vs PENDING) is still decided independently, later, by `resolveJoinStatus`.
- **New `searchAgentCandidates(agents, street)`** replaces `getAgentsByStreetPrefix` + `mergeAgentMatches` (both deleted, only ever used by this route):
  - agents with a real `address.street`: case-insensitive **prefix** match
  - agents with no `address`: case-insensitive **contains** match on `title`
  - returns every matching candidate, not a single best guess
- `getAgentByAddress` (CREATE-path conflict check in `write-agent-registration.ts`, legacy public form in `legacy.routes.ts`) is **untouched** — out of scope for this endpoint's redesign, those flows still want a single decisive answer.
- Test file rewritten: old tests for the removed functions replaced with coverage for `searchAgentCandidates` (prefix match, contains match, case-insensitivity, address-always-wins-even-if-it-doesn't-match, empty input).

## Screenshots / Demos
N/A (backend matching/query logic). See companion `fe` PR for the picker UI this feeds.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Tests added/updated
- [ ] Documentation updated
- [x] CI passes (pending)
