### PR TITLE
feat: implement opportunity contact relink via contact.id (be#824)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.138",
+    "need4deed-sdk": "0.0.139",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -676,13 +676,12 @@ export default async function opportunityRoutes(
         // both `agent.id` and `contact.id` in one request validates the
         // contact against the opportunity's *new* agent, not the old one.
         const effectiveAgentId = agentLinkId ?? opportunity.agentId;
-        const isAgentContact = await fastify.db.agentPersonRepository.findOneBy(
-          {
+        const agentContactMembership =
+          await fastify.db.agentPersonRepository.findOneBy({
             agentId: effectiveAgentId,
             personId: contactLinkId,
-          },
-        );
-        if (!isAgentContact) {
+          });
+        if (!agentContactMembership) {
           throw new NotFoundError(
             `Contact (personId:${contactLinkId}) is not registered as a contact of this opportunity's agent.`,
           );

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -28,7 +28,6 @@ import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
-import Person from "../../../data/entity/person.entity";
 import { updateVolunteerMatching } from "../../../data/utils";
 import { getDistrictFromPostcode } from "../../../data/utils/get-district";
 import logger from "../../../logger";
@@ -589,7 +588,6 @@ export default async function opportunityRoutes(
 
       const {
         opportunity: opportunityObj,
-        contact,
         agent,
         accompanying,
         onetimerDate,
@@ -599,6 +597,7 @@ export default async function opportunityRoutes(
         activities,
       } = parseOpportunity(request.body);
       const agentLinkId = request.body.agent?.id;
+      const contactLinkId = request.body.contact?.id;
 
       if (
         request.body.opportunity_type === OpportunityType.ACCOMPANYING &&
@@ -650,15 +649,6 @@ export default async function opportunityRoutes(
         }
       }
 
-      if (contact) {
-        const success = await patchEntity(Person, contact);
-        if (!success) {
-          throw new Error(
-            "Patching contact failed while patching opportunity.",
-          );
-        }
-      }
-
       if (agentLinkId !== undefined) {
         const linkedAgent = await fastify.db.agentRepository.findOne({
           where: { id: agentLinkId },
@@ -678,6 +668,32 @@ export default async function opportunityRoutes(
         const success = await patchEntity(Agent, agent, opportunity.agentId);
         if (!success) {
           throw new Error("Patching agent failed while patching opportunity.");
+        }
+      }
+
+      if (contactLinkId !== undefined) {
+        // Evaluated after the agent relink above so a payload that relinks
+        // both `agent.id` and `contact.id` in one request validates the
+        // contact against the opportunity's *new* agent, not the old one.
+        const effectiveAgentId = agentLinkId ?? opportunity.agentId;
+        const isAgentContact = await fastify.db.agentPersonRepository.findOneBy(
+          {
+            agentId: effectiveAgentId,
+            personId: contactLinkId,
+          },
+        );
+        if (!isAgentContact) {
+          throw new NotFoundError(
+            `Contact (personId:${contactLinkId}) is not registered as a contact of this opportunity's agent.`,
+          );
+        }
+        const success = await patchEntity(
+          Opportunity,
+          { contactPersonId: contactLinkId } as Partial<Opportunity>,
+          opportunity.id,
+        );
+        if (!success) {
+          throw new BadRequestError("Relinking opportunity contact failed.");
         }
       }
 

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -656,9 +656,16 @@ export default async function opportunityRoutes(
         if (!linkedAgent) {
           throw new NotFoundError(`Agent (id:${agentLinkId}) not found.`);
         }
+        // The opportunity's existing contact (if any) belongs to the *old*
+        // agent and has no guaranteed relationship to the new one — clear it
+        // rather than leave a stale cross-agent reference. If the request
+        // also carries `contact.id`, the contactLinkId branch below sets the
+        // real (validated-against-the-new-agent) value right after this.
+        const contactReset: Partial<Opportunity> =
+          contactLinkId === undefined ? { contactPersonId: null } : {};
         const success = await patchEntity(
           Opportunity,
-          { agentId: agentLinkId } as Partial<Opportunity>,
+          { agentId: agentLinkId, ...contactReset } as Partial<Opportunity>,
           opportunity.id,
         );
         if (!success) {

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -851,21 +851,6 @@
           "properties": {
             "id": {
               "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            },
-            "phone": {
-              "type": "string"
-            },
-            "email": {
-              "type": "string"
-            },
-            "waysToContact": {
-              "type": "array",
-              "items": {
-                "$ref": "PreferredCommunicationType#"
-              }
             }
           }
         },

--- a/src/services/dto/parser-opportunity-patch-data.ts
+++ b/src/services/dto/parser-opportunity-patch-data.ts
@@ -1,6 +1,5 @@
 import { ApiOpportunityPatch, LangPurpose } from "need4deed-sdk";
 import { In, Repository } from "typeorm";
-import { getNameFields } from "..";
 import { BadRequestError } from "../../config";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../data/entity/opportunity/agent.entity";
@@ -73,15 +72,6 @@ export function parseOpportunity(body: ApiOpportunityPatch) {
         infoConfidential: body.description,
         type: body.opportunity_type,
       },
-      contact: body?.contact
-        ? {
-            id: body?.contact?.id,
-            ...getNameFields(body.contact.name),
-            phone: body?.contact?.phone,
-            email: body?.contact?.email,
-            preferredCommunicationType: body?.contact?.waysToContact,
-          }
-        : {},
       agent:
         agentBody && agentBody.id === undefined
           ? ({

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -138,6 +138,16 @@ describe("PATCH /opportunity/:id agent status update", () => {
         role: AgentRoleType.OTHER,
       }),
     );
+    // Registered as a contact of otherAgent, not ownAgent — used to confirm
+    // the membership check rejects a contact that belongs to a different
+    // agent, not just a person with no agent contact at all.
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: otherAgent.id,
+        personId: unrelatedPerson.id,
+        role: AgentRoleType.OTHER,
+      }),
+    );
 
     const login = async (email: string): Promise<string> => {
       const res = await fastify.inject({
@@ -164,6 +174,10 @@ describe("PATCH /opportunity/:id agent status update", () => {
     await fastify.db.agentPersonRepository.delete({
       agentId: ownAgent.id,
       personId: agentContactPerson.id,
+    });
+    await fastify.db.agentPersonRepository.delete({
+      agentId: otherAgent.id,
+      personId: unrelatedPerson.id,
     });
     await fastify.db.dealRepository.delete({ id: ownDeal.id });
     await fastify.db.dealRepository.delete({ id: otherDeal.id });
@@ -311,7 +325,7 @@ describe("PATCH /opportunity/:id agent status update", () => {
     expect(updated.contactPersonId).toBe(agentContactPerson.id);
   });
 
-  it("404s when relinking an opportunity's contact to a person who isn't a registered contact of its agent", async () => {
+  it("404s when relinking an opportunity's contact to a person who is a registered contact of a different agent", async () => {
     const before = await fastify.db.opportunityRepository.findOneByOrFail({
       id: ownOpportunity.id,
     });
@@ -328,6 +342,35 @@ describe("PATCH /opportunity/:id agent status update", () => {
       id: ownOpportunity.id,
     });
     expect(unchanged.contactPersonId).toBe(before.contactPersonId);
+  });
+
+  // unrelatedPerson is only a registered contact of otherAgent (confirmed
+  // rejected against ownAgent by the previous test) — relinking agent.id and
+  // contact.id together in one request must validate the contact against
+  // the *new* agent, not the opportunity's current one.
+  it("lets a coordinator relink both agent and contact in one request, validating the contact against the new agent", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        agent: { id: otherAgent.id },
+        contact: { id: unrelatedPerson.id },
+      },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(updated.agentId).toBe(otherAgent.id);
+    expect(updated.contactPersonId).toBe(unrelatedPerson.id);
+
+    // Restore for any later test in this file that assumes ownAgent.
+    await fastify.db.opportunityRepository.update(
+      { id: ownOpportunity.id },
+      { agentId: ownAgent.id, contactPersonId: agentContactPerson.id },
+    );
   });
 });
 

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from "fastify";
 import {
+  AgentRoleType,
   EntityTableName,
   OpportunityStatusType,
   OpportunityType,
@@ -48,6 +49,8 @@ describe("PATCH /opportunity/:id agent status update", () => {
   let otherDeal: Deal;
   let agentPerson: Person;
   let coordinatorPerson: Person;
+  let agentContactPerson: Person;
+  let unrelatedPerson: Person;
   let agentCookie: string;
   let coordinatorCookie: string;
 
@@ -99,6 +102,12 @@ describe("PATCH /opportunity/:id agent status update", () => {
     coordinatorPerson = await fastify.db.personRepository.save(
       new Person({ firstName: "Test", lastName: "Coordinator" }),
     );
+    agentContactPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "AgentContact" }),
+    );
+    unrelatedPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Unrelated" }),
+    );
 
     const pwHash = await hashPassword(PASSWORD);
     await fastify.db.userRepository.save(
@@ -121,6 +130,13 @@ describe("PATCH /opportunity/:id agent status update", () => {
     );
     await fastify.db.agentPersonRepository.save(
       new AgentPerson({ agentId: ownAgent.id, personId: agentPerson.id }),
+    );
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: ownAgent.id,
+        personId: agentContactPerson.id,
+        role: AgentRoleType.OTHER,
+      }),
     );
 
     const login = async (email: string): Promise<string> => {
@@ -145,6 +161,10 @@ describe("PATCH /opportunity/:id agent status update", () => {
       agentId: ownAgent.id,
       personId: agentPerson.id,
     });
+    await fastify.db.agentPersonRepository.delete({
+      agentId: ownAgent.id,
+      personId: agentContactPerson.id,
+    });
     await fastify.db.dealRepository.delete({ id: ownDeal.id });
     await fastify.db.dealRepository.delete({ id: otherDeal.id });
     await fastify.db.agentRepository.delete({ id: ownAgent.id });
@@ -153,6 +173,8 @@ describe("PATCH /opportunity/:id agent status update", () => {
     await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
     await fastify.db.personRepository.delete({ id: agentPerson.id });
     await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: agentContactPerson.id });
+    await fastify.db.personRepository.delete({ id: unrelatedPerson.id });
     await fastify.close();
   });
 
@@ -254,6 +276,58 @@ describe("PATCH /opportunity/:id agent status update", () => {
       { id: ownOpportunity.id },
       { agentId: ownAgent.id },
     );
+  });
+
+  it("403s when an agent tries to relink an opportunity's contact via contact.id", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: agentCookie },
+      payload: {
+        statusOpportunity: OpportunityStatusType.ACTIVE,
+        contact: { id: agentContactPerson.id },
+      },
+    });
+    expect(res.statusCode).toBe(403);
+
+    const unchanged = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(unchanged.contactPersonId).toBeFalsy();
+  });
+
+  it("lets a coordinator relink an opportunity's contact to a registered contact of its agent", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { contact: { id: agentContactPerson.id } },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(updated.contactPersonId).toBe(agentContactPerson.id);
+  });
+
+  it("404s when relinking an opportunity's contact to a person who isn't a registered contact of its agent", async () => {
+    const before = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { contact: { id: unrelatedPerson.id } },
+    });
+    expect(res.statusCode).toBe(404);
+
+    const unchanged = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(unchanged.contactPersonId).toBe(before.contactPersonId);
   });
 });
 

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -325,6 +325,29 @@ describe("PATCH /opportunity/:id agent status update", () => {
     expect(updated.contactPersonId).toBe(agentContactPerson.id);
   });
 
+  it("clears the opportunity's contact when relinking agent.id without also sending contact.id", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${ownOpportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { agent: { id: otherAgent.id } },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: ownOpportunity.id,
+    });
+    expect(updated.agentId).toBe(otherAgent.id);
+    expect(updated.contactPersonId).toBeFalsy();
+
+    // Restore for the following tests, which assume ownOpportunity is on
+    // ownAgent again.
+    await fastify.db.opportunityRepository.update(
+      { id: ownOpportunity.id },
+      { agentId: ownAgent.id },
+    );
+  });
+
   it("404s when relinking an opportunity's contact to a person who is a registered contact of a different agent", async () => {
     const before = await fastify.db.opportunityRepository.findOneByOrFail({
       id: ownOpportunity.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.138:
-  version "0.0.138"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.138.tgz#7464a7cefb8c4ef4b01d28ebdf4d095a59bda9f5"
-  integrity sha512-imAqPSMmc0N9MNp10fqDKHyRVZXRImhrW9ZdahO9HR29IAlDL3VBn10F/8AsX4k9kJ/8VbXj1tq1nkLiUHmjKA==
+need4deed-sdk@0.0.139:
+  version "0.0.139"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.139.tgz#34ca63577a104dcaa3353d3b1c6c9661da182c40"
+  integrity sha512-gU3wlLF4sUxz9azKUBcceuiOgUmt1Q6Km6sXvVWzSDbZa7BieXu9Xr2Lz7NQDVZxMM817nDt5y8CLfrKBexvrw==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## What

`PATCH /opportunity/:id` now actually relinks an opportunity's contact when `contact.id` is sent — pointing `Opportunity.contactPersonId` at a different `Person`, instead of the previous behavior of patching whichever Person happened to already be linked with the submitted name/phone/email/waysToContact fields (which made a bare `{ id }` payload a silent no-op — the exact bug this issue is about).

## How

- Bumped `need4deed-sdk` to `0.0.139` (sdk#188 — narrows `ApiOpportunityPatch.contact` to relink-only `{ id }`), which surfaced a compile error in `parser-opportunity-patch-data.ts` exactly where the stale Person-field reads needed to come out.
- Removed the `contact` key from `parseOpportunity`'s output — editing a contact Person's own fields is no longer something this route does.
- Added a `contactLinkId` branch in the PATCH handler, mirroring the existing `agentLinkId` relink pattern: validates the given `contact.id` is a registered `AgentPerson` contact of the opportunity's agent (rejecting with 404 otherwise, to prevent linking to an unrelated Person), then updates `contactPersonId`.
- Evaluated after the `agent.id` relink branch, so a request that relinks both `agent.id` and `contact.id` together validates the contact against the *new* agent.
- Narrowed the hand-maintained `ApiVolunteerOpportunityPatch.contact` JSON schema in `sdk-types.json` to match (`{ id }` only).
- Added test coverage: coordinator can relink to a registered agent contact (204, `contactPersonId` updated), 404 when the target Person isn't a contact of the opportunity's agent (unchanged), and an AGENT-role user is still blocked from touching `contact` at all (existing `disallowedKeys` status-only restriction, same as `agent.id`).

## Not in scope

Editing a contact's own name/phone/email/waysToContact — that's a separate concern (agent-contact endpoints), not this route. The read side (`GET /opportunity/:id` → `ApiOpportunityContact`) is unchanged.

Closes #824

Refs need4deed-org/sdk#188