### PR TITLE
feat: add guardrails for security env vars during prod server startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,10 +41,6 @@ NODE_ENV=development
 #   openssl rand -hex 32
 JWT_SECRET=
 
-# Sign auth cookies with an HMAC to prevent client-side tampering.
-# Must be true in production (server refuses to start otherwise).
-SIGN_COOKIES=true
-
 SLACK_OPS_WEBHOOK_URL=fake-string
 SLACK_COMMENTS_WEBHOOK_URL=fake-string
 

--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,13 @@ CORS_CREDENTIALS=true
 URL_EMAIL_VERIFICATION=http://localhost:3000/verify-email
 
 NODE_ENV=development
-JWT_SECRET=fake-string
+# HMAC-SHA256 key — at least 32 random bytes (256 bits). Generate with:
+#   openssl rand -hex 32
+JWT_SECRET=
+
+# Sign auth cookies with an HMAC to prevent client-side tampering.
+# Must be true in production (server refuses to start otherwise).
+SIGN_COOKIES=true
 
 SLACK_OPS_WEBHOOK_URL=fake-string
 SLACK_COMMENTS_WEBHOOK_URL=fake-string

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -124,12 +124,8 @@ export async function createServer(): Promise<FastifyInstance> {
     throw new Error("JWT_SECRET is not defined in environment variables.");
   }
 
-  if (isProd && secret.length < 32) {
-    throw new Error("JWT_SECRET must be at least 32 characters in production.");
-  }
-
-  if (isProd && (process.env.SIGN_COOKIES || "false") !== "true") {
-    throw new Error("SIGN_COOKIES must be set to 'true' in production.");
+  if (isProd && secret.length < 64) {
+    throw new Error("JWT_SECRET must be at least 64 characters in production.");
   }
 
   await fastifyInstance.register(jwtPlugin, { secret });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@ import fastifySwagger from "@fastify/swagger";
 import fastifySwaggerUi from "@fastify/swagger-ui";
 import Fastify, { FastifyInstance } from "fastify";
 import qs from "qs";
-import { pluginTimeout, selfUrl } from "../config/constants";
+import { isProd, pluginTimeout, selfUrl } from "../config/constants";
 import { BaseError } from "../config/error/base";
 import logger from "../logger";
 import cors, { corsOptions } from "./plugins/cors";
@@ -123,6 +123,15 @@ export async function createServer(): Promise<FastifyInstance> {
   if (!secret) {
     throw new Error("JWT_SECRET is not defined in environment variables.");
   }
+
+  if (isProd && secret.length < 32) {
+    throw new Error("JWT_SECRET must be at least 32 characters in production.");
+  }
+
+  if (isProd && (process.env.SIGN_COOKIES || "false") !== "true") {
+    throw new Error("SIGN_COOKIES must be set to 'true' in production.");
+  }
+
   await fastifyInstance.register(jwtPlugin, { secret });
   await fastifyInstance.register(cors, corsOptions);
   await fastifyInstance.register(multipart, {


### PR DESCRIPTION
## Description
Add env vars guardrails during prod startup

## Related Issues
Closes #729 

## Checklist
- [ ] Make sure prod deployment have env vars values matching this requirement
