### PR TITLE
feat: introduce Onetimer entity for ACCOMPANYING/EVENTS start date

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.137",
+    "need4deed-sdk": "0.0.138",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/data/data-source.ts
+++ b/src/data/data-source.ts
@@ -30,6 +30,7 @@ import OpportunityVolunteer from "./entity/m2m/opportunity-volunteer";
 import NotionRelation from "./entity/notion-relation.entity";
 import Accompanying from "./entity/opportunity/accompanying.entity";
 import Agent from "./entity/opportunity/agent.entity";
+import Onetimer from "./entity/opportunity/onetimer.entity";
 import Opportunity from "./entity/opportunity/opportunity.entity";
 import Option from "./entity/option.entity";
 import Organization from "./entity/organization.entity";
@@ -94,6 +95,7 @@ export const dataSource = new DataSource({
     Language,
     LeadFrom,
     NotionRelation,
+    Onetimer,
     Opportunity,
     OpportunityVolunteer,
     Organization,

--- a/src/data/entity/opportunity/accompanying.entity.ts
+++ b/src/data/entity/opportunity/accompanying.entity.ts
@@ -1,4 +1,4 @@
-import { IsDate, IsEnum, IsOptional, IsString } from "class-validator";
+import { IsEnum, IsOptional, IsString } from "class-validator";
 import { TranslatedIntoType } from "need4deed-sdk";
 import {
   Column,
@@ -39,10 +39,6 @@ export default class Accompanying {
   @IsString()
   @IsOptional()
   email?: string;
-
-  @Column({ type: "timestamptz" })
-  @IsDate()
-  date: Date;
 
   @Column({ type: "enum", enum: TranslatedIntoType, nullable: true })
   @IsOptional()

--- a/src/data/entity/opportunity/onetimer.entity.ts
+++ b/src/data/entity/opportunity/onetimer.entity.ts
@@ -1,0 +1,22 @@
+import { IsDate } from "class-validator";
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import Opportunity from "./opportunity.entity";
+
+@Entity()
+export default class Onetimer {
+  constructor(onetimer?: Partial<Onetimer>) {
+    if (onetimer) {
+      Object.assign(this, onetimer);
+    }
+  }
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: "timestamptz" })
+  @IsDate()
+  date: Date;
+
+  @OneToMany(() => Opportunity, (opportunity) => opportunity.onetimer)
+  opportunity: Opportunity[];
+}

--- a/src/data/entity/opportunity/opportunity.entity.ts
+++ b/src/data/entity/opportunity/opportunity.entity.ts
@@ -23,6 +23,7 @@ import Person from "../person.entity";
 import Appreciation from "../volunteer/appreciation.entity";
 import Accompanying from "./accompanying.entity";
 import Agent from "./agent.entity";
+import Onetimer from "./onetimer.entity";
 
 @Entity()
 export default class Opportunity {
@@ -98,6 +99,16 @@ export default class Opportunity {
   accompanying?: Accompanying;
   @Column({ nullable: true })
   accompanyingId?: number;
+
+  // Single-occurrence start date/time, shared by ACCOMPANYING (appointment)
+  // and EVENTS (event start) types — see be#746.
+  @ManyToOne(() => Onetimer, (onetimer) => onetimer.opportunity, {
+    nullable: true,
+  })
+  @JoinColumn({ name: "onetimer_id" })
+  onetimer?: Onetimer;
+  @Column({ nullable: true })
+  onetimerId?: number;
 
   @ManyToOne(() => Deal)
   @JoinColumn({ name: "deal_id" })

--- a/src/data/migrations/1785481503175-add-onetimer-entity.ts
+++ b/src/data/migrations/1785481503175-add-onetimer-entity.ts
@@ -1,0 +1,89 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Backfills the new `onetimer` table from the two places a single-occurrence
+// start date/time is stored today:
+//  - `accompanying.date`, for ACCOMPANYING-type opportunities
+//  - the one-off `timeslot` linked via `deal_timeslot` (no end/rrule/occasional),
+//    for EVENTS-type opportunities (see dto-opportunity.ts's former heuristic)
+// See be#746. `accompanying.date` itself is dropped in a later migration,
+// once application code no longer reads/writes it.
+export class AddOnetimerEntity1785481503175 implements MigrationInterface {
+  name = "AddOnetimerEntity1785481503175";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "onetimer" ("id" SERIAL NOT NULL, "date" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_b8eaa44fc91a9cdc55406ef8701" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" ADD "onetimer_id" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" ADD CONSTRAINT "FK_9ca1ae76540d50eba7156eceaa2" FOREIGN KEY ("onetimer_id") REFERENCES "onetimer"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+
+    await queryRunner.query(`
+      CREATE TEMP TABLE "tmp_onetimer_backfill" (
+        "tmp_id" SERIAL PRIMARY KEY,
+        "opportunity_id" integer NOT NULL,
+        "date" TIMESTAMP WITH TIME ZONE NOT NULL
+      ) ON COMMIT DROP
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO "tmp_onetimer_backfill" ("opportunity_id", "date")
+      SELECT o."id", a."date"
+      FROM "opportunity" o
+      JOIN "accompanying" a ON a."id" = o."accompanying_id"
+      WHERE o."type" = 'accompanying' AND a."date" IS NOT NULL
+    `);
+
+    // EVENTS-type opportunities may hold their date in the one-off timeslot
+    // (set by the patch handler) and/or in the blanked-out "accompanying" row
+    // (set by the create handler — a pre-existing gap where create never
+    // wrote a timeslot). Prefer the timeslot when both are present.
+    await queryRunner.query(`
+      INSERT INTO "tmp_onetimer_backfill" ("opportunity_id", "date")
+      SELECT o."id", COALESCE(ts."start", a."date")
+      FROM "opportunity" o
+      LEFT JOIN "accompanying" a ON a."id" = o."accompanying_id"
+      LEFT JOIN LATERAL (
+        SELECT t."start"
+        FROM "deal_timeslot" dt
+        JOIN "timeslot" t ON t."id" = dt."timeslot_id"
+        WHERE dt."deal_id" = o."deal_id"
+          AND t."start" IS NOT NULL
+          AND t."end" IS NULL
+          AND t."rrule" IS NULL
+          AND t."occasional" IS NULL
+        ORDER BY t."id"
+        LIMIT 1
+      ) ts ON true
+      WHERE o."type" = 'events' AND COALESCE(ts."start", a."date") IS NOT NULL
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO "onetimer" ("id", "date")
+      SELECT "tmp_id", "date" FROM "tmp_onetimer_backfill" ORDER BY "tmp_id"
+    `);
+    await queryRunner.query(`
+      SELECT setval('onetimer_id_seq', (SELECT COALESCE(MAX("id"), 0) FROM "onetimer"))
+    `);
+
+    await queryRunner.query(`
+      UPDATE "opportunity" o
+      SET "onetimer_id" = tb."tmp_id"
+      FROM "tmp_onetimer_backfill" tb
+      WHERE o."id" = tb."opportunity_id"
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" DROP CONSTRAINT "FK_9ca1ae76540d50eba7156eceaa2"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "opportunity" DROP COLUMN "onetimer_id"`,
+    );
+    await queryRunner.query(`DROP TABLE "onetimer"`);
+  }
+}

--- a/src/data/migrations/1785481623751-retire-accompanying-date.ts
+++ b/src/data/migrations/1785481623751-retire-accompanying-date.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Run after AddOnetimerEntity1785481503175 has backfilled `onetimer` (see
+// be#746). EVENTS-type opportunities never had a real accompanying record —
+// `accompanying` was only ever created for them to hold `date`, with
+// `address`/`name` hardcoded to "". Now that the date lives on `onetimer`,
+// those blank rows are unlinked and deleted; ACCOMPANYING-type `accompanying`
+// rows are untouched apart from losing the (now-redundant) `date` column.
+export class RetireAccompanyingDate1785481623751 implements MigrationInterface {
+  name = "RetireAccompanyingDate1785481623751";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TEMP TABLE "tmp_events_accompanying" AS
+      SELECT o."id" AS "opportunity_id", o."accompanying_id"
+      FROM "opportunity" o
+      WHERE o."type" = 'events' AND o."accompanying_id" IS NOT NULL
+    `);
+
+    await queryRunner.query(`
+      UPDATE "opportunity" o
+      SET "accompanying_id" = NULL
+      FROM "tmp_events_accompanying" tea
+      WHERE o."id" = tea."opportunity_id"
+    `);
+
+    await queryRunner.query(`
+      DELETE FROM "accompanying" a
+      USING "tmp_events_accompanying" tea
+      WHERE a."id" = tea."accompanying_id"
+    `);
+
+    await queryRunner.query(`ALTER TABLE "accompanying" DROP COLUMN "date"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "accompanying" ADD "date" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`,
+    );
+    // The deleted EVENTS-only "accompanying" rows and their opportunity links
+    // are not recreated — they carried no data beyond the blanked-out
+    // placeholder fields already superseded by `onetimer`.
+  }
+}

--- a/src/data/migrations/1785481623751-retire-accompanying-date.ts
+++ b/src/data/migrations/1785481623751-retire-accompanying-date.ts
@@ -11,7 +11,7 @@ export class RetireAccompanyingDate1785481623751 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-      CREATE TEMP TABLE "tmp_events_accompanying" AS
+      CREATE TEMP TABLE "tmp_events_accompanying" ON COMMIT DROP AS
       SELECT o."id" AS "opportunity_id", o."accompanying_id"
       FROM "opportunity" o
       WHERE o."type" = 'events' AND o."accompanying_id" IS NOT NULL

--- a/src/data/seeds/fixtures/test.ts
+++ b/src/data/seeds/fixtures/test.ts
@@ -23,6 +23,7 @@ import DealTimeslot from "../../entity/m2m/deal-timeslot";
 import OpportunityVolunteer from "../../entity/m2m/opportunity-volunteer";
 import Accompanying from "../../entity/opportunity/accompanying.entity";
 import Agent from "../../entity/opportunity/agent.entity";
+import Onetimer from "../../entity/opportunity/onetimer.entity";
 import Opportunity from "../../entity/opportunity/opportunity.entity";
 import Organization from "../../entity/organization.entity";
 import Person from "../../entity/person.entity";
@@ -341,6 +342,7 @@ export async function seedTestFixtures(dataSource: DataSource): Promise<void> {
   // --- opportunities ---
   const opportunityRepo = getRepository(dataSource, Opportunity);
   const accompanyingRepo = getRepository(dataSource, Accompanying);
+  const onetimerRepo = getRepository(dataSource, Onetimer);
 
   const oppDeal1 = await makeDeal(
     dataSource,
@@ -391,9 +393,11 @@ export async function seedTestFixtures(dataSource: DataSource): Promise<void> {
     new Accompanying({
       address: "Musterstraße 1, Berlin",
       name: "Test Appointment",
-      date: accompanyingTimeslot.start,
       postcodeId: pc12043.id,
     }),
+  );
+  const onetimer = await onetimerRepo.save(
+    new Onetimer({ date: accompanyingTimeslot.start }),
   );
   const oppDeal3 = await makeDeal(
     dataSource,
@@ -408,6 +412,7 @@ export async function seedTestFixtures(dataSource: DataSource): Promise<void> {
       agentId: agent2.id,
       deal: oppDeal3,
       accompanyingId: accompanying.id,
+      onetimerId: onetimer.id,
       numberVolunteers: 1,
     }),
   );

--- a/src/data/seeds/populate/opportunity.seed.ts
+++ b/src/data/seeds/populate/opportunity.seed.ts
@@ -9,6 +9,7 @@ import logger from "../../../logger";
 import { tryCatch } from "../../../services/utils";
 import NotionRelation from "../../entity/notion-relation.entity";
 import Accompanying from "../../entity/opportunity/accompanying.entity";
+import Onetimer from "../../entity/opportunity/onetimer.entity";
 import Opportunity from "../../entity/opportunity/opportunity.entity";
 import { fetchJsonFromUrl, getRepository } from "../../utils";
 import {
@@ -69,11 +70,19 @@ export async function seedOpportunities(dataSource: DataSource): Promise<void> {
                 address: opportunity.accompanying.address || "Berlin",
                 name: opportunity.accompanying.name || "unknown",
                 phone: opportunity.accompanying.phone,
-                date: new Date(opportunity.accompanying.date),
                 languageToTranslate: getToTranslate(
                   opportunity.accompanying.languageToTranslate,
                 ),
               }),
+            )
+          : Promise.reject(),
+      );
+
+      const onetimerRepository = getRepository(dataSource, Onetimer);
+      const [onetimer] = await tryCatch(
+        opportunity.accompanying?.date
+          ? onetimerRepository.save(
+              new Onetimer({ date: new Date(opportunity.accompanying.date) }),
             )
           : Promise.reject(),
       );
@@ -92,6 +101,7 @@ export async function seedOpportunities(dataSource: DataSource): Promise<void> {
         createdAt: new Date(opportunity.timestamp),
         updatedAt: new Date(opportunity.timestamp),
         ...(accompanying?.id ? { accompanyingId: accompanying.id } : {}),
+        ...(onetimer?.id ? { onetimerId: onetimer.id } : {}),
         ...(notionRelation?.hostId
           ? { agentId: notionRelation?.hostId }
           : { agent: await getOrCreateAgent(opportunity.agent, dataSource) }),

--- a/src/server/plugins/typeorm.ts
+++ b/src/server/plugins/typeorm.ts
@@ -13,6 +13,7 @@ import AgentPerson from "../../data/entity/m2m/agent-person";
 import OpportunityVolunteer from "../../data/entity/m2m/opportunity-volunteer";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../data/entity/opportunity/agent.entity";
+import Onetimer from "../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../data/entity/opportunity/opportunity.entity";
 import Option from "../../data/entity/option.entity";
 import Organization from "../../data/entity/organization.entity";
@@ -53,6 +54,7 @@ const typeormPlugin: FastifyPluginAsync = async (fastify) => {
       agentRepository: dataSource.getRepository(Agent),
       agentPersonRepository: dataSource.getRepository(AgentPerson),
       accompanyingRepository: dataSource.getRepository(Accompanying),
+      onetimerRepository: dataSource.getRepository(Onetimer),
       organizationRepository: dataSource.getRepository(Organization),
       postcodeRepository: dataSource.getRepository(Postcode),
       postRepository: dataSource.getRepository(Post),

--- a/src/server/routes/m2m/opportunity-volunteer.routes.ts
+++ b/src/server/routes/m2m/opportunity-volunteer.routes.ts
@@ -195,6 +195,7 @@ export default async function m2mOpportunityVolunteerRoutes(
                   "opportunity.agent.agentPerson.person",
                   "opportunity.agent.agentPerson.person.users",
                   "opportunity.accompanying.postcode",
+                  "opportunity.onetimer",
                   "opportunity.district",
                 ],
               });

--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -290,10 +290,14 @@ export default async function opportunityLegacyRoutes(
             email ? `Email: ${email}` : null,
           ].filter(Boolean);
 
-          // Treat the epoch sentinel date as "no date set"
-          const EPOCH = "1970-01-01T00:00:00.000Z";
+          // Treat the epoch sentinel date as "no date set". Compare by
+          // timestamp (not string equality) since onetimerDate is a real
+          // Date instance here, not an ISO string.
+          const EPOCH_MS = 0;
           const accomp_datetime =
-            !onetimerDate || onetimerDate === EPOCH ? null : onetimerDate;
+            !onetimerDate || new Date(onetimerDate).getTime() === EPOCH_MS
+              ? null
+              : onetimerDate;
 
           return {
             accomp_information:

--- a/src/server/routes/opportunity/legacy.routes.ts
+++ b/src/server/routes/opportunity/legacy.routes.ts
@@ -11,14 +11,15 @@ import {
 import { In } from "typeorm";
 import { dataSource } from "../../../data/data-source";
 import Address from "../../../data/entity/location/address.entity";
-import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
+import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
 import { getPostcode, getRepository } from "../../../data/utils";
 import logger from "../../../logger";
 import {
   accompanyingParserOpportunity,
+  parseAccompDatetime,
   parseFormData,
   parseOpportunityLegacy,
 } from "../../../services";
@@ -105,16 +106,18 @@ export default async function opportunityLegacyRoutes(
 
       opportunity.deal = await dealParserOpportunity(request.body);
       opportunity.accompanying = undefined;
+      opportunity.onetimer = undefined;
 
       if (request.body.opportunity_type === "accompanying") {
         opportunity.accompanying = await accompanyingParserOpportunity(
           request.body,
         );
+        opportunity.onetimer = new Onetimer({
+          date: parseAccompDatetime(request.body.accomp_datetime),
+        });
       } else if (opportunity.type === OpportunityType.EVENTS) {
-        opportunity.accompanying = new Accompanying({
+        opportunity.onetimer = new Onetimer({
           date: new Date(request.body.onetime_date_time),
-          address: "",
-          name: "",
         });
       }
 
@@ -267,7 +270,7 @@ export default async function opportunityLegacyRoutes(
           };
         }
 
-        function parseAccompanying(accompanying) {
+        function parseAccompanying(accompanying, onetimerDate) {
           if (!accompanying) {
             return {
               accomp_information: null,
@@ -276,7 +279,7 @@ export default async function opportunityLegacyRoutes(
             };
           }
 
-          const { address, name, phone, email, date, languageToTranslate } =
+          const { address, name, phone, email, languageToTranslate } =
             accompanying;
 
           // Build accomp_information from available contact fields
@@ -289,7 +292,8 @@ export default async function opportunityLegacyRoutes(
 
           // Treat the epoch sentinel date as "no date set"
           const EPOCH = "1970-01-01T00:00:00.000Z";
-          const accomp_datetime = !date || date === EPOCH ? null : date;
+          const accomp_datetime =
+            !onetimerDate || onetimerDate === EPOCH ? null : onetimerDate;
 
           return {
             accomp_information:
@@ -320,7 +324,7 @@ export default async function opportunityLegacyRoutes(
 
           const { timeslots, schedule_str } = parseTimeslots(deal.dealTimeslot);
           const { accomp_information, accomp_translation, accomp_datetime } =
-            parseAccompanying(raw.accompanying);
+            parseAccompanying(raw.accompanying, raw.onetimer?.date);
 
           return {
             id: raw.id,
@@ -366,6 +370,7 @@ export default async function opportunityLegacyRoutes(
           "deal.dealTimeslot.timeslot",
           "deal.dealDistrict.district",
           "accompanying",
+          "onetimer",
         ],
       });
       return reply

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -7,6 +7,7 @@ import {
   OpportunityFormDataWithAgentSubmitter,
   OpportunityLegacyFormData,
   OpportunityLegacyType,
+  OpportunitySortField,
   OpportunityType,
   SortOrder,
   UserRole,
@@ -270,13 +271,40 @@ export default async function opportunityRoutes(
       ];
 
       const opportunityRepository = fastify.db.opportunityRepository;
-      const [opportunities, count] = await opportunityRepository.findAndCount({
-        where,
-        relations,
-        skip,
-        take,
-        ...(order ? order : {}),
-      });
+
+      // Sorting by start date (be#746) needs NULLS LAST regardless of
+      // direction — opportunities with no onetimer (REGULAR type, or an
+      // ACCOMPANYING/EVENTS one with no date set yet) always sort last, so
+      // they don't crowd out real dates at the top of a "soonest first"
+      // list. `find()`'s plain `order` option can't express that (Postgres
+      // defaults DESC to NULLS FIRST), so this path uses the query builder.
+      // The extra `leftJoin`+`addSelect` for ordering is harmless alongside
+      // the `relations`-driven join of the same to-one relation — it can't
+      // multiply rows, and keeps `relations` as the single source of truth
+      // for what gets loaded. The `addSelect` is required, not cosmetic:
+      // paginating (skip/take) alongside the other one-to-many joins forces
+      // TypeORM to wrap the query in a DISTINCT subquery, and any column
+      // referenced in ORDER BY must be part of that subquery's projection.
+      const [opportunities, count] =
+        request.query.sortBy === OpportunitySortField.START_DATE
+          ? await opportunityRepository
+              .createQueryBuilder("opportunity")
+              .setFindOptions({ where, relations, skip, take })
+              .leftJoin("opportunity.onetimer", "onetimerSort")
+              .addSelect("onetimerSort.date")
+              .orderBy(
+                "onetimerSort.date",
+                request.query.sortOrder === SortOrder.OldToNew ? "ASC" : "DESC",
+                "NULLS LAST",
+              )
+              .getManyAndCount()
+          : await opportunityRepository.findAndCount({
+              where,
+              relations,
+              skip,
+              take,
+              ...(order ? order : {}),
+            });
 
       const { addCategoryToDeal, updates: dealUpdates } =
         getCategoryToDealHandler();

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -277,21 +277,25 @@ export default async function opportunityRoutes(
       // ACCOMPANYING/EVENTS one with no date set yet) always sort last, so
       // they don't crowd out real dates at the top of a "soonest first"
       // list. `find()`'s plain `order` option can't express that (Postgres
-      // defaults DESC to NULLS FIRST), so this path uses the query builder.
-      // The extra `leftJoin`+`addSelect` for ordering is harmless alongside
-      // the `relations`-driven join of the same to-one relation — it can't
-      // multiply rows, and keeps `relations` as the single source of truth
-      // for what gets loaded. The `addSelect` is required, not cosmetic:
-      // paginating (skip/take) alongside the other one-to-many joins forces
+      // defaults DESC to NULLS FIRST), so this path uses the query builder,
+      // with its own `leftJoinAndSelect` on `onetimer` (excluded from the
+      // `relations` passed to `setFindOptions` to avoid joining it twice)
+      // so the same alias both hydrates the entity and drives ORDER BY.
+      // Pagination (skip/take) alongside the other one-to-many joins forces
       // TypeORM to wrap the query in a DISTINCT subquery, and any column
-      // referenced in ORDER BY must be part of that subquery's projection.
+      // referenced in ORDER BY must be part of that subquery's projection —
+      // `leftJoinAndSelect` (unlike plain `leftJoin`) satisfies that.
       const [opportunities, count] =
         request.query.sortBy === OpportunitySortField.START_DATE
           ? await opportunityRepository
               .createQueryBuilder("opportunity")
-              .setFindOptions({ where, relations, skip, take })
-              .leftJoin("opportunity.onetimer", "onetimerSort")
-              .addSelect("onetimerSort.date")
+              .setFindOptions({
+                where,
+                relations: relations.filter((r) => r !== "onetimer"),
+                skip,
+                take,
+              })
+              .leftJoinAndSelect("opportunity.onetimer", "onetimerSort")
               .orderBy(
                 "onetimerSort.date",
                 request.query.sortOrder === SortOrder.OldToNew ? "ASC" : "DESC",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -25,6 +25,7 @@ import DealSkill from "../../../data/entity/m2m/deal-skill";
 import DealTimeslot from "../../../data/entity/m2m/deal-timeslot";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
+import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
 import { updateVolunteerMatching } from "../../../data/utils";
@@ -34,6 +35,7 @@ import {
   accompanyingParserOpportunity,
   dtoOpportunityGet,
   dtoOpportunityGetList,
+  parseAccompDatetime,
   parseOpportunity,
   parseOpportunityLegacy,
 } from "../../../services";
@@ -64,12 +66,12 @@ import {
   getOpportunityNotificationText,
   getOpportunityOrphanageAgent,
   getOpportunityWhere,
-  getOrCreateEventTimeslot,
   getOrCreateTimeslot,
   getPostcode,
   getSkipTake,
   patchEntity,
   updateOptionList,
+  upsertOnetimer,
   writeOpportunityLegacy,
 } from "../../utils";
 import { logEmailCommunication } from "../../utils/data/log-email-communication";
@@ -150,6 +152,7 @@ export default async function opportunityRoutes(
       const relations = [
         "accompanying",
         "accompanying.postcode",
+        "onetimer",
         "deal.dealLanguage.language",
         "deal.dealActivity.activity",
         "deal.dealSkill.skill",
@@ -262,6 +265,7 @@ export default async function opportunityRoutes(
         "deal.dealDistrict.district",
         "agent",
         "accompanying",
+        "onetimer",
         "opportunityVolunteer.volunteer.person",
       ];
 
@@ -392,15 +396,17 @@ export default async function opportunityRoutes(
       );
 
       opportunity.accompanying = undefined;
+      opportunity.onetimer = undefined;
 
       if (body.opportunity_type === OpportunityLegacyType.ACCOMPANYING) {
         opportunity.accompanying =
           await accompanyingParserOpportunity(legacyBody);
+        opportunity.onetimer = new Onetimer({
+          date: parseAccompDatetime(legacyBody.accomp_datetime),
+        });
       } else if (opportunity.type === OpportunityType.EVENTS) {
-        opportunity.accompanying = new Accompanying({
+        opportunity.onetimer = new Onetimer({
           date: new Date(legacyBody.onetime_date_time),
-          address: "",
-          name: "",
         });
       }
 
@@ -450,6 +456,7 @@ export default async function opportunityRoutes(
               [
                 "accompanying",
                 "accompanying.postcode",
+                "onetimer",
                 "submittedByPerson",
                 "submittedByPerson.users",
                 "contactPerson",
@@ -553,6 +560,7 @@ export default async function opportunityRoutes(
         contact,
         agent,
         accompanying,
+        onetimerDate,
         languages,
         schedule,
         skills,
@@ -691,7 +699,22 @@ export default async function opportunityRoutes(
         }
       }
 
-      // If the opportunity is being changed to an event or already an event, create or update the accompanying record with the event date and time, and create or update the timeslot for the event.
+      // Appointment start date/time for ACCOMPANYING, shared with EVENTS via
+      // the same `onetimer` (see be#746) — owned 1:1 by the opportunity.
+      if (onetimerDate) {
+        const onetimer = await upsertOnetimer(
+          opportunity.onetimerId,
+          onetimerDate,
+        );
+        if (!opportunity.onetimerId) {
+          await patchEntity(
+            Opportunity,
+            { onetimerId: onetimer.id } as Partial<Opportunity>,
+            opportunity.id,
+          );
+        }
+      }
+
       if (
         effectiveType === OpportunityType.EVENTS &&
         request.body.event?.date &&
@@ -701,58 +724,36 @@ export default async function opportunityRoutes(
           request.body.event.date,
           request.body.event.time,
         );
-
-        if (opportunity.accompanyingId) {
+        const onetimer = await upsertOnetimer(
+          opportunity.onetimerId,
+          eventDate,
+        );
+        if (!opportunity.onetimerId) {
           await patchEntity(
-            Accompanying,
-            {
-              date: eventDate,
-              address: "",
-              name: "",
-              phone: null,
-              email: null,
-              languageToTranslate: null,
-              postcodeId: null,
-            },
-            opportunity.accompanyingId,
+            Opportunity,
+            { onetimerId: onetimer.id } as Partial<Opportunity>,
+            opportunity.id,
           );
-        } else {
-          const newAccompanying = new Accompanying({
-            date: eventDate,
-            address: "",
-            name: "",
-          });
-          try {
-            await fastify.db.accompanyingRepository.manager.transaction(
-              async (manager) => {
-                await manager.save(Accompanying, newAccompanying);
-                await manager.update(Opportunity, opportunity.id, {
-                  accompanyingId: newAccompanying.id,
-                });
-              },
-            );
-          } catch {
-            throw new BadRequestError(
-              "Saving new accompanying for event failed",
-            );
-          }
         }
-
-        const timeslot = await getOrCreateEventTimeslot(eventDate);
-        await updateOptionList(dealId, DealTimeslot, [{ id: timeslot.id }]);
       }
 
       if (
         effectiveType === OpportunityType.REGULAR &&
         opportunity.type !== OpportunityType.REGULAR &&
-        opportunity.accompanyingId
+        (opportunity.accompanyingId || opportunity.onetimerId)
       ) {
         await fastify.db.accompanyingRepository.manager.transaction(
           async (manager) => {
             await manager.update(Opportunity, opportunity.id, {
               accompanyingId: null,
+              onetimerId: null,
             });
-            await manager.delete(Accompanying, opportunity.accompanyingId);
+            if (opportunity.accompanyingId) {
+              await manager.delete(Accompanying, opportunity.accompanyingId);
+            }
+            if (opportunity.onetimerId) {
+              await manager.delete(Onetimer, opportunity.onetimerId);
+            }
           },
         );
       }
@@ -840,7 +841,7 @@ export default async function opportunityRoutes(
         throw new NotFoundError(`Opportunity (id:${id}) not found.`);
       }
 
-      const { dealId, accompanyingId } = opportunity;
+      const { dealId, accompanyingId, onetimerId } = opportunity;
 
       // OpportunityVolunteer rows cascade at the DB level, which bypasses
       // TypeORM's @AfterRemove hook (it never loads/removes those entities
@@ -863,6 +864,9 @@ export default async function opportunityRoutes(
         }
         if (accompanyingId) {
           await manager.delete(Accompanying, { id: accompanyingId });
+        }
+        if (onetimerId) {
+          await manager.delete(Onetimer, { id: onetimerId });
         }
       });
 

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -699,42 +699,38 @@ export default async function opportunityRoutes(
         }
       }
 
-      // Appointment start date/time for ACCOMPANYING, shared with EVENTS via
-      // the same `onetimer` (see be#746) — owned 1:1 by the opportunity.
-      if (onetimerDate) {
-        const onetimer = await upsertOnetimer(
-          opportunity.onetimerId,
-          onetimerDate,
-        );
-        if (!opportunity.onetimerId) {
-          await patchEntity(
-            Opportunity,
-            { onetimerId: onetimer.id } as Partial<Opportunity>,
-            opportunity.id,
-          );
-        }
-      }
+      // Single-occurrence start date/time, shared by ACCOMPANYING and EVENTS
+      // via `onetimer` (see be#746) — owned 1:1 by the opportunity. Resolved
+      // from whichever source matches the *resulting* type, so a payload that
+      // (incorrectly) carries both `accompanyingDetails` and `event` — or
+      // either alongside an unrelated type change — can't write a onetimer
+      // that doesn't belong to this opportunity's new type.
+      const resolvedOnetimerDate =
+        effectiveType === OpportunityType.EVENTS
+          ? request.body.event?.date && request.body.event?.time
+            ? getDateObj(request.body.event.date, request.body.event.time)
+            : undefined
+          : effectiveType === OpportunityType.ACCOMPANYING
+            ? onetimerDate
+            : undefined;
 
-      if (
-        effectiveType === OpportunityType.EVENTS &&
-        request.body.event?.date &&
-        request.body.event?.time
-      ) {
-        const eventDate = getDateObj(
-          request.body.event.date,
-          request.body.event.time,
-        );
-        const onetimer = await upsertOnetimer(
-          opportunity.onetimerId,
-          eventDate,
-        );
-        if (!opportunity.onetimerId) {
-          await patchEntity(
-            Opportunity,
-            { onetimerId: onetimer.id } as Partial<Opportunity>,
-            opportunity.id,
+      if (resolvedOnetimerDate) {
+        await dataSource.manager.transaction(async (manager) => {
+          const onetimer = await upsertOnetimer(
+            opportunity.onetimerId,
+            resolvedOnetimerDate,
+            manager,
           );
-        }
+          if (!opportunity.onetimerId) {
+            await patchEntity(
+              Opportunity,
+              { onetimerId: onetimer.id } as Partial<Opportunity>,
+              opportunity.id,
+              manager,
+            );
+            opportunity.onetimerId = onetimer.id;
+          }
+        });
       }
 
       if (

--- a/src/server/schema/querystring.ts
+++ b/src/server/schema/querystring.ts
@@ -1,4 +1,4 @@
-import { SortOrder } from "need4deed-sdk";
+import { OpportunitySortField, SortOrder } from "need4deed-sdk";
 import { getRef } from "../utils";
 
 const paginationProps = {
@@ -25,11 +25,22 @@ const sortOrderProps = {
   },
 };
 
+// Opportunity-list-only: which field `sortOrder` applies to. Not part of
+// `sortOrderProps` since sorting by start date is meaningless for
+// agent/volunteer/user lists that also reuse that shared prop set.
+const sortByProps = {
+  sortBy: {
+    type: "string",
+    enum: Object.values(OpportunitySortField),
+  },
+};
+
 export const opportunityListQuerySchema = {
   type: "object",
   properties: {
     ...paginationProps,
     ...sortOrderProps,
+    ...sortByProps,
     ...langProp,
     filter: {
       type: "object",

--- a/src/server/types/endpoint-handlers.ts
+++ b/src/server/types/endpoint-handlers.ts
@@ -1,4 +1,4 @@
-import { Lang, SortOrder, UserRole } from "need4deed-sdk";
+import { Lang, OpportunitySortField, SortOrder, UserRole } from "need4deed-sdk";
 
 export interface ParamsId {
   id: number;
@@ -55,7 +55,12 @@ export type QuerystringVolunteerOpportunityGetList =
   QuerystringPaginationLanguage & QuerystringOpportunityFiltering;
 
 export type QuerystringOpportunityList = QuerystringPaginationLanguage &
-  QuerystringOpportunityFiltering;
+  QuerystringOpportunityFiltering & {
+    // Which field `sortOrder` applies to. Scoped to the opportunity list
+    // only (not the shared QuerystringPaginationOrdering) — sorting by
+    // start date only makes sense here, not for agent/volunteer/user lists.
+    sortBy?: OpportunitySortField;
+  };
 
 export interface QuerystringAgentFiltering {
   filter?: {

--- a/src/server/types/fastify.d.ts
+++ b/src/server/types/fastify.d.ts
@@ -15,6 +15,7 @@ import AgentPerson from "../../data/entity/m2m/agent-person";
 import OpportunityVolunteer from "../../data/entity/m2m/opportunity-volunteer";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../data/entity/opportunity/agent.entity";
+import Onetimer from "../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../data/entity/opportunity/opportunity.entity";
 import Option from "../../data/entity/option.entity";
 import Organization from "../../data/entity/organization.entity";
@@ -46,6 +47,7 @@ declare module "fastify" {
       agentRepository: Repository<Agent>;
       agentPersonRepository: Repository<AgentPerson>;
       accompanyingRepository: Repository<Accompanying>;
+      onetimerRepository: Repository<Onetimer>;
       organizationRepository: Repository<Organization>;
       postcodeRepository: Repository<Postcode>;
       postRepository: Repository<Post>;

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -34,6 +34,7 @@ import District from "../../../data/entity/location/district.entity";
 import Postcode from "../../../data/entity/location/postcode.entity";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentService from "../../../data/entity/m2m/agent-service";
+import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Option from "../../../data/entity/option.entity";
 import Person from "../../../data/entity/person.entity";
 import Language from "../../../data/entity/profile/language.entity";
@@ -561,24 +562,22 @@ export async function getOrCreateTimeslot(
   return timeslot;
 }
 
-export async function getOrCreateEventTimeslot(date: Date): Promise<Timeslot> {
-  const normalizedDate = new Date(date);
-  normalizedDate.setSeconds(0, 0);
-  const repository = getRepository(dataSource, Timeslot);
-  let timeslot = await repository.findOneBy({
-    start: normalizedDate,
-    end: null,
-    rrule: null,
-    occasional: null,
-  });
-  if (!timeslot) {
-    timeslot = new Timeslot({
-      start: normalizedDate,
-      info: `One-time event on ${normalizedDate.toISOString()}`,
-    });
-    await repository.save(timeslot);
+// The single-occurrence start date/time for ACCOMPANYING/EVENTS
+// opportunities (see be#746). Unlike `getOrCreateTimeslot`, a `Onetimer` is
+// owned 1:1 by its opportunity rather than deduplicated by value, so this
+// updates the opportunity's existing row in place or creates a new one.
+export async function upsertOnetimer(
+  existingOnetimerId: number | undefined,
+  date: Date,
+): Promise<Onetimer> {
+  const repository = getRepository(dataSource, Onetimer);
+  if (existingOnetimerId) {
+    await repository.update(existingOnetimerId, { date });
+    return repository.findOneByOrFail({ id: existingOnetimerId });
   }
-  return timeslot;
+  const onetimer = new Onetimer({ date });
+  await repository.save(onetimer);
+  return onetimer;
 }
 
 export async function updateOptionList<

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -568,15 +568,18 @@ export async function getOrCreateTimeslot(
 // updates the opportunity's existing row in place or creates a new one.
 // Accepts an optional manager so the caller can wrap this + the opportunity's
 // onetimerId link-update in a single transaction.
+// Returns only `id`/`date` on the update path (the caller only ever needs
+// the id) rather than a full `Onetimer` — avoids faking the rest of the
+// entity's shape just to satisfy the return type.
 export async function upsertOnetimer(
   existingOnetimerId: number | undefined,
   date: Date,
   manager: DataSource | EntityManager = dataSource,
-): Promise<Onetimer> {
+): Promise<Pick<Onetimer, "id" | "date">> {
   const repository = getRepository(manager, Onetimer);
   if (existingOnetimerId) {
     await repository.update(existingOnetimerId, { date });
-    return { id: existingOnetimerId, date } as Onetimer;
+    return { id: existingOnetimerId, date };
   }
   const onetimer = new Onetimer({ date });
   await repository.save(onetimer);

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -566,14 +566,17 @@ export async function getOrCreateTimeslot(
 // opportunities (see be#746). Unlike `getOrCreateTimeslot`, a `Onetimer` is
 // owned 1:1 by its opportunity rather than deduplicated by value, so this
 // updates the opportunity's existing row in place or creates a new one.
+// Accepts an optional manager so the caller can wrap this + the opportunity's
+// onetimerId link-update in a single transaction.
 export async function upsertOnetimer(
   existingOnetimerId: number | undefined,
   date: Date,
+  manager: DataSource | EntityManager = dataSource,
 ): Promise<Onetimer> {
-  const repository = getRepository(dataSource, Onetimer);
+  const repository = getRepository(manager, Onetimer);
   if (existingOnetimerId) {
     await repository.update(existingOnetimerId, { date });
-    return repository.findOneByOrFail({ id: existingOnetimerId });
+    return { id: existingOnetimerId, date } as Onetimer;
   }
   const onetimer = new Onetimer({ date });
   await repository.save(onetimer);

--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -6,14 +6,19 @@ import { formatDate, formatTime } from "../utils";
 
 export function dtoOpportunityAccompanying(
   accompanying: Accompanying,
+  onetimerDate?: Date,
   dealLanguage: DealLanguage[] = [],
   district?: District | null,
 ): ApiOpportunityAccompanyingDetails {
   return accompanying
     ? {
         appointmentAddress: accompanying.address,
-        appointmentDate: formatDate(accompanying.date),
-        appointmentTime: formatTime(accompanying.date),
+        ...(onetimerDate
+          ? {
+              appointmentDate: formatDate(onetimerDate),
+              appointmentTime: formatTime(onetimerDate),
+            }
+          : {}),
         refugeeNumber: accompanying.phone,
         refugeeName: accompanying.name,
         appointmentLanguage: accompanying.languageToTranslate,

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -80,7 +80,10 @@ export function dtoOpportunityGetList(
       id: ld.district.id,
     })),
     availability: getAvailabilityTryCatch(opportunity.deal.dealTimeslot) ?? [],
-    accompanyingDetails: dtoOpportunityAccompanying(opportunity.accompanying!),
+    accompanyingDetails: dtoOpportunityAccompanying(
+      opportunity.accompanying!,
+      opportunity.onetimer?.date,
+    ),
     agentTitle: opportunity.agent?.title ?? "",
     agentId: opportunity.agentId,
     // Names of the volunteers MATCHED to the opportunity (status opp-matched
@@ -121,6 +124,7 @@ export function dtoVolunteerOpportunityGetList(
     availability: getAvailabilityTryCatch(opportunity.deal.dealTimeslot) ?? [],
     accompanyingDetails: dtoOpportunityAccompanying(
       opportunity.accompanying!,
+      opportunity.onetimer?.date,
       opportunity.deal.dealLanguage,
     ),
     statusMatch: opportunity.statusMatch,
@@ -131,16 +135,10 @@ export function dtoOpportunityGet(
   opportunityComments: Opportunity & { comments: Comment[] },
   accompanyingDistrict?: District | null,
 ): ApiOpportunityGet {
-  let eventStart: Date | undefined = undefined;
-  if (opportunityComments.type === OpportunityType.EVENTS) {
-    eventStart = (opportunityComments.deal?.dealTimeslot ?? []).find(
-      (dt) =>
-        dt.timeslot?.start &&
-        !dt.timeslot?.end &&
-        !dt.timeslot?.rrule &&
-        !dt.timeslot?.occasional,
-    )?.timeslot?.start;
-  }
+  const eventStart =
+    opportunityComments.type === OpportunityType.EVENTS
+      ? opportunityComments.onetimer?.date
+      : undefined;
 
   return {
     id: opportunityComments.id,
@@ -183,6 +181,7 @@ export function dtoOpportunityGet(
     agent: dtoOpportunityAgent(opportunityComments.agent!),
     accompanyingDetails: dtoOpportunityAccompanying(
       opportunityComments.accompanying!,
+      opportunityComments.onetimer?.date,
       opportunityComments.deal.dealLanguage,
       accompanyingDistrict,
     ),

--- a/src/services/dto/parser-accompanying-legacy.ts
+++ b/src/services/dto/parser-accompanying-legacy.ts
@@ -4,7 +4,7 @@ import { getPostcode } from "../../data/utils";
 
 // Parses a datetime string as Europe/Berlin time when no timezone is specified.
 // Uses the Intl API so DST transitions (CET⇔CEST) are handled automatically.
-function parseAccompDatetime(value: string | undefined): Date {
+export function parseAccompDatetime(value: string | undefined): Date {
   if (!value) {
     return new Date(NaN);
   }
@@ -47,7 +47,6 @@ export async function accompanyingParserOpportunity(
     address: body.accomp_address,
     name: body.accomp_name,
     phone: body.accomp_phone,
-    date: parseAccompDatetime(body.accomp_datetime),
     languageToTranslate: body.accomp_translation as TranslatedIntoType,
   });
 

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -91,17 +91,17 @@ export function parseOpportunity(body: ApiOpportunityPatch) {
       accompanying: accompanyingDetails
         ? ({
             address: accompanyingDetails.appointmentAddress,
-            date: accompanyingDetails.appointmentDate
-              ? getDateObj(
-                  accompanyingDetails.appointmentDate,
-                  accompanyingDetails.appointmentTime || "00:00",
-                )
-              : undefined,
             phone: accompanyingDetails.refugeeNumber,
             name: accompanyingDetails.refugeeName,
             languageToTranslate: accompanyingDetails.appointmentLanguage,
           } as Partial<Accompanying>)
         : {},
+      onetimerDate: accompanyingDetails?.appointmentDate
+        ? getDateObj(
+            accompanyingDetails.appointmentDate,
+            accompanyingDetails.appointmentTime || "00:00",
+          )
+        : undefined,
       languages: dedupeLanguages([
         ...(body?.languagesMain || []).map((l) => ({
           id: l.id,

--- a/src/services/jobs/scan-accompany-not-found.ts
+++ b/src/services/jobs/scan-accompany-not-found.ts
@@ -31,11 +31,12 @@ export async function scanAccompanyNotFound(
         OpportunityStatusType.SEARCHING,
         OpportunityStatusType.ACTIVE,
       ]),
-      accompanying: { date: Between(startOfDay, endOfDay) },
+      onetimer: { date: Between(startOfDay, endOfDay) },
     },
     relations: [
       "accompanying",
       "accompanying.postcode",
+      "onetimer",
       "contactPerson",
       "contactPerson.users",
       "district",

--- a/src/services/jobs/scan-expired-onetimers.ts
+++ b/src/services/jobs/scan-expired-onetimers.ts
@@ -4,7 +4,6 @@ import {
   OpportunityType,
   OpportunityVolunteerStatusType,
 } from "need4deed-sdk";
-import { Brackets } from "typeorm";
 import logger from "../../logger";
 import { addWorkingDays, berlinToday } from "./german-holidays";
 
@@ -15,10 +14,7 @@ export async function scanExpiredOnetimers(
 
   const expiredOpportunities = await fastify.db.opportunityRepository
     .createQueryBuilder("opportunity")
-    .leftJoinAndSelect("opportunity.accompanying", "accompanying")
-    .leftJoinAndSelect("opportunity.deal", "deal")
-    .leftJoinAndSelect("deal.dealTimeslot", "dealTimeslot")
-    .leftJoinAndSelect("dealTimeslot.timeslot", "timeslot")
+    .leftJoinAndSelect("opportunity.onetimer", "onetimer")
     .leftJoinAndSelect(
       "opportunity.opportunityVolunteer",
       "opportunityVolunteer",
@@ -29,15 +25,9 @@ export async function scanExpiredOnetimers(
     .andWhere("opportunity.status != :inactive", {
       inactive: OpportunityStatusType.INACTIVE,
     })
-    .andWhere(
-      new Brackets((qb) => {
-        qb.where("accompanying.date < :yesterday", {
-          yesterday: dayBeforeToday,
-        }).orWhere("timeslot.start < :yesterday", {
-          yesterday: dayBeforeToday,
-        });
-      }),
-    )
+    .andWhere("onetimer.date < :yesterday", {
+      yesterday: dayBeforeToday,
+    })
     .getMany();
 
   if (!expiredOpportunities.length) {

--- a/src/services/notify/events/email-accompany-match.ts
+++ b/src/services/notify/events/email-accompany-match.ts
@@ -89,8 +89,8 @@ export async function sendEmailAccompanyMatch(
     .join(", ");
 
   const clientName = accompanying?.name ?? "";
-  const appointmentDate = accompanying?.date
-    ? new Date(accompanying.date).toLocaleDateString("de-DE", {
+  const appointmentDate = opportunity.onetimer?.date
+    ? new Date(opportunity.onetimer.date).toLocaleDateString("de-DE", {
         timeZone: "Europe/Berlin",
         year: "numeric",
         month: "2-digit",

--- a/src/services/notify/events/email-accompany-not-found.ts
+++ b/src/services/notify/events/email-accompany-not-found.ts
@@ -46,8 +46,8 @@ export async function sendEmailAccompanyNotFound(
 
   const contactpersonName = opportunity.contactPerson!.name;
   const accompanying = opportunity.accompanying;
-  const appointmentDate = accompanying?.date
-    ? new Date(accompanying.date).toLocaleDateString("de-DE", {
+  const appointmentDate = opportunity.onetimer?.date
+    ? new Date(opportunity.onetimer.date).toLocaleDateString("de-DE", {
         timeZone: "Europe/Berlin",
         year: "numeric",
         month: "2-digit",

--- a/src/services/notify/events/email-new-accompanying.ts
+++ b/src/services/notify/events/email-new-accompanying.ts
@@ -49,8 +49,8 @@ export async function sendEmailNewAccompanying(
 
   const accompanying = opportunity.accompanying;
   const contactpersonName = contactPerson.name;
-  const appointmentDate = accompanying?.date
-    ? new Date(accompanying.date).toLocaleDateString("de-DE", {
+  const appointmentDate = opportunity.onetimer?.date
+    ? new Date(opportunity.onetimer.date).toLocaleDateString("de-DE", {
         timeZone: "Europe/Berlin",
         year: "numeric",
         month: "2-digit",

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -479,3 +479,130 @@ describe("DELETE /opportunity/:id", () => {
     );
   });
 });
+
+// Regression test for be#816: the onetimer-writing logic in the PATCH
+// handler used to be two independent blocks, each reading the pre-request
+// `opportunity.onetimerId`. A payload carrying both `accompanyingDetails`
+// and `event` in the same request (the JSON schema doesn't forbid it) made
+// the second block miss the onetimer the first had just created and linked,
+// creating a second, orphaned `Onetimer` row. The fix resolves a single date
+// tied to the *resulting* type before writing onetimer at all.
+describe("PATCH /opportunity/:id onetimer resolution", () => {
+  let fastify: FastifyInstance;
+  let agent: Agent;
+  let deal: Deal;
+  let opportunity: Opportunity;
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (onetimer-resolve) ${suffix}` }),
+    );
+    deal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    opportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (onetimer-resolve) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.NEW,
+        agentId: agent.id,
+        dealId: deal.id,
+      }),
+    );
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    const pwHash = await hashPassword(PASSWORD);
+    const coordinatorUser = await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-onetimer-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+
+    const login = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: coordinatorUser.email,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(login.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    const updated = await fastify.db.opportunityRepository.findOneBy({
+      id: opportunity.id,
+    });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.opportunityRepository.delete({ id: opportunity.id });
+    if (updated?.onetimerId) {
+      await fastify.db.onetimerRepository.delete({ id: updated.onetimerId });
+    }
+    await fastify.db.dealRepository.delete({ id: deal.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.close();
+  });
+
+  it("writes exactly one onetimer using the event date when both accompanyingDetails and event are sent", async () => {
+    // Distinct, test-specific dates so we can positively assert neither an
+    // orphaned row (from the accompanyingDetails date) nor a stray one from
+    // other concurrently-running tests interferes with the check.
+    const eventDate = "2026-08-01";
+    const accompanyingDate = "2026-09-11";
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${opportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        opportunity_type: "events",
+        event: { date: eventDate, time: "14:00" },
+        accompanyingDetails: {
+          appointmentDate: accompanyingDate,
+          appointmentTime: "09:00",
+        },
+      },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: opportunity.id,
+    });
+    expect(updated.onetimerId).toBeTruthy();
+
+    const onetimer = await fastify.db.onetimerRepository.findOneByOrFail({
+      id: updated.onetimerId,
+    });
+    // The event date wins (matches the resulting EVENTS type), not the
+    // accompanyingDetails date.
+    expect(new Date(onetimer.date).toISOString().slice(0, 10)).toBe(eventDate);
+
+    // No orphaned second row was created from the accompanyingDetails date —
+    // if the two write paths still raced, this row would exist and be
+    // unreferenced by any opportunity.
+    const orphan = await fastify.db.onetimerRepository
+      .createQueryBuilder("onetimer")
+      .where("CAST(onetimer.date AS date) = CAST(:date AS date)", {
+        date: accompanyingDate,
+      })
+      .getOne();
+    expect(orphan).toBeNull();
+  });
+});

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -15,6 +15,7 @@ import AgentPerson from "../../../data/entity/m2m/agent-person";
 import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
+import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
 import User from "../../../data/entity/user.entity";
@@ -264,6 +265,7 @@ describe("DELETE /opportunity/:id", () => {
   let opportunity: Opportunity;
   let deal: Deal;
   let accompanying: Accompanying;
+  let onetimer: Onetimer;
   let opportunityVolunteer: OpportunityVolunteer;
   let comment: Comment;
   let agentPerson: Person;
@@ -290,8 +292,10 @@ describe("DELETE /opportunity/:id", () => {
       new Accompanying({
         address: "Test Address",
         name: "Test Refugee",
-        date: new Date(),
       }),
+    );
+    onetimer = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: new Date() }),
     );
     opportunity = await fastify.db.opportunityRepository.save(
       new Opportunity({
@@ -301,6 +305,7 @@ describe("DELETE /opportunity/:id", () => {
         agentId: agent.id,
         dealId: deal.id,
         accompanyingId: accompanying.id,
+        onetimerId: onetimer.id,
       }),
     );
 
@@ -407,6 +412,7 @@ describe("DELETE /opportunity/:id", () => {
     await fastify.db.opportunityRepository.delete({ id: opportunity.id });
     await fastify.db.dealRepository.delete({ id: deal.id });
     await fastify.db.accompanyingRepository.delete({ id: accompanying.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimer.id });
     await fastify.db.volunteerRepository.delete({ id: volunteer.id });
     await fastify.close();
   });
@@ -429,7 +435,7 @@ describe("DELETE /opportunity/:id", () => {
     expect(res.statusCode).toBe(404);
   });
 
-  it("lets a coordinator delete an opportunity, cascading its deal, accompanying, comments, and match link", async () => {
+  it("lets a coordinator delete an opportunity, cascading its deal, accompanying, onetimer, comments, and match link", async () => {
     const res = await fastify.inject({
       method: "DELETE",
       url: `/opportunity/${opportunity.id}`,
@@ -447,6 +453,9 @@ describe("DELETE /opportunity/:id", () => {
       await fastify.db.accompanyingRepository.findOneBy({
         id: accompanying.id,
       }),
+    ).toBeNull();
+    expect(
+      await fastify.db.onetimerRepository.findOneBy({ id: onetimer.id }),
     ).toBeNull();
     expect(
       await fastify.db.commentRepository.findOneBy({ id: comment.id }),

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -606,3 +606,160 @@ describe("PATCH /opportunity/:id onetimer resolution", () => {
     expect(orphan).toBeNull();
   });
 });
+
+// be#746: server-side sort by start date, replacing the old client-side
+// per-page sort — this is what actually fixes opportunities falling through
+// the cracks across pages. Verifies both the ordering and that opportunities
+// with no onetimer (e.g. REGULAR type) always sort last, regardless of
+// direction (Postgres defaults DESC to NULLS FIRST, which would be wrong
+// here).
+describe("GET /opportunity sortBy=start-date", () => {
+  let fastify: FastifyInstance;
+  let agent: Agent;
+  let dealSoon: Deal;
+  let dealLater: Deal;
+  let dealNoDate: Deal;
+  let onetimerSoon: Onetimer;
+  let onetimerLater: Onetimer;
+  let oppSoon: Opportunity;
+  let oppLater: Opportunity;
+  let oppNoDate: Opportunity;
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (sort-start-date) ${suffix}` }),
+    );
+
+    const inDays = (n: number) => {
+      const d = new Date();
+      d.setDate(d.getDate() + n);
+      return d;
+    };
+    onetimerSoon = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: inDays(5) }),
+    );
+    onetimerLater = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: inDays(20) }),
+    );
+
+    dealSoon = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    dealLater = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    dealNoDate = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+
+    oppSoon = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Sort Soon ${suffix}`,
+        type: OpportunityType.EVENTS,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealSoon.id,
+        onetimerId: onetimerSoon.id,
+      }),
+    );
+    oppLater = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Sort Later ${suffix}`,
+        type: OpportunityType.EVENTS,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealLater.id,
+        onetimerId: onetimerLater.id,
+      }),
+    );
+    // No onetimer at all — must sort last in both directions.
+    oppNoDate = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Sort No Date ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealNoDate.id,
+      }),
+    );
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "SortCoordinator" }),
+    );
+    const pwHash = await hashPassword(PASSWORD);
+    const coordinatorUser = await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-sort-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const login = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: coordinatorUser.email, password: PASSWORD },
+    });
+    coordinatorCookie = getCookie(login.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.opportunityRepository.delete({ id: oppSoon.id });
+    await fastify.db.opportunityRepository.delete({ id: oppLater.id });
+    await fastify.db.opportunityRepository.delete({ id: oppNoDate.id });
+    await fastify.db.dealRepository.delete({ id: dealSoon.id });
+    await fastify.db.dealRepository.delete({ id: dealLater.id });
+    await fastify.db.dealRepository.delete({ id: dealNoDate.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimerSoon.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimerLater.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.close();
+  });
+
+  // Relative order of our known ids within the response, ignoring whatever
+  // other opportunities exist in the shared dev DB.
+  function relativeOrder(data: { id: number }[], ids: number[]): number[] {
+    return data.map((o) => o.id).filter((id) => ids.includes(id));
+  }
+
+  it("orders soonest-first (old-new) with no-date opportunities last", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity?sortBy=start-date&sortOrder=old-new&limit=120",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const { data } = res.json();
+    expect(
+      relativeOrder(data, [oppSoon.id, oppLater.id, oppNoDate.id]),
+    ).toEqual([oppSoon.id, oppLater.id, oppNoDate.id]);
+  });
+
+  it("orders latest-first (new-old) with no-date opportunities still last", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity?sortBy=start-date&sortOrder=new-old&limit=120",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const { data } = res.json();
+    expect(
+      relativeOrder(data, [oppSoon.id, oppLater.id, oppNoDate.id]),
+    ).toEqual([oppLater.id, oppSoon.id, oppNoDate.id]);
+  });
+});

--- a/src/test/services/dto/dto-accompanying.test.ts
+++ b/src/test/services/dto/dto-accompanying.test.ts
@@ -6,12 +6,13 @@ import DealLanguage from "../../../data/entity/m2m/deal-language";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import { dtoOpportunityAccompanying } from "../../../services/dto/dto-accompanying";
 
+const TEST_DATE = new Date("2026-06-01T10:30:00Z");
+
 const buildAccompanying = (overrides: Partial<Accompanying> = {}) =>
   new Accompanying({
     address: "Musterstraße 1",
     name: "Jane Doe",
     phone: "030123456",
-    date: new Date("2026-06-01T10:30:00Z"),
     languageToTranslate: TranslatedIntoType.DEUTSCHE,
     ...overrides,
   });
@@ -29,21 +30,26 @@ describe("dtoOpportunityAccompanying", () => {
   });
 
   it("maps base fields", () => {
-    const result = dtoOpportunityAccompanying(buildAccompanying());
+    const result = dtoOpportunityAccompanying(buildAccompanying(), TEST_DATE);
 
     expect(result.appointmentAddress).toBe("Musterstraße 1");
     expect(result.refugeeName).toBe("Jane Doe");
     expect(result.refugeeNumber).toBe("030123456");
     expect(result.appointmentLanguage).toBe(TranslatedIntoType.DEUTSCHE);
-    expect(result.appointmentDate).toBe(
-      new Date("2026-06-01T10:30:00Z").toISOString().split("T")[0],
-    );
+    expect(result.appointmentDate).toBe(TEST_DATE.toISOString().split("T")[0]);
     expect(result.appointmentTime).toBe("10:30");
     expect(result.refugeeLanguage).toEqual([]);
   });
 
+  it("omits appointmentDate/appointmentTime when no onetimer date is given", () => {
+    const result = dtoOpportunityAccompanying(buildAccompanying());
+
+    expect(result).not.toHaveProperty("appointmentDate");
+    expect(result).not.toHaveProperty("appointmentTime");
+  });
+
   it("maps refugeeLanguage from dealLanguage, skipping falsy entries", () => {
-    const result = dtoOpportunityAccompanying(buildAccompanying(), [
+    const result = dtoOpportunityAccompanying(buildAccompanying(), TEST_DATE, [
       buildDealLanguage(7),
       null as unknown as DealLanguage,
       buildDealLanguage(9),
@@ -53,26 +59,34 @@ describe("dtoOpportunityAccompanying", () => {
   });
 
   it("omits appointmentPostcode when accompanying.postcode is absent", () => {
-    const result = dtoOpportunityAccompanying(buildAccompanying());
+    const result = dtoOpportunityAccompanying(buildAccompanying(), TEST_DATE);
 
     expect(result).not.toHaveProperty("appointmentPostcode");
   });
 
   it("emits appointmentPostcode value when accompanying.postcode is loaded", () => {
     const postcode = new Postcode({ id: 42, value: "10115" });
-    const result = dtoOpportunityAccompanying(buildAccompanying({ postcode }));
+    const result = dtoOpportunityAccompanying(
+      buildAccompanying({ postcode }),
+      TEST_DATE,
+    );
 
     expect(result.appointmentPostcode).toBe("10115");
   });
 
   it("omits appointmentDistrict when district is undefined", () => {
-    const result = dtoOpportunityAccompanying(buildAccompanying());
+    const result = dtoOpportunityAccompanying(buildAccompanying(), TEST_DATE);
 
     expect(result).not.toHaveProperty("appointmentDistrict");
   });
 
   it("omits appointmentDistrict when district is null", () => {
-    const result = dtoOpportunityAccompanying(buildAccompanying(), [], null);
+    const result = dtoOpportunityAccompanying(
+      buildAccompanying(),
+      TEST_DATE,
+      [],
+      null,
+    );
 
     expect(result).not.toHaveProperty("appointmentDistrict");
   });
@@ -81,6 +95,7 @@ describe("dtoOpportunityAccompanying", () => {
     const district = new District({ id: 3, title: "Mitte" });
     const result = dtoOpportunityAccompanying(
       buildAccompanying(),
+      TEST_DATE,
       [],
       district,
     );
@@ -94,6 +109,7 @@ describe("dtoOpportunityAccompanying", () => {
 
     const result = dtoOpportunityAccompanying(
       buildAccompanying({ postcode }),
+      TEST_DATE,
       [],
       district,
     );

--- a/src/test/services/dto/dto-opportunity.test.ts
+++ b/src/test/services/dto/dto-opportunity.test.ts
@@ -238,23 +238,10 @@ describe("dtoOpportunityGet", () => {
     opportunityVolunteer: [],
   };
 
-  it("populates event from a one-time event timeslot", () => {
+  it("populates event from the opportunity's onetimer", () => {
     const opportunity = {
       ...baseDetail,
-      deal: {
-        ...baseDetail.deal,
-        dealTimeslot: [
-          {
-            timeslot: {
-              id: 10,
-              start: eventDate,
-              end: null,
-              rrule: null,
-              occasional: null,
-            },
-          },
-        ],
-      },
+      onetimer: { id: 10, date: eventDate },
     };
 
     const result = dtoOpportunityGet(opportunity as any);
@@ -265,13 +252,10 @@ describe("dtoOpportunityGet", () => {
     });
   });
 
-  it("returns undefined event when there are no dealTimeslots", () => {
+  it("returns undefined event when the opportunity has no onetimer", () => {
     const opportunity = {
       ...baseDetail,
-      deal: {
-        ...baseDetail.deal,
-        dealTimeslot: [],
-      },
+      onetimer: undefined,
     };
 
     const result = dtoOpportunityGet(opportunity as any);
@@ -279,47 +263,11 @@ describe("dtoOpportunityGet", () => {
     expect(result.event).toBeUndefined();
   });
 
-  it("returns undefined event when timeslots are recurring (have rrule)", () => {
+  it("returns undefined event for non-EVENTS types even when a onetimer is present", () => {
     const opportunity = {
       ...baseDetail,
-      deal: {
-        ...baseDetail.deal,
-        dealTimeslot: [
-          {
-            timeslot: {
-              id: 11,
-              start: new Date("2026-01-01T08:00:00Z"),
-              end: new Date("2026-01-01T11:00:00Z"),
-              rrule: "FREQ=WEEKLY;BYDAY=MO",
-              occasional: null,
-            },
-          },
-        ],
-      },
-    };
-
-    const result = dtoOpportunityGet(opportunity as any);
-
-    expect(result.event).toBeUndefined();
-  });
-
-  it("returns undefined event when timeslots are occasional", () => {
-    const opportunity = {
-      ...baseDetail,
-      deal: {
-        ...baseDetail.deal,
-        dealTimeslot: [
-          {
-            timeslot: {
-              id: 12,
-              start: null,
-              end: null,
-              rrule: null,
-              occasional: "weekends",
-            },
-          },
-        ],
-      },
+      type: "accompanying",
+      onetimer: { id: 13, date: eventDate },
     };
 
     const result = dtoOpportunityGet(opportunity as any);

--- a/src/test/services/dto/parser-accompanying-legacy.test.ts
+++ b/src/test/services/dto/parser-accompanying-legacy.test.ts
@@ -1,6 +1,9 @@
 import { OpportunityLegacyFormData, TranslatedIntoType } from "need4deed-sdk";
 import { describe, expect, it, vi } from "vitest";
-import { accompanyingParserOpportunity } from "../../../services/dto/parser-accompanying-legacy";
+import {
+  accompanyingParserOpportunity,
+  parseAccompDatetime,
+} from "../../../services/dto/parser-accompanying-legacy";
 
 const { mockPostcode, getPostcodeMock } = vi.hoisted(() => {
   const mockPostcode = { id: 1, value: "10115" };
@@ -31,8 +34,13 @@ describe("accompanyingParserOpportunity", () => {
     expect(result.name).toBe("Jane Doe");
     expect(result.phone).toBe("030123456");
     expect(result.languageToTranslate).toBe(TranslatedIntoType.DEUTSCHE);
-    expect(result.date).toBeInstanceOf(Date);
-    expect(isNaN(result.date.getTime())).toBe(false);
+  });
+
+  it("parseAccompDatetime parses accomp_datetime into a valid Date", () => {
+    const date = parseAccompDatetime(baseBody.accomp_datetime);
+
+    expect(date).toBeInstanceOf(Date);
+    expect(isNaN(date.getTime())).toBe(false);
   });
 
   it("resolves and assigns postcode entity when accomp_postcode is provided", async () => {

--- a/src/test/services/dto/parser-opportunity-patch-data.test.ts
+++ b/src/test/services/dto/parser-opportunity-patch-data.test.ts
@@ -42,7 +42,7 @@ describe("parseOpportunity", () => {
     });
   });
 
-  it("composes accompanying.date from appointmentDate + appointmentTime", () => {
+  it("composes onetimerDate from appointmentDate + appointmentTime", () => {
     const result = parseOpportunity({
       accompanyingDetails: {
         appointmentDate: "2026-06-01",
@@ -50,7 +50,17 @@ describe("parseOpportunity", () => {
       },
     });
 
-    expect(result.accompanying?.date).toBeInstanceOf(Date);
+    expect(result.onetimerDate).toBeInstanceOf(Date);
+  });
+
+  it("leaves onetimerDate undefined when no appointmentDate is sent", () => {
+    const result = parseOpportunity({
+      accompanyingDetails: {
+        appointmentAddress: "Musterstraße 1",
+      },
+    });
+
+    expect(result.onetimerDate).toBeUndefined();
   });
 
   it("does not set accompanying.postcode (resolved in route handler instead)", () => {

--- a/src/test/services/jobs/scan-accompany-not-found.test.ts
+++ b/src/test/services/jobs/scan-accompany-not-found.test.ts
@@ -1,0 +1,118 @@
+import { FastifyInstance } from "fastify";
+import { OpportunityStatusType, OpportunityType } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import Deal from "../../../data/entity/deal.entity";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import { DealType } from "../../../data/types";
+import { createServer } from "../../../server";
+import {
+  addWorkingDays,
+  berlinDayBoundaries,
+  berlinToday,
+} from "../../../services/jobs/german-holidays";
+import { scanAccompanyNotFound } from "../../../services/jobs/scan-accompany-not-found";
+
+// Regression coverage for be#746: the query moved from
+// `where: { accompanying: { date: ... } }` to
+// `where: { onetimer: { date: ... } }` when the appointment date moved off
+// `Accompanying` onto the new `Onetimer` entity. This exercises the real
+// query/relations against the DB rather than mocking the repository, since a
+// wrong relation/column name here would only surface at runtime.
+describe("scanAccompanyNotFound", () => {
+  let fastify: FastifyInstance;
+  let agent: Agent;
+  let dealInWindow: Deal;
+  let dealOutOfWindow: Deal;
+  let onetimerInWindow: Onetimer;
+  let onetimerOutOfWindow: Onetimer;
+  let oppInWindow: Opportunity;
+  let oppOutOfWindow: Opportunity;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+    fastify.notify.emailAccompanyNotFound = vi
+      .fn()
+      .mockResolvedValue(undefined);
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (scan-not-found) ${suffix}` }),
+    );
+
+    const targetDay = addWorkingDays(berlinToday(), 4);
+    const { startOfDay } = berlinDayBoundaries(targetDay);
+    const inWindowDate = new Date(startOfDay.getTime() + 60 * 60 * 1000);
+    const outOfWindowDate = new Date(startOfDay.getTime() - 60 * 60 * 1000);
+
+    onetimerInWindow = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: inWindowDate }),
+    );
+    onetimerOutOfWindow = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: outOfWindowDate }),
+    );
+
+    dealInWindow = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    dealOutOfWindow = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+
+    oppInWindow = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Accompanying In Window ${suffix}`,
+        type: OpportunityType.ACCOMPANYING,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealInWindow.id,
+        onetimerId: onetimerInWindow.id,
+      }),
+    );
+    oppOutOfWindow = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Accompanying Out of Window ${suffix}`,
+        type: OpportunityType.ACCOMPANYING,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealOutOfWindow.id,
+        onetimerId: onetimerOutOfWindow.id,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await fastify.db.communicationRepository.delete({
+      opportunityId: oppInWindow.id,
+    });
+    await fastify.db.communicationRepository.delete({
+      opportunityId: oppOutOfWindow.id,
+    });
+    await fastify.db.opportunityRepository.delete({ id: oppInWindow.id });
+    await fastify.db.opportunityRepository.delete({ id: oppOutOfWindow.id });
+    await fastify.db.dealRepository.delete({ id: dealInWindow.id });
+    await fastify.db.dealRepository.delete({ id: dealOutOfWindow.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimerInWindow.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimerOutOfWindow.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.close();
+  });
+
+  it("emails only for opportunities whose onetimer date falls in the target window", async () => {
+    await scanAccompanyNotFound(fastify);
+
+    const calls = (
+      fastify.notify.emailAccompanyNotFound as ReturnType<typeof vi.fn>
+    ).mock.calls;
+    const calledIds = calls.map(([opp]: [Opportunity]) => opp.id);
+
+    expect(calledIds).toContain(oppInWindow.id);
+    expect(calledIds).not.toContain(oppOutOfWindow.id);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.137:
-  version "0.0.137"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.137.tgz#679a423eae87009c4fe34f7d43f0bef02f780361"
-  integrity sha512-uMqDXoWMhdUf4/tlOhUnf5ASU4c4Pa+ijlhHFnDSatlg5E5s3jAUt1vVmkkvzTBrw1uMcCtI8I9sM92mBvn86w==
+need4deed-sdk@0.0.138:
+  version "0.0.138"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.138.tgz#7464a7cefb8c4ef4b01d28ebdf4d095a59bda9f5"
+  integrity sha512-imAqPSMmc0N9MNp10fqDKHyRVZXRImhrW9ZdahO9HR29IAlDL3VBn10F/8AsX4k9kJ/8VbXj1tq1nkLiUHmjKA==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

Implements be#746 via the `Onetimer` design discussed in the issue comments, replacing the dual/hacky storage of the ACCOMPANYING/EVENTS single-occurrence date:

- Today, `EVENTS` opportunities get a blanked-out `Accompanying` row (`address: ""`, `name: ""`) created solely to hold `date`, **and** a duplicate one-off `Timeslot`/`DealTimeslot` row, read back through a fragile heuristic in `dto-opportunity.ts` ("no end, no rrule, not occasional"). `ACCOMPANYING` opportunities use `Accompanying.date` correctly, but for no good reason share the same column name/type as this hack.
- New `Onetimer` entity (`id`, `date timestamptz`), owned 1:1 by `Opportunity` via a nullable `onetimerId`, used by **both** ACCOMPANYING and EVENTS.
- `Accompanying` now holds only real appointment metadata (address/phone/postcode/language) — the `date` column is dropped.
- `Timeslot`/`DealTimeslot` return to being scoped purely to recurring/volunteer availability — the EVENTS hack's leftover rows are left in place (can't safely distinguish them from real one-off availability slots by data alone) but are no longer written or read for this purpose.

## Migrations

Two, in sequence — deliberately split (expand/contract) rather than combined:
1. `add-onetimer-entity`: creates `onetimer`, adds `opportunity.onetimer_id` + FK, backfills from `accompanying.date` (ACCOMPANYING) and the old timeslot heuristic with an `accompanying.date` fallback (EVENTS — the create path never wrote a timeslot, a pre-existing gap, so some EVENTS rows only ever had the date on `accompanying`).
2. `retire-accompanying-date`: nulls `accompanying_id` + deletes the blanked-out EVENTS-only `accompanying` rows, then drops the `date` column.

Verified locally: `migration:run` → `migration:revert` (x2) → `migration:run` round-trips cleanly against real dev data; backfill correctness checked via direct SQL against the dev DB before/after.

## Sorting (be#746's other half — now included)

need4deed-org/sdk#184 (adds `OpportunitySortField`) has been merged and published to npm as `need4deed-sdk@0.0.138`; this PR bumps the dependency and finishes the sort wiring:

- New `sortBy=start-date` query param on `GET /opportunity` (scoped to this endpoint only, not the shared `sortOrderProps`).
- Real server-side sort by `onetimer.date`, replacing the old client-side-per-page sort (see fe#460) that let opportunities with a near-term date but an old `createdAt` fall through the cracks on later pages.
- Opportunities with no onetimer (REGULAR type, or ACCOMPANYING/EVENTS with no date set) always sort last, in both directions — required an explicit `NULLS LAST` via the query builder since Postgres defaults DESC to NULLS FIRST.

## Test plan

- [x] `yarn typecheck`, `yarn lint`, `yarn prettier --check` all clean on touched files
- [x] Full `yarn test:run` — 60 files / 503 tests passing (real DB, pre-push hook also ran this)
- [x] Updated tests: `dto-opportunity.test.ts` (onetimer-based `event` field), `dto-accompanying.test.ts`, `parser-accompanying-legacy.test.ts`, `parser-opportunity-patch-data.test.ts`, `opportunity.routes.test.ts` (onetimer cascade-delete, dual-payload race regression, both sort directions), `scan-accompany-not-found.test.ts` (new)
- [x] Local dev server (`docker compose`) picked up the migrations + entity changes cleanly on restart
- [ ] Full `docker compose down -v` fresh-reseed replay check (the canonical migration self-containment check per CLAUDE.md) — not run yet, since it wipes the local dev DB; happy to run if wanted before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)