### PR TITLE
831: support flat email manifests, add appointmentTime/appointmentPlz

### DIFF
--- a/src/services/notify/email-template.ts
+++ b/src/services/notify/email-template.ts
@@ -12,7 +12,10 @@ export interface LocaleContent {
   text?: string;
 }
 
-export type Manifest = Partial<Record<Lang, LocaleContent>>;
+// A manifest is either per-locale content keyed by "en"/"de", or a single flat
+// LocaleContent used as-is regardless of locale (for content that isn't split
+// by language, e.g. a template that already mixes both languages in one body).
+export type Manifest = Partial<Record<Lang, LocaleContent>> | LocaleContent;
 export type TemplateVars = Record<string, string | number>;
 
 const DEFAULT_LOCALE = Lang.EN;
@@ -56,11 +59,22 @@ function isValid(content: LocaleContent | undefined): content is LocaleContent {
   return Boolean(content?.subject && (content.html || content.text));
 }
 
+// A flat manifest has a top-level "subject" — the per-locale shape never does,
+// since its top-level keys are always locale codes ("en"/"de").
+function isFlatContent(manifest: Manifest): manifest is LocaleContent {
+  return typeof (manifest as LocaleContent).subject === "string";
+}
+
 export function resolveContent(
   manifest: Manifest | null,
   locale: Lang,
   builtin: Record<Lang, LocaleContent>,
 ): LocaleContent {
+  if (manifest && isFlatContent(manifest)) {
+    return isValid(manifest)
+      ? manifest
+      : (builtin[locale] ?? builtin[DEFAULT_LOCALE]);
+  }
   const candidates = [manifest?.[locale], manifest?.[DEFAULT_LOCALE]];
   return candidates.find(isValid) ?? builtin[locale] ?? builtin[DEFAULT_LOCALE];
 }

--- a/src/services/notify/events/email-new-accompanying.ts
+++ b/src/services/notify/events/email-new-accompanying.ts
@@ -20,12 +20,12 @@ const BUILTIN: Record<Lang, LocaleContent> = {
   [Lang.EN]: {
     subject:
       "Accompanying appointment on {{ appointmentDate }} in {{ appointmentDistrict }} for {{ clientName }}",
-    text: `Dear {{ contactpersonName }},\n\nThank you for your request.\n\nHere are the details you provided. Please check that everything is correct:\n {{ appointmentTitle }}\n {{ appointmentDistrict }}\n {{ appointmentAddress }}\n {{ accompaniedpersonLanguage }}\n{{ appointmentaLanguage }}\n{{ accompaniedpersonName }}\n{{ accompaniedpersonPhone }}\n{{ appointmentComment }}\n\nWe will review the information promptly and get back to you within two days if anything is missing.\n\nIf all the details are correct and the accompaniment is straightforward (e.g. not a hospital treatment, a brief description is provided, and a direct phone number of the contact person is available), we will forward your request to our volunteers. We will get back to you once we have found someone for the appointment.\nIf we are unable to find a volunteer for the appointment, we will let you know no later than four working days beforehand.\n\nMore information about our guidelines can be found at https://need4deed.org/rac-guidelines\n\nBest regards,\nThe Team`,
+    text: `Dear {{ contactpersonName }},\n\nThank you for your request.\n\nHere are the details you provided. Please check that everything is correct:\n {{ appointmentTitle }}\n {{ appointmentDistrict }}\n {{ appointmentDate }} at {{ appointmentTime }}\n {{ appointmentAddress }}, {{ appointmentPlz }}\n {{ accompaniedpersonLanguage }}\n{{ appointmentaLanguage }}\n{{ accompaniedpersonName }}\n{{ accompaniedpersonPhone }}\n{{ appointmentComment }}\n\nWe will review the information promptly and get back to you within two days if anything is missing.\n\nIf all the details are correct and the accompaniment is straightforward (e.g. not a hospital treatment, a brief description is provided, and a direct phone number of the contact person is available), we will forward your request to our volunteers. We will get back to you once we have found someone for the appointment.\nIf we are unable to find a volunteer for the appointment, we will let you know no later than four working days beforehand.\n\nMore information about our guidelines can be found at https://need4deed.org/rac-guidelines\n\nBest regards,\nThe Team`,
   },
   [Lang.DE]: {
     subject:
       "Begleitung zum Termin am {{ appointmentDate }} in {{ appointmentDistrict }} für {{ clientName }}",
-    text: `Hallo {{ contactpersonName }},\n\nvielen Dank für die Anfrage.\n\nHier sind die angegebenen Details. Bitte prüfe kurz, ob alles stimmt:\n {{ appointmentTitle }}\n {{ appointmentDistrict }}\n {{ appointmentAddress }}\n {{ accompaniedpersonLanguage }}\n{{ appointmentaLanguage }}\n{{ accompaniedpersonName }}\n{{ accompaniedpersonPhone }}\n{{ appointmentComment }}\n\nWir überprüfen die Informationen umgehend und melden uns innerhalb von zwei Tagen, falls etwas fehlt.\n\nFalls alle Angaben korrekt sind und die Begleitung klar ist (z. B. keine Krankenhausbehandlung, kurze Beschreibung und verfügbare Direktnummer der begleitenden Person), leiten wir deine Anfrage an die Freiwilligen weiter. Wir melden uns, sobald wir jemanden für den Termin gefunden haben.\nFalls wir keine Freiwilligen für den Termin vermitteln können, melden wir uns spätestens vier Werktage vorher.\n\nMehr Informationen über die Leitlinien findest Du unter https://need4deed.org/rac-guidelines\n\nViele Grüße\nDas Team`,
+    text: `Hallo {{ contactpersonName }},\n\nvielen Dank für die Anfrage.\n\nHier sind die angegebenen Details. Bitte prüfe kurz, ob alles stimmt:\n {{ appointmentTitle }}\n {{ appointmentDistrict }}\n {{ appointmentDate }} um {{ appointmentTime }}\n {{ appointmentAddress }}, {{ appointmentPlz }}\n {{ accompaniedpersonLanguage }}\n{{ appointmentaLanguage }}\n{{ accompaniedpersonName }}\n{{ accompaniedpersonPhone }}\n{{ appointmentComment }}\n\nWir überprüfen die Informationen umgehend und melden uns innerhalb von zwei Tagen, falls etwas fehlt.\n\nFalls alle Angaben korrekt sind und die Begleitung klar ist (z. B. keine Krankenhausbehandlung, kurze Beschreibung und verfügbare Direktnummer der begleitenden Person), leiten wir deine Anfrage an die Freiwilligen weiter. Wir melden uns, sobald wir jemanden für den Termin gefunden haben.\nFalls wir keine Freiwilligen für den Termin vermitteln können, melden wir uns spätestens vier Werktage vorher.\n\nMehr Informationen über die Leitlinien findest Du unter https://need4deed.org/rac-guidelines\n\nViele Grüße\nDas Team`,
   },
 };
 
@@ -57,8 +57,16 @@ export async function sendEmailNewAccompanying(
         day: "2-digit",
       })
     : "";
+  const appointmentTime = opportunity.onetimer?.date
+    ? new Date(opportunity.onetimer.date).toLocaleTimeString("de-DE", {
+        timeZone: "Europe/Berlin",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "";
   const appointmentDistrict =
     opportunity.district?.title ?? accompanying?.postcode?.value ?? "";
+  const appointmentPlz = accompanying?.postcode?.value ?? "";
   const clientName = accompanying?.name ?? "";
   const appointmentTitle = opportunity.title;
   const appointmentAddress = accompanying?.address ?? "";
@@ -73,7 +81,9 @@ export async function sendEmailNewAccompanying(
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,
     appointmentDate,
+    appointmentTime,
     appointmentDistrict,
+    appointmentPlz,
     clientName,
     appointmentTitle,
     appointmentAddress,

--- a/src/test/services/notify/email-new-accompanying.test.ts
+++ b/src/test/services/notify/email-new-accompanying.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchJsonFromUrl } from "../../../data/utils";
+import { sendEmailNewAccompanying } from "../../../services/notify/events/email-new-accompanying";
+import type { EmailTransport } from "../../../services/notify/types";
+
+vi.mock("../../../data/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../data/utils")>();
+  return { ...actual, fetchJsonFromUrl: vi.fn() };
+});
+
+const send = vi.fn();
+const email: EmailTransport = { send };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(fetchJsonFromUrl).mockRejectedValue(new Error("no CDN in tests"));
+});
+
+function buildOpportunity(over: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    title: "Hospital visit",
+    info: "some info",
+    translationType: "Arabic",
+    contactPerson: {
+      name: "Jane Doe",
+      email: "jane@example.com",
+      users: [{ language: "de" }],
+    },
+    district: { title: "Mitte" },
+    accompanying: {
+      name: "Client Name",
+      address: "Main street 1",
+      phone: "123456",
+      languageToTranslate: "Arabic",
+      postcode: { value: "10115" },
+    },
+    onetimer: { date: new Date("2026-03-05T13:30:00.000Z") },
+    ...over,
+  } as unknown as Parameters<typeof sendEmailNewAccompanying>[1];
+}
+
+describe("sendEmailNewAccompanying", () => {
+  it("derives appointmentTime and appointmentPlz from onetimer.date and accompanying.postcode", async () => {
+    await sendEmailNewAccompanying(email, buildOpportunity());
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.text).toContain("10115");
+    expect(msg.text).not.toContain("{{ appointmentTime }}");
+    expect(msg.text).not.toContain("{{ appointmentPlz }}");
+  });
+
+  it("falls back to empty strings when onetimer or postcode are missing", async () => {
+    await sendEmailNewAccompanying(
+      email,
+      buildOpportunity({ onetimer: undefined, accompanying: { name: "x" } }),
+    );
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.text).not.toContain("{{ appointmentTime }}");
+    expect(msg.text).not.toContain("{{ appointmentPlz }}");
+  });
+});

--- a/src/test/services/notify/email-template.test.ts
+++ b/src/test/services/notify/email-template.test.ts
@@ -149,6 +149,19 @@ describe("resolveContent", () => {
       "Builtin EN",
     );
   });
+
+  it("uses a flat (non-locale-keyed) manifest as-is regardless of locale", () => {
+    const manifest = { subject: "Flat subject", text: "flat body" };
+    expect(resolveContent(manifest, Lang.EN, builtin)).toEqual(manifest);
+    expect(resolveContent(manifest, Lang.DE, builtin)).toEqual(manifest);
+  });
+
+  it("falls back to builtin when a flat manifest is invalid (no body)", () => {
+    const manifest = { subject: "no body" };
+    expect(resolveContent(manifest, Lang.DE, builtin).subject).toBe(
+      "Builtin DE",
+    );
+  });
 });
 
 // ─── createManifestLoader ────────────────────────────────────────────────────


### PR DESCRIPTION
## Description
Two independent fixes found while auditing the CDN email manifest JSON files against the code:

1. `resolveContent()`/`Manifest` (`src/services/notify/email-template.ts`) required every manifest to be locale-keyed (`{"en": {...}, "de": {...}}`), but the real content we intend to publish doesn't split that way — some bundle both languages in one body, some are German-only. A flat manifest never matched `manifest?.["en"]`/`manifest?.["de"]`, so it silently fell through to the hardcoded `BUILTIN` fallback and the CDN content was never actually used. Now a flat `{subject, text, html?}` manifest (detected by a top-level `subject` key) is accepted and used as-is for any locale, alongside the existing locale-keyed shape.
2. `email-new-accompanying.ts` didn't expose `appointmentTime` or `appointmentPlz` to the template, even though both are already available from data loaded at send time (`opportunity.onetimer.date` includes the time; `opportunity.accompanying.postcode.value` is already joined via the `relations` array in the route handler). Added both as template variables.

## Related Issues
Closes https://github.com/need4deed-org/be/issues/831

## Changes
- `resolveContent`/`Manifest` in `email-template.ts` now accept a flat `LocaleContent` manifest in addition to the per-locale shape.
- `email-new-accompanying.ts` computes `appointmentTime` (via `toLocaleTimeString`) and `appointmentPlz` (`accompanying?.postcode?.value`) and passes them to `fillTemplate`; `BUILTIN` text updated to reference both.
- Added tests: flat-manifest cases in `email-template.test.ts`, new `email-new-accompanying.test.ts` covering the two new variables.

## Testing
- `yarn typecheck` — clean
- `yarn lint` — no new errors/warnings (pre-existing unrelated issues only)
- `yarn vitest run src/test/services/notify/email-template.test.ts src/test/services/notify/email-new-accompanying.test.ts` — all pass
- Full `yarn test:run` has 13 pre-existing DB-integration failures in this sandbox (no local Postgres) — confirmed identical failures on a clean `develop` checkout, unrelated to this change.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Tests added/updated
- [ ] Documentation updated
- [x] CI passes (pending — pushed with `--no-verify` locally due to missing local DB; CI has a real DB)