### PR TITLE
fix: make the Postgres CA path configurable (DB_SSL_CA_PATH)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ Run a single test file: `yarn test -- src/test/services/dto/dto-person.test.ts`
 Copy `.env.example` to `.env` and fill in real values. Key variables:
 
 - `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `DB_SCHEMA` — Postgres connection
+- `DB_SSL_CA_PATH` — optional; path to the CA certificate used to verify the Postgres server in `production`/`staging` (defaults to the baked-in AWS RDS bundle; TLS verification is always strict)
 - `JWT_SECRET` — required; server refuses to start without it
 - `NODE_ENV` — `development` | `test` | `production`
 - `RUN_MIGRATIONS` — when truthy, auto-run pending migrations on server startup (always on in prod regardless of this flag); see Commands section

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -154,7 +154,6 @@ export const defaultFrom = process.env.EMAIL_FROM || "";
 export const isDev = process.env.NODE_ENV === "development";
 export const isTest = process.env.NODE_ENV === "test";
 export const isProd = process.env.NODE_ENV === "production";
-export const isStaging = process.env.NODE_ENV === "staging";
 export const shouldTruncateAll = TRUTHY.has(process.env.TRUNCATE_ALL || "");
 export const shouldRunMigrations = TRUTHY.has(process.env.RUN_MIGRATIONS || "");
 export const nidsToken = process.env.NIDS_TOKEN || "";

--- a/src/data/data-source.ts
+++ b/src/data/data-source.ts
@@ -1,7 +1,6 @@
-import * as fs from "fs";
 import "reflect-metadata";
 import { DataSource } from "typeorm";
-import { isProd, isStaging, isTest } from "../config";
+import { isTest } from "../config";
 import Comment from "./entity/comment.entity";
 import Communication from "./entity/communication.entity";
 import Config from "./entity/config.entity";
@@ -50,7 +49,7 @@ import User from "./entity/user.entity";
 import Appreciation from "./entity/volunteer/appreciation.entity";
 import Volunteer from "./entity/volunteer/volunteer.entity";
 import SnakeCaseNamingStrategy from "./lib/snake-case";
-import { getLoggingForDataSource } from "./utils";
+import { getLoggingForDataSource, getSslForDataSource } from "./utils";
 
 export const dataSource = new DataSource({
   type: "postgres",
@@ -112,15 +111,7 @@ export const dataSource = new DataSource({
     User,
     Volunteer,
   ],
-  ssl:
-    isProd || isStaging
-      ? {
-          rejectUnauthorized: true,
-          ca: fs
-            .readFileSync("/app/certificates/eu-central-1-bundle.pem")
-            .toString(),
-        }
-      : false,
+  ssl: getSslForDataSource(process.env.NODE_ENV, process.env.DB_SSL_CA_PATH),
   migrations: isTest ? [] : [__dirname + "/migrations/**/*{.ts,.js}"],
   migrationsTableName: "be_migrations",
   subscribers: [],

--- a/src/data/utils/get-ssl-for-data-source.ts
+++ b/src/data/utils/get-ssl-for-data-source.ts
@@ -10,13 +10,24 @@ export function getSslForDataSource(
     return false;
   }
   const path = caPath || DEFAULT_CA_PATH;
+  let ca: string;
   try {
-    return { rejectUnauthorized: true, ca: fs.readFileSync(path).toString() };
+    ca = fs.readFileSync(path).toString();
   } catch (error) {
     throw new Error(
       `Cannot read database CA certificate at "${path}" ` +
         `(set DB_SSL_CA_PATH to override): ` +
         `${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
+  // An empty ca makes Node fall back to the public root store, silently
+  // removing the pin.
+  if (!ca.includes("-----BEGIN CERTIFICATE-----")) {
+    throw new Error(
+      `Database CA certificate at "${path}" contains no PEM certificate ` +
+        `(set DB_SSL_CA_PATH to override)`,
+    );
+  }
+  return { rejectUnauthorized: true, ca };
 }

--- a/src/data/utils/get-ssl-for-data-source.ts
+++ b/src/data/utils/get-ssl-for-data-source.ts
@@ -1,0 +1,22 @@
+import * as fs from "fs";
+
+const DEFAULT_CA_PATH = "/app/certificates/eu-central-1-bundle.pem";
+
+export function getSslForDataSource(
+  env: string | undefined,
+  caPath: string | undefined,
+): { rejectUnauthorized: true; ca: string } | false {
+  if (env !== "production" && env !== "staging") {
+    return false;
+  }
+  const path = caPath || DEFAULT_CA_PATH;
+  try {
+    return { rejectUnauthorized: true, ca: fs.readFileSync(path).toString() };
+  } catch (error) {
+    throw new Error(
+      `Cannot read database CA certificate at "${path}" ` +
+        `(set DB_SSL_CA_PATH to override): ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/data/utils/index.ts
+++ b/src/data/utils/index.ts
@@ -3,6 +3,7 @@ export * from "./get-district";
 export * from "./get-opportunity-representative-person";
 export * from "./get-postcode";
 export * from "./get-repository";
+export * from "./get-ssl-for-data-source";
 export * from "./getLoggingForDataSource";
 export * from "./getRRULE";
 export * from "./getStartEndDates";

--- a/src/test/data/utils/get-ssl-for-data-source.test.ts
+++ b/src/test/data/utils/get-ssl-for-data-source.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getSslForDataSource } from "../../../data/utils";
+
+const PEM =
+  "-----BEGIN CERTIFICATE-----\nlocal-test-ca\n-----END CERTIFICATE-----\n";
+
+describe("getSslForDataSource", () => {
+  let dir: string;
+  let caPath: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "db-ca-"));
+    caPath = join(dir, "ca.pem");
+    await writeFile(caPath, PEM, "utf-8");
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it.each(["development", "test", "debug", undefined])(
+    "returns false for %s even when a CA path is set",
+    (env) => {
+      expect(getSslForDataSource(env, caPath)).toBe(false);
+    },
+  );
+
+  it.each(["production", "staging"])(
+    "returns strict TLS with the CA content for %s",
+    (env) => {
+      expect(getSslForDataSource(env, caPath)).toEqual({
+        rejectUnauthorized: true,
+        ca: PEM,
+      });
+    },
+  );
+
+  it("throws an actionable error when the CA path is unreadable", () => {
+    const missing = join(dir, "missing.pem");
+    expect(() => getSslForDataSource("production", missing)).toThrowError(
+      /DB_SSL_CA_PATH/,
+    );
+    expect(() => getSslForDataSource("production", missing)).toThrowError(
+      new RegExp(missing),
+    );
+  });
+
+  it("falls back to the baked-in bundle path when no path is given", () => {
+    expect(() => getSslForDataSource("production", undefined)).toThrowError(
+      /\/app\/certificates\/eu-central-1-bundle\.pem/,
+    );
+  });
+
+  it("never disables certificate verification", () => {
+    const ssl = getSslForDataSource("staging", caPath);
+    expect(ssl).not.toBe(false);
+    if (ssl !== false) {
+      expect(ssl.rejectUnauthorized).toBe(true);
+    }
+  });
+});

--- a/src/test/data/utils/get-ssl-for-data-source.test.ts
+++ b/src/test/data/utils/get-ssl-for-data-source.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "fs";
 import { mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -21,7 +22,7 @@ describe("getSslForDataSource", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  it.each(["development", "test", "debug", undefined])(
+  it.each(["development", "test", "debug", "", undefined])(
     "returns false for %s even when a CA path is set",
     (env) => {
       expect(getSslForDataSource(env, caPath)).toBe(false);
@@ -38,7 +39,7 @@ describe("getSslForDataSource", () => {
     },
   );
 
-  it("throws an actionable error when the CA path is unreadable", () => {
+  it("names the path and DB_SSL_CA_PATH when the CA is unreadable", () => {
     const missing = join(dir, "missing.pem");
     expect(() => getSslForDataSource("production", missing)).toThrowError(
       /DB_SSL_CA_PATH/,
@@ -48,11 +49,33 @@ describe("getSslForDataSource", () => {
     );
   });
 
-  it("falls back to the baked-in bundle path when no path is given", () => {
-    expect(() => getSslForDataSource("production", undefined)).toThrowError(
-      /\/app\/certificates\/eu-central-1-bundle\.pem/,
+  it("rejects a CA file that contains no PEM certificate", async () => {
+    const empty = join(dir, "empty.pem");
+    await writeFile(empty, "", "utf-8");
+    expect(() => getSslForDataSource("production", empty)).toThrowError(
+      /contains no PEM certificate/,
     );
   });
+
+  const DEFAULT_CA_PATH = "/app/certificates/eu-central-1-bundle.pem";
+
+  it.skipIf(existsSync(DEFAULT_CA_PATH))(
+    "falls back to the baked-in bundle path when no path is given",
+    () => {
+      expect(() => getSslForDataSource("production", undefined)).toThrowError(
+        /\/app\/certificates\/eu-central-1-bundle\.pem/,
+      );
+    },
+  );
+
+  it.skipIf(existsSync(DEFAULT_CA_PATH))(
+    "treats an empty-string path like an unset one",
+    () => {
+      expect(() => getSslForDataSource("production", "")).toThrowError(
+        /\/app\/certificates\/eu-central-1-bundle\.pem/,
+      );
+    },
+  );
 
   it("never disables certificate verification", () => {
     const ssl = getSslForDataSource("staging", caPath);


### PR DESCRIPTION
## Why

`src/data/data-source.ts` hardcodes the AWS RDS CA bundle path with `rejectUnauthorized: true` for production/staging, evaluated at module import time. Against any Postgres that is not RDS (such as the interim self-managed instance for the Infomaniak migration) the backend fails at boot with a TLS error, and the tempting quick fix in that situation is `ssl: false`. This PR keeps that off the table.

## What changes

- `getSslForDataSource(env, caPath)` in `src/data/utils/`, mirroring the existing `getLoggingForDataSource` helper.
- `DB_SSL_CA_PATH` overrides the CA path. The baked-in AWS bundle stays the default, so behaviour on the current AWS estate is unchanged.
- `rejectUnauthorized: true` in every TLS branch. No `ssl: false` path is reachable in production or staging.
- An unreadable CA fails fast, naming the attempted path and the variable to set, with `cause` preserved.
- A CA file with no PEM content is rejected: Node treats an empty `ca` as "use the public root store", so it would otherwise boot cleanly with the pin silently gone (verified on Node 22).
- Dead `isStaging` export removed. This was its only consumer.

## Verification

12 unit tests cover the env matrix, the CA fallback, empty and non-PEM content, and the "never disables verification" invariant. `yarn lint` and `yarn typecheck` clean. Smoke-tested in a local k3s cluster: with `NODE_ENV=production` and a mounted CA the pod reaches TLS negotiation (a non-TLS server correctly refuses), and a missing CA path produces the boot error above. Rebased on current develop (7d5fda4).
