### PR TITLE
feat: add rate-limiting for auth routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,14 @@ SLACK_OPS_WEBHOOK_URL=fake-string
 SLACK_COMMENTS_WEBHOOK_URL=fake-string
 
 MOCK_VOLUNTEER_DOC_S3_UPLOAD_URL=http://localhost:5000
+
+# Whether to trust the X-Forwarded-* headers from a reverse proxy
+# Passed to fastify's `trustProxy` option
+# If not set, defaults to false
+# true becomes true
+# false becomes false
+# If only digits, becomes a number (number of hops to trust)
+# If a comma-separated list of strings, becomes as a list of strings
+# If string without commas passed as string
+# For reference see https://fastify.dev/docs/latest/Reference/Server/#trustproxy
+TRUST_PROXY=false

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@fastify/cors": "^11.0.1",
     "@fastify/jwt": "^9.1.0",
     "@fastify/multipart": "^9.3.0",
+    "@fastify/rate-limit": "^11.2.0",
     "@fastify/swagger": "^9.5.2",
     "@fastify/swagger-ui": "^5.2.3",
     "bcrypt": "^6.0.0",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,7 @@ import logger from "../logger";
 import cors, { corsOptions } from "./plugins/cors";
 import jwtPlugin from "./plugins/jwt";
 import notifyPlugin from "./plugins/notify";
+import rateLimitPlugin from "./plugins/rate-limit";
 import schedulerDailyPlugin from "./plugins/scheduler-daily";
 import schedulerHourlyPlugin from "./plugins/scheduler-hourly";
 import typeormPlugin from "./plugins/typeorm";
@@ -95,6 +96,12 @@ export async function createServer(): Promise<FastifyInstance> {
   await fastifyInstance.setErrorHandler((error, request, reply) => {
     request.log.error(error);
 
+    if (error.statusCode === 429) {
+      return reply.status(429).send({
+        message: "Too many requests. Please try again later.",
+      });
+    }
+
     // If it's one of our custom errors, use its status code
     if (error instanceof BaseError) {
       return reply.status(error.statusCode).send({
@@ -128,6 +135,7 @@ export async function createServer(): Promise<FastifyInstance> {
   await fastifyInstance.register(multipart, {
     attachFieldsToBody: "keyValues",
   });
+  await fastifyInstance.register(rateLimitPlugin);
 
   await fastifyInstance.register(fastifySwagger, {
     openapi: {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -43,11 +43,40 @@ import volunteerApiSchema from "./schema/volunteer-api.json";
 import volunteerFormDataSchema from "./schema/volunteer-form.json";
 import { RoutePrefix } from "./types";
 
+const decodeTrustProxyEnv = (
+  value: string | undefined,
+): boolean | string | number | string[] => {
+  if (value === undefined || value === null || value.trim() === "") {
+    return false;
+  }
+
+  const normalized = value.trim();
+
+  if (/^\d+$/.test(normalized)) {
+    return parseInt(normalized, 10);
+  }
+
+  if (normalized.toLowerCase() === "true") {
+    return true;
+  }
+
+  if (normalized.toLowerCase() === "false") {
+    return false;
+  }
+
+  if (normalized.includes(",")) {
+    return normalized.split(",").map((item) => item.trim());
+  }
+
+  return normalized;
+};
+
 export async function createServer(): Promise<FastifyInstance> {
   const fastifyInstance: FastifyInstance = Fastify({
     pluginTimeout,
     querystringParser: (str) => qs.parse(str),
     loggerInstance: logger,
+    trustProxy: decodeTrustProxyEnv(process.env.TRUST_PROXY),
     ajv: {
       customOptions: {
         strict: false,
@@ -97,9 +126,8 @@ export async function createServer(): Promise<FastifyInstance> {
     request.log.error(error);
 
     if (error.statusCode === 429) {
-      return reply.status(429).send({
-        message: "Too many requests. Please try again later.",
-      });
+      reply.status(429).send(error);
+      return;
     }
 
     // If it's one of our custom errors, use its status code

--- a/src/server/plugins/rate-limit.ts
+++ b/src/server/plugins/rate-limit.ts
@@ -6,6 +6,13 @@ async function rateLimitPlugin(fastify: FastifyInstance) {
   await fastify.register(rateLimit, {
     global: false,
     cache: 5000,
+    errorResponseBuilder() {
+      return {
+        statusCode: 429,
+        error: "Too Many Requests",
+        message: `Rate limit exceeded`,
+      };
+    },
   });
 }
 

--- a/src/server/plugins/rate-limit.ts
+++ b/src/server/plugins/rate-limit.ts
@@ -1,0 +1,14 @@
+import rateLimit from "@fastify/rate-limit";
+import { FastifyInstance } from "fastify";
+import fp from "fastify-plugin";
+
+async function rateLimitPlugin(fastify: FastifyInstance) {
+  await fastify.register(rateLimit, {
+    global: false,
+    cache: 5000,
+  });
+}
+
+export default fp(rateLimitPlugin, {
+  name: "rate-limit-plugin",
+});

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -42,6 +42,7 @@ async function authRoutes(
   }>(
     prefixedPath + RoutePrefix.LOGIN,
     {
+      config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
       schema: {
         body: userLoginSchema,
         response: {
@@ -248,6 +249,7 @@ async function authRoutes(
   }>(
     prefixedPath + RoutePrefix.REQUEST_RESET,
     {
+      config: { rateLimit: { max: 3, timeWindow: "5 minutes" } },
       schema: {
         body: requestResetSchema,
         response: responseSchema(""),
@@ -281,6 +283,7 @@ async function authRoutes(
   }>(
     prefixedPath + RoutePrefix.RESET_PASSWORD,
     {
+      config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
       schema: {
         body: resetPasswordSchema,
         response: responseSchema(""),

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -137,6 +137,7 @@ async function authRoutes(
   }>(
     prefixedPath + RoutePrefix.REFRESH,
     {
+      config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
       schema: {
         body: refreshAccessSchema,
         response: {
@@ -328,6 +329,7 @@ async function authRoutes(
   }>(
     prefixedPath + RoutePrefix.CHANGE_PASSWORD,
     {
+      config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
       onRequest: [fastify.authenticate()],
       schema: {
         body: changePasswordSchema,

--- a/src/test/server/routes/auth.test.ts
+++ b/src/test/server/routes/auth.test.ts
@@ -325,3 +325,128 @@ describe("POST /auth/request-reset", () => {
     expect(passwordResetSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("Rate limiting", () => {
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("POST /auth/login limits to 10 requests per minute", async () => {
+    for (let i = 0; i < 10; i++) {
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/auth/login",
+        payload: { email: "test@example.com", password: "whatever" },
+      });
+      expect(response.statusCode).not.toBe(429);
+    }
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: "test@example.com", password: "whatever" },
+    });
+    expect(response.statusCode).toBe(429);
+    expect(response.json().message).toBe("Rate limit exceeded");
+  });
+
+  it("POST /auth/refresh limits to 20 requests per minute", async () => {
+    for (let i = 0; i < 20; i++) {
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/auth/refresh",
+        payload: { refresh: "some-token" },
+      });
+      expect(response.statusCode).not.toBe(429);
+    }
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/refresh",
+      payload: { refresh: "some-token" },
+    });
+    expect(response.statusCode).toBe(429);
+    expect(response.json().message).toBe("Rate limit exceeded");
+  });
+
+  it("POST /auth/request-reset limits to 3 requests per 5 minutes", async () => {
+    for (let i = 0; i < 3; i++) {
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/auth/request-reset",
+        payload: { email: "test@example.com" },
+      });
+      expect(response.statusCode).not.toBe(429);
+    }
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/request-reset",
+      payload: { email: "test@example.com" },
+    });
+    expect(response.statusCode).toBe(429);
+    expect(response.json().message).toBe("Rate limit exceeded");
+  });
+
+  it("POST /auth/password-reset limits to 10 requests per minute", async () => {
+    for (let i = 0; i < 10; i++) {
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/auth/password-reset",
+        payload: { token: "invalid", newPassword: "newpass123456" },
+      });
+      expect(response.statusCode).not.toBe(429);
+    }
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-reset",
+      payload: { token: "invalid", newPassword: "newpass123456" },
+    });
+    expect(response.statusCode).toBe(429);
+    expect(response.json().message).toBe("Rate limit exceeded");
+  });
+
+  it("POST /auth/password-change limits to 20 requests per minute", async () => {
+    const accessToken = fastify.jwt.sign({
+      id: 999,
+      email: "test@example.com",
+      type: "access",
+    });
+
+    vi.spyOn(fastify.db.userRepository, "findOne").mockResolvedValue({
+      id: 999,
+      role: "volunteer",
+    } as any);
+
+    for (let i = 0; i < 20; i++) {
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/auth/password-change",
+        cookies: { access: accessToken },
+        payload: { password: "old", newPassword: "new" },
+      });
+      expect(response.statusCode).not.toBe(429);
+    }
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: "/auth/password-change",
+      cookies: { access: accessToken },
+      payload: { password: "old", newPassword: "new" },
+    });
+    expect(response.statusCode).toBe(429);
+    expect(response.json().message).toBe("Rate limit exceeded");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,6 +373,16 @@
     "@fastify/forwarded" "^3.0.0"
     ipaddr.js "^2.1.0"
 
+"@fastify/rate-limit@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@fastify/rate-limit/-/rate-limit-11.2.0.tgz#1eea79a5db89bd75bef3bb45eb805cf108f77860"
+  integrity sha512-X7osJd4XSvMoejYrnJkSZYYjY1eNYoBqhjlzf1RakC2204qExFqZFTKj5+T7VuzA/iUI9Z3UoSqQRkB2HpG0oQ==
+  dependencies:
+    "@lukeed/ms" "^2.0.2"
+    fastify-plugin "^6.0.0"
+    ip-address "^10.2.0"
+    toad-cache "^3.7.0"
+
 "@fastify/send@^4.0.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@fastify/send/-/send-4.1.0.tgz#d9c283b86e12080c0dcc160bbc16106debf1f0d3"
@@ -2073,6 +2083,11 @@ fastify-plugin@^5.0.0, fastify-plugin@^5.0.1:
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-5.1.0.tgz#7083e039d6418415f9a669f8c25e72fc5bf2d3e7"
   integrity sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==
 
+fastify-plugin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-6.0.0.tgz#7cd659c6aad5f3bf07b4c59205412351a47d39c8"
+  integrity sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==
+
 fastify@^5.3.3:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/fastify/-/fastify-5.6.1.tgz#551248a047758ed82741aea15ac4396875d73687"
@@ -2445,6 +2460,11 @@ internal-slot@^1.1.0:
     es-errors "^1.3.0"
     hasown "^2.0.2"
     side-channel "^1.1.0"
+
+ip-address@^10.2.0:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.3.1.tgz#929f9629d1724f7e1b7485ce89752f3675336a10"
+  integrity sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==
 
 ipaddr.js@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
## Description
Add rate-limiting for login, request-reset, reset-password routes

FYI limitations of this rate limiting:
- 5000 size LRU cache(default of the lib) - it will evict old records(even if the record has requests earlier that timeWindow)
- IP used as key
- In memory, so it will reset after server restart, can use up instance memory

I also increased login rate-limit a little bit compared to what is requested in the issue

## Related Issues
Closes #725

## Changes
- Add rate limiting for login, request-reset, reset-password routes

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [ ] returns status 429 response if hit rate limit on particular request
