### PR TITLE
fix: recompute match status after unmatching a volunteer/opportunity link

### DIFF
--- a/src/server/routes/m2m/opportunity-volunteer.routes.ts
+++ b/src/server/routes/m2m/opportunity-volunteer.routes.ts
@@ -7,6 +7,10 @@ import {
 } from "need4deed-sdk";
 import { ConflictError, NotFoundError } from "../../../config";
 import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
+import {
+  updateOpportunityMatching,
+  updateVolunteerMatching,
+} from "../../../data/utils";
 import logger from "../../../logger";
 import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyMessage } from "../../types";
@@ -284,6 +288,8 @@ export default async function m2mOpportunityVolunteerRoutes(
       }
 
       await opportunityVolunteerRepository.delete({ id });
+      await updateVolunteerMatching(m2mInstance.volunteerId);
+      await updateOpportunityMatching(m2mInstance.opportunityId);
 
       return reply.status(204).send();
     },

--- a/src/server/routes/volunteer/opportunity-volunteer.routes.ts
+++ b/src/server/routes/volunteer/opportunity-volunteer.routes.ts
@@ -5,6 +5,10 @@ import {
   UserRole,
 } from "need4deed-sdk";
 import { BadRequestError, NotFoundError } from "../../../config/error/fastify";
+import {
+  updateOpportunityMatching,
+  updateVolunteerMatching,
+} from "../../../data/utils";
 import { volunteerOpportunityVolunteerDTO } from "../../../services";
 import {
   idmM2mIdParamSchema,
@@ -149,6 +153,8 @@ export default function volunteerOpportunityVolunteerRoutes(
       }
 
       await opportunityVolunteerRepository.delete({ id: m2mId });
+      await updateVolunteerMatching(opportunity.volunteerId);
+      await updateOpportunityMatching(opportunity.opportunityId);
 
       return reply.status(200).send({
         message: msg200(opportunity.opportunityId, volunteerId, "deleted"),

--- a/src/test/server/routes/m2m-opportunity-volunteer.routes.test.ts
+++ b/src/test/server/routes/m2m-opportunity-volunteer.routes.test.ts
@@ -41,7 +41,9 @@ describe("DELETE /opportunity-volunteer/:id", () => {
   let opportunityDeal: Deal;
   let opportunity: Opportunity;
   let opportunityVolunteer: OpportunityVolunteer;
+  let agentPerson: Person;
   let coordinatorPerson: Person;
+  let agentCookie: string;
   let coordinatorCookie: string;
 
   beforeAll(async () => {
@@ -93,11 +95,23 @@ describe("DELETE /opportunity-volunteer/:id", () => {
       { statusMatch: OpportunityMatchStatusType.MATCHED },
     );
 
+    agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Agent" }),
+    );
     coordinatorPerson = await fastify.db.personRepository.save(
       new Person({ firstName: "Test", lastName: "Coordinator" }),
     );
 
     const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `agent-m2m-unmatch-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
     await fastify.db.userRepository.save(
       new User({
         email: `coordinator-m2m-unmatch-${suffix}@test.need4deed.org`,
@@ -117,13 +131,16 @@ describe("DELETE /opportunity-volunteer/:id", () => {
       return getCookie(res.cookies, accessCookieName);
     };
 
+    agentCookie = await login(`agent-m2m-unmatch-${suffix}@test.need4deed.org`);
     coordinatorCookie = await login(
       `coordinator-m2m-unmatch-${suffix}@test.need4deed.org`,
     );
   });
 
   afterAll(async () => {
+    await fastify.db.userRepository.delete({ personId: agentPerson.id });
     await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: agentPerson.id });
     await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
     // The match link is deleted by the DELETE call itself in the test below;
     // this is best-effort in case a test fails before reaching that point.
@@ -136,6 +153,15 @@ describe("DELETE /opportunity-volunteer/:id", () => {
     await fastify.db.opportunityRepository.delete({ id: opportunity.id });
     await fastify.db.dealRepository.delete({ id: opportunityDeal.id });
     await fastify.close();
+  });
+
+  it("403s when a non-coordinator tries to remove the link", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/opportunity-volunteer/${opportunityVolunteer.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+    });
+    expect(res.statusCode).toBe(403);
   });
 
   it("404s for a nonexistent m2m relation", async () => {

--- a/src/test/server/routes/m2m-opportunity-volunteer.routes.test.ts
+++ b/src/test/server/routes/m2m-opportunity-volunteer.routes.test.ts
@@ -1,0 +1,183 @@
+import { FastifyInstance } from "fastify";
+import {
+  OpportunityMatchStatusType,
+  OpportunityStatusType,
+  OpportunityType,
+  OpportunityVolunteerStatusType,
+  UserRole,
+  VolunteerStateMatchType,
+} from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import Deal from "../../../data/entity/deal.entity";
+import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
+import { DealType } from "../../../data/types";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("DELETE /opportunity-volunteer/:id", () => {
+  let fastify: FastifyInstance;
+
+  let deal: Deal;
+  let volunteerPerson: Person;
+  let volunteer: Volunteer;
+  let opportunityDeal: Deal;
+  let opportunity: Opportunity;
+  let opportunityVolunteer: OpportunityVolunteer;
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    deal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.VOLUNTEER, postcodeId: postcode.id }),
+    );
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    volunteer = await fastify.db.volunteerRepository.save(
+      new Volunteer({ dealId: deal.id, personId: volunteerPerson.id }),
+    );
+
+    opportunityDeal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    opportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (unmatch via m2m route) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.NEW,
+        dealId: opportunityDeal.id,
+      }),
+    );
+    opportunityVolunteer = await fastify.db.opportunityVolunteerRepository.save(
+      new OpportunityVolunteer({
+        opportunityId: opportunity.id,
+        volunteerId: volunteer.id,
+        status: OpportunityVolunteerStatusType.MATCHED,
+      }),
+    );
+    // Set deterministically rather than relying on OpportunityVolunteer's
+    // fire-and-forget @AfterInsert hook, so the "before" state for the
+    // recompute assertion below isn't a race.
+    await fastify.db.volunteerRepository.update(
+      { id: volunteer.id },
+      { statusMatch: VolunteerStateMatchType.MATCHED },
+    );
+    await fastify.db.opportunityRepository.update(
+      { id: opportunity.id },
+      { statusMatch: OpportunityMatchStatusType.MATCHED },
+    );
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-m2m-unmatch-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+
+    const login = async (email: string): Promise<string> => {
+      const res = await fastify.inject({
+        method: "POST",
+        url: "/auth/login",
+        payload: { email, password: PASSWORD },
+      });
+      return getCookie(res.cookies, accessCookieName);
+    };
+
+    coordinatorCookie = await login(
+      `coordinator-m2m-unmatch-${suffix}@test.need4deed.org`,
+    );
+  });
+
+  afterAll(async () => {
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    // The match link is deleted by the DELETE call itself in the test below;
+    // this is best-effort in case a test fails before reaching that point.
+    await fastify.db.opportunityVolunteerRepository.delete({
+      id: opportunityVolunteer.id,
+    });
+    await fastify.db.volunteerRepository.delete({ id: volunteer.id });
+    await fastify.db.dealRepository.delete({ id: deal.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.db.opportunityRepository.delete({ id: opportunity.id });
+    await fastify.db.dealRepository.delete({ id: opportunityDeal.id });
+    await fastify.close();
+  });
+
+  it("404s for a nonexistent m2m relation", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/opportunity-volunteer/999999999`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("removes the link and recomputes statusMatch on both the volunteer and opportunity sides", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/opportunity-volunteer/${opportunityVolunteer.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(204);
+
+    expect(
+      await fastify.db.opportunityVolunteerRepository.findOneBy({
+        id: opportunityVolunteer.id,
+      }),
+    ).toBeNull();
+
+    // Regression for be#808: repository.delete() never fires the
+    // OpportunityVolunteer entity's @AfterRemove hook, so both sides'
+    // statusMatch must be recomputed explicitly by the route handler —
+    // otherwise they stay frozen at MATCHED forever.
+    const survivingVolunteer = await fastify.db.volunteerRepository.findOneBy({
+      id: volunteer.id,
+    });
+    expect(survivingVolunteer?.statusMatch).toBe(
+      VolunteerStateMatchType.NEEDS_REMATCH,
+    );
+
+    const survivingOpportunity =
+      await fastify.db.opportunityRepository.findOneBy({
+        id: opportunity.id,
+      });
+    expect(survivingOpportunity?.statusMatch).toBe(
+      OpportunityMatchStatusType.NEEDS_REMATCH,
+    );
+  });
+});

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -332,15 +332,6 @@ describe("DELETE /opportunity/:id", () => {
     const language = await fastify.db.languageRepository.findOneOrFail({
       where: {},
     });
-    comment = await fastify.db.commentRepository.save(
-      new Comment({
-        text: "Test comment",
-        entityType: EntityTableName.OPPORTUNITY,
-        entityId: opportunity.id,
-        languageId: language.id,
-        userId: 0, // overwritten below once the coordinator user exists
-      }),
-    );
 
     agentPerson = await fastify.db.personRepository.save(
       new Person({ firstName: "Test", lastName: "Agent" }),
@@ -359,9 +350,14 @@ describe("DELETE /opportunity/:id", () => {
         personId: coordinatorPerson.id,
       }),
     );
-    await fastify.db.commentRepository.update(
-      { id: comment.id },
-      { userId: coordinatorUser.id },
+    comment = await fastify.db.commentRepository.save(
+      new Comment({
+        text: "Test comment",
+        entityType: EntityTableName.OPPORTUNITY,
+        entityId: opportunity.id,
+        languageId: language.id,
+        userId: coordinatorUser.id,
+      }),
     );
     await fastify.db.userRepository.save(
       new User({

--- a/src/test/server/routes/volunteer-opportunity-linked.routes.test.ts
+++ b/src/test/server/routes/volunteer-opportunity-linked.routes.test.ts
@@ -1,0 +1,209 @@
+import { FastifyInstance } from "fastify";
+import {
+  OpportunityMatchStatusType,
+  OpportunityStatusType,
+  OpportunityType,
+  OpportunityVolunteerStatusType,
+  UserRole,
+  VolunteerStateMatchType,
+} from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import Deal from "../../../data/entity/deal.entity";
+import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
+import { DealType } from "../../../data/types";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("DELETE /volunteer/:id/opportunity-linked/:m2mId", () => {
+  let fastify: FastifyInstance;
+
+  let deal: Deal;
+  let volunteerPerson: Person;
+  let volunteer: Volunteer;
+  let opportunityDeal: Deal;
+  let opportunity: Opportunity;
+  let opportunityVolunteer: OpportunityVolunteer;
+  let agentPerson: Person;
+  let coordinatorPerson: Person;
+  let agentCookie: string;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    deal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.VOLUNTEER, postcodeId: postcode.id }),
+    );
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    volunteer = await fastify.db.volunteerRepository.save(
+      new Volunteer({ dealId: deal.id, personId: volunteerPerson.id }),
+    );
+
+    opportunityDeal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    opportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (unmatch via volunteer route) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.NEW,
+        dealId: opportunityDeal.id,
+      }),
+    );
+    opportunityVolunteer = await fastify.db.opportunityVolunteerRepository.save(
+      new OpportunityVolunteer({
+        opportunityId: opportunity.id,
+        volunteerId: volunteer.id,
+        status: OpportunityVolunteerStatusType.MATCHED,
+      }),
+    );
+    // Set deterministically rather than relying on OpportunityVolunteer's
+    // fire-and-forget @AfterInsert hook, so the "before" state for the
+    // recompute assertion below isn't a race.
+    await fastify.db.volunteerRepository.update(
+      { id: volunteer.id },
+      { statusMatch: VolunteerStateMatchType.MATCHED },
+    );
+    await fastify.db.opportunityRepository.update(
+      { id: opportunity.id },
+      { statusMatch: OpportunityMatchStatusType.MATCHED },
+    );
+
+    agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Agent" }),
+    );
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-vol-unmatch-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `agent-vol-unmatch-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
+
+    const login = async (email: string): Promise<string> => {
+      const res = await fastify.inject({
+        method: "POST",
+        url: "/auth/login",
+        payload: { email, password: PASSWORD },
+      });
+      return getCookie(res.cookies, accessCookieName);
+    };
+
+    agentCookie = await login(`agent-vol-unmatch-${suffix}@test.need4deed.org`);
+    coordinatorCookie = await login(
+      `coordinator-vol-unmatch-${suffix}@test.need4deed.org`,
+    );
+  });
+
+  afterAll(async () => {
+    await fastify.db.userRepository.delete({ personId: agentPerson.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: agentPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    // The match link is deleted by the DELETE call itself in the test below;
+    // this is best-effort in case a test fails before reaching that point.
+    await fastify.db.opportunityVolunteerRepository.delete({
+      id: opportunityVolunteer.id,
+    });
+    await fastify.db.volunteerRepository.delete({ id: volunteer.id });
+    await fastify.db.dealRepository.delete({ id: deal.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.db.opportunityRepository.delete({ id: opportunity.id });
+    await fastify.db.dealRepository.delete({ id: opportunityDeal.id });
+    await fastify.close();
+  });
+
+  it("403s when a non-coordinator tries to remove the link", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/volunteer/${volunteer.id}/opportunity-linked/${opportunityVolunteer.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("404s for a nonexistent m2m relation", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/volunteer/${volunteer.id}/opportunity-linked/999999999`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("removes the link and recomputes statusMatch on both the volunteer and opportunity sides", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/volunteer/${volunteer.id}/opportunity-linked/${opportunityVolunteer.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    expect(
+      await fastify.db.opportunityVolunteerRepository.findOneBy({
+        id: opportunityVolunteer.id,
+      }),
+    ).toBeNull();
+
+    // Regression for be#808: repository.delete() never fires the
+    // OpportunityVolunteer entity's @AfterRemove hook, so both sides'
+    // statusMatch must be recomputed explicitly by the route handler —
+    // otherwise they stay frozen at MATCHED forever.
+    const survivingVolunteer = await fastify.db.volunteerRepository.findOneBy({
+      id: volunteer.id,
+    });
+    expect(survivingVolunteer?.statusMatch).toBe(
+      VolunteerStateMatchType.NEEDS_REMATCH,
+    );
+
+    const survivingOpportunity =
+      await fastify.db.opportunityRepository.findOneBy({
+        id: opportunity.id,
+      });
+    expect(survivingOpportunity?.statusMatch).toBe(
+      OpportunityMatchStatusType.NEEDS_REMATCH,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes be#808: `Volunteer`/`Opportunity` `statusMatch` was left stale after unmatching a link, since both delete routes call `repository.delete({ id })`, which never fires `OpportunityVolunteer`'s `@AfterRemove` hook (the only place `updateVolunteerMatching`/`updateOpportunityMatching` were called from).
- Adds explicit recompute calls after the delete in both affected routes, same shape as the be#787/#788 hard-delete fix:
  - `DELETE /volunteer/:id/opportunity-linked/:m2mId`
  - `DELETE /opportunity-volunteer/:id`
- Also fixes a pre-existing bug in `opportunity.routes.test.ts`'s `DELETE /opportunity/:id` suite: its `Comment` fixture was inserted with a placeholder `userId: 0` before the coordinator user existed, relying on a later `.update()` to fix it up. The `user_id` FK on `comment` isn't deferrable, so that insert fails outright unless a user with id `0` already exists (it never does). Reordered fixture setup so the comment is created with the real coordinator user id directly.

## Not included
- The issue's "Data cleanup" follow-up (one-off script to recompute `statusMatch` for all existing volunteers/opportunities to fix already-corrupted data) is flagged in the issue as a non-blocking follow-up, not part of this fix.

## Test plan
- [x] Added regression tests for both routes confirming a `MATCHED` volunteer/opportunity pair transitions to `NEEDS_REMATCH` on both sides after the link is removed.
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes on changed files
- [x] `yarn test:run` — full suite passes (496/496)

🤖 Generated with [Claude Code](https://claude.com/claude-code)