### PR TITLE
fix: test teardown/isolation bugs from #828 (be#834)

### DIFF
--- a/src/test/data/utils/get-district.test.ts
+++ b/src/test/data/utils/get-district.test.ts
@@ -112,6 +112,17 @@ describe("getDistrictFromPostcode", () => {
 });
 
 describe("getDistrictByTitle", () => {
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
   it("returns null for a title with no matching district", async () => {
     const result = await getDistrictByTitle(
       `Nonexistent District ${Date.now()}`,

--- a/src/test/server/routes/agent.routes.test.ts
+++ b/src/test/server/routes/agent.routes.test.ts
@@ -343,6 +343,15 @@ describe("PATCH /agent/:id organization details", () => {
       const districtPostcodeRepository =
         dataSource.getRepository(DistrictPostcode);
 
+      // The tests below leave agent.districtId/addressId pointing at the
+      // fixtures created here — clear both first. Otherwise deleting the
+      // districts violates the agent -> district FK directly, and deleting
+      // the postcodes cascades into the address row still referenced by
+      // agent.addressId (also a no-cascade FK).
+      await fastify.db.agentRepository.update(
+        { id: agent.id },
+        { districtId: null, addressId: null },
+      );
       await districtPostcodeRepository.delete({ id: mappingA.id });
       await districtPostcodeRepository.delete({ id: mappingB.id });
       await districtRepository.delete({ id: districtA.id });


### PR DESCRIPTION
## Summary
- `get-district.test.ts`: `getDistrictByTitle`'s describe block had no setup of its own and relied on the sibling `getDistrictFromPostcode` block's `fastify` instance staying open. That block's `afterAll` closes it, destroying the shared `dataSource` — so `getDistrictByTitle`'s test threw `TypeORMError: Driver not Connected` whenever it ran after the sibling's teardown. Gave it its own `beforeAll`/`afterAll`, matching the existing sibling pattern.
- `agent.routes.test.ts`: the "district derivation from postcode" describe block PATCHes the shared `agent` fixture's `districtId`/`addressId`, then its `afterAll` deleted the district/postcode rows without clearing those FKs off the agent first — violating `agent -> district` directly, and (via cascade) `agent -> address -> postcode`. Reset both to `null` before deleting the fixture rows.

Both bugs only surface when the full suite runs (not when the file runs in isolation), which is presumably how they slipped through #828's own CI run.

Closes #834

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test:run` — full suite, 62 files / 528 tests, run twice to confirm it's not still flaky