### PR TITLE
feat: allow coordinators to create posts, not just agents

### DIFF
--- a/src/server/routes/post.routes.ts
+++ b/src/server/routes/post.routes.ts
@@ -93,9 +93,16 @@ export default async function postRoutes(
           statusCode: 201,
         }),
       },
-      onRequest: [fastify.authenticate({ role: UserRole.AGENT })],
+      onRequest: [fastify.authenticate()],
     },
     async (request, reply) => {
+      const { role } = request.user;
+      if (role !== UserRole.AGENT && role !== UserRole.COORDINATOR) {
+        throw new UnauthorizedError(
+          "Only agents and coordinators can create posts.",
+        );
+      }
+
       const personId = request.authUser?.personId;
       if (!personId) {
         throw new BadRequestError("No person linked to this user.");

--- a/src/test/server/routes/post.routes.test.ts
+++ b/src/test/server/routes/post.routes.test.ts
@@ -1,0 +1,150 @@
+import { FastifyInstance } from "fastify";
+import { UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("POST /post", () => {
+  let fastify: FastifyInstance;
+
+  let agentPerson: Person;
+  let coordinatorPerson: Person;
+  let volunteerPerson: Person;
+  let agentCookie: string;
+  let coordinatorCookie: string;
+  let volunteerCookie: string;
+  const createdPostIds: number[] = [];
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+    agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Agent" }),
+    );
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `agent-post-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-post-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `volunteer-post-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.VOLUNTEER,
+        isActive: true,
+        personId: volunteerPerson.id,
+      }),
+    );
+
+    const login = async (email: string): Promise<string> => {
+      const res = await fastify.inject({
+        method: "POST",
+        url: "/auth/login",
+        payload: { email, password: PASSWORD },
+      });
+      return getCookie(res.cookies, accessCookieName);
+    };
+
+    agentCookie = await login(`agent-post-${suffix}@test.need4deed.org`);
+    coordinatorCookie = await login(
+      `coordinator-post-${suffix}@test.need4deed.org`,
+    );
+    volunteerCookie = await login(
+      `volunteer-post-${suffix}@test.need4deed.org`,
+    );
+  });
+
+  afterAll(async () => {
+    if (createdPostIds.length) {
+      await fastify.db.postRepository.delete(createdPostIds);
+    }
+    await fastify.db.userRepository.delete({ personId: agentPerson.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.userRepository.delete({ personId: volunteerPerson.id });
+    await fastify.db.personRepository.delete({ id: agentPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.close();
+  });
+
+  it("lets an agent create a post", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/post",
+      cookies: { [accessCookieName]: agentCookie },
+      payload: { text: "Test post from agent" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    createdPostIds.push(body.data.id);
+    expect(body.data.author.id).toBe(agentPerson.id);
+  });
+
+  it("lets a coordinator create a post, with agentId null", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/post",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { text: "Test post from coordinator" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    createdPostIds.push(body.data.id);
+    expect(body.data.author.id).toBe(coordinatorPerson.id);
+
+    const saved = await fastify.db.postRepository.findOneByOrFail({
+      id: body.data.id,
+    });
+    expect(saved.agentId).toBeNull();
+  });
+
+  it("403s when a volunteer tries to create a post", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/post",
+      cookies: { [accessCookieName]: volunteerCookie },
+      payload: { text: "Should not be allowed" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #806. Backend companion to [need4deed-org/fe#892](https://github.com/need4deed-org/fe/issues/892) (the real Posts feed feature, replacing the current non-functional placeholder).

`POST /post` was gated with `fastify.authenticate({ role: UserRole.AGENT })`, so only NGO users could create posts — coordinators (and any non-agent user) got a 403 for an action the feature is supposed to allow both roles to do.

## Fix
Matches the existing pattern already used by this same file's PATCH/DELETE handlers: broaden the `onRequest` hook to just `authenticate()` (any authenticated user), then manually check the role in the handler body. ADMIN bypasses automatically via the auth plugin.

`agentId` already resolves to `null` gracefully for a poster with no `AgentPerson` membership (`getAgentPersonRepresentative` returns `null` rather than throwing), so a coordinator-authored post correctly ends up with `agentId: null` with no other change needed.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — clean on touched files
- [x] New test file `post.routes.test.ts`: agent can post (unchanged behavior), coordinator can now post (with `agentId: null` verified), volunteer still gets 403
- [ ] Full suite not run in this environment (no local Postgres/Docker available) — new tests are structurally verified (discovered correctly by vitest, fail only on `ECONNREFUSED 127.0.0.1:5432` in `beforeAll`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)