### PR TITLE
fix: remove PII from auth/opportunity logs (be#728)

### DIFF
--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -61,8 +61,6 @@ async function authRoutes(
       }
 
       try {
-        logger.debug(`Attempting to authenticate: ${email}`);
-
         const userRepository = fastify.db.userRepository;
         if (!userRepository) {
           throw new Error("User repository is not initialized.");

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -599,9 +599,6 @@ export default async function opportunityRoutes(
         activities,
       } = parseOpportunity(request.body);
       const agentLinkId = request.body.agent?.id;
-      logger.debug(
-        `PATCH /opportunity/{id} ${JSON.stringify(parseOpportunity(request.body))}`,
-      );
 
       if (
         request.body.opportunity_type === OpportunityType.ACCOMPANYING &&

--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -232,7 +232,7 @@ export default async function userRoutes(
         });
 
         if (!user) {
-          logger.warn(`User with email ${email} not found.`);
+          logger.warn("User not found for login attempt.");
           return reply.status(400).send({ message: "Invalid token." });
         }
 


### PR DESCRIPTION
## Summary
- Removed the `debug` log in `auth.ts` that printed the raw login email
- Removed the `debug` log in `opportunity.routes.ts` that dumped the full PATCH body (may include `appointmentAddress`, refugee PII)
- Stripped the email from the `warn` log in `user.ts` ("user not found") — replaced with a non-PII message

Closes #728

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (no new errors introduced by these changes)
- [x] `yarn test:run` (503 tests passed, via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)