### PR TITLE
feat: add 4 volunteer appreciation options

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.136",
+    "need4deed-sdk": "0.0.137",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/data/migrations/1785445240609-add-volunteer-appreciation-options.ts
+++ b/src/data/migrations/1785445240609-add-volunteer-appreciation-options.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddVolunteerAppreciationOptions1785445240609
+  implements MigrationInterface
+{
+  name = "AddVolunteerAppreciationOptions1785445240609";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."appreciation_title_enum" RENAME TO "appreciation_title_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."appreciation_title_enum" AS ENUM('t-shirt', 'benefit-card', 'tote-bag', 'need4deed-certificate', 'cap', 'notebook', 'city-certificate')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "appreciation" ALTER COLUMN "title" TYPE "public"."appreciation_title_enum" USING "title"::"text"::"public"."appreciation_title_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."appreciation_title_enum_old"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."volunteer_status_appreciation_enum" RENAME TO "volunteer_status_appreciation_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."volunteer_status_appreciation_enum" AS ENUM('t-shirt', 'benefit-card', 'tote-bag', 'need4deed-certificate', 'cap', 'notebook', 'city-certificate')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "volunteer" ALTER COLUMN "status_appreciation" TYPE "public"."volunteer_status_appreciation_enum" USING "status_appreciation"::"text"::"public"."volunteer_status_appreciation_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."volunteer_status_appreciation_enum_old"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."volunteer_status_appreciation_enum_old" AS ENUM('benefit-card', 't-shirt', 'tote-bag')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "volunteer" ALTER COLUMN "status_appreciation" TYPE "public"."volunteer_status_appreciation_enum_old" USING "status_appreciation"::"text"::"public"."volunteer_status_appreciation_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."volunteer_status_appreciation_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."volunteer_status_appreciation_enum_old" RENAME TO "volunteer_status_appreciation_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."appreciation_title_enum_old" AS ENUM('benefit-card', 't-shirt', 'tote-bag')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "appreciation" ALTER COLUMN "title" TYPE "public"."appreciation_title_enum_old" USING "title"::"text"::"public"."appreciation_title_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."appreciation_title_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."appreciation_title_enum_old" RENAME TO "appreciation_title_enum"`,
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.136:
-  version "0.0.136"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.136.tgz#331130387c520bffbf55d118e801abd844d95f3d"
-  integrity sha512-OeYBZnAb+d/hMC8FArJ+PD42oXg04BZgj36aqggx61LYGAINtiMb7aE6vG/h5yoTCrTkvG0doQa8HXqfF1tFMw==
+need4deed-sdk@0.0.137:
+  version "0.0.137"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.137.tgz#679a423eae87009c4fe34f7d43f0bef02f780361"
+  integrity sha512-uMqDXoWMhdUf4/tlOhUnf5ASU4c4Pa+ijlhHFnDSatlg5E5s3jAUt1vVmkkvzTBrw1uMcCtI8I9sM92mBvn86w==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
Closes #795. Adds `NEED4DEED_CERTIFICATE`, `CAP`, `NOTEBOOK`, and `CITY_CERTIFICATE` to the volunteer appreciation picklist.

- Bumps `need4deed-sdk` to `0.0.137` (published from need4deed-org/sdk#182), which adds the 4 values to `VolunteerStateAppreciationType`.
- Auto-generated migration (`yarn migration:generate`, no hand-written SQL) extends both native Postgres enum types backing `Appreciation.title` and `Volunteer.statusAppreciation`, using the same rename/recreate/cast/drop pattern as `1771858452728-update-agent-entity-4.ts` (Postgres has no `DROP VALUE`, so a real `down` needs this).
- No entity or other backend code changes — both columns already spread `VolunteerStateAppreciationType` directly via decorators.

## Test plan
- [x] `yarn typecheck`, `yarn lint` on changed files, `yarn test:run` (497 tests) all pass
- [x] Fresh `yarn migration:run` applies the new migration cleanly against the current dev DB
- [x] `yarn migration:revert` cleanly rolls back to the pre-migration enum values, then re-ran forward
- [x] Verified via `psql` that both `appreciation_title_enum` and `volunteer_status_appreciation_enum` contain all 7 values post-migration