### PR TITLE
fix: stop guessing recipient locale, use flat/bilingual email content (be#838)

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -89,7 +89,7 @@ export const urlEmailVerification =
 export const urlPasswordReset =
   process.env.URL_PASSWORD_RESET || "https://app.need4deed.org/reset-password";
 
-// CDN manifest (per-locale subject + html/text) for the verification email.
+// CDN manifest (flat, bilingual subject + html/text) for the verification email.
 export const emailVerificationManifestUrl =
   CDNBaseUrl + "/emails/verification.json";
 

--- a/src/services/notify/builtin-content.ts
+++ b/src/services/notify/builtin-content.ts
@@ -2,127 +2,71 @@
 // that email can't be loaded (fetch failure/timeout) or lacks a valid entry
 // for the requested locale. Kept in one file so editing copy doesn't require
 // hunting through every event file in ./events.
+//
+// Mirrors dev/files/manifests/*.json (the live CDN content) exactly, so a
+// fallback looks the same as the real thing. Most of these are flat — a
+// single body used regardless of recipient — either because they're
+// German-only (RAC/contact-person workflow) or because they bilingually
+// concatenate English+German in one body (volunteer-facing workflow, where
+// the recipient's language can't be reliably known; see be#830/#838).
+// PASSWORD_RESET_BUILTIN is the one exception still split per locale, since
+// no flat manifest was provided for it.
 import { Lang } from "need4deed-sdk";
 import type { LocaleContent } from "./email-template";
 
-export const STALE_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject: "Are you still interested in volunteering? — Need4Deed",
-    text: `Dear {{ volunteerName }},\n\nWe wanted to check in. Two months ago we sent you a volunteering opportunity, but we have not heard back yet.\n\nIf you are still interested in volunteering, please reply to this email.\n\nBest regards,\nNeed4Deed`,
-  },
-  [Lang.DE]: {
-    subject: "Bist du noch interessiert? — Need4Deed",
-    text: `Hallo {{ volunteerName }},\n\nwir wollten kurz nachfragen. Vor zwei Monaten haben wir dir eine ehrenamtliche Möglichkeit vorgeschlagen, aber bisher haben wir keine Rückmeldung erhalten.\n\nFalls du weiterhin Interesse hast, antworte bitte auf diese E-Mail.\n\nViele Grüße\nNeed4Deed`,
-  },
+export const STALE_BUILTIN: LocaleContent = {
+  subject: "Are you still interested in volunteering? Need4Deed",
+  text: `Dear {{ volunteerName }},\n \nWe wanted to check in. Two months ago we sent you a volunteering opportunity, but we have not heard back yet.\n \nIf you are still interested in volunteering, please reply to this email.\n \nBest regards,\nNeed4Deed\n \nHallo {{ volunteerName }},\n \nvor zwei Monaten haben wir dir eine ehrenamtliche Möglichkeit vorgeschlagen, aber bisher haben wir keine Rückmeldung erhalten.\n \nFalls du weiterhin Interesse hast, antworte bitte auf diese E-Mail.\n \nViele Grüße\nNeed4Deed`,
 };
 
-export const POST_MATCH_CHECKUP_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject: "Checking in — are you still volunteering?",
-    text: `Dear {{ volunteerName }},\n\nWe wanted to check in. You were matched two months ago, have you had the chance to volunteer and are you still active?\n\nLet us know by replying to this email so we can keep your profile up to date.\n\nThank you,\nNeed4Deed`,
-  },
-  [Lang.DE]: {
-    subject: "Kurze Nachfrage — bist du noch aktiv?",
-    text: `Hallo {{ volunteerName }},\n\nwir wollten kurz nachfragen. Du wurdest vor zwei Monaten vermittelt — hattest du die Gelegenheit, dich ehrenamtlich zu engagieren, und bist du noch aktiv?\n\nBitte antworte einfach auf diese E-Mail, damit wir dein Profil aktuell halten können.\n\nVielen Dank\nNeed4Deed`,
-  },
+export const POST_MATCH_CHECKUP_BUILTIN: LocaleContent = {
+  subject: "Checking in: are you still volunteering?",
+  text: `Dear {{ volunteerName }},\n \nYou registered with us two months ago, we'd love to know if you're still interested in volunteering. If you are, please reply and we'll try to find you a suitable opportunity.\n \nThank you,\n\nHallo {{ volunteerName }},\n\nDu hast dich vor zwei Monaten bei uns registriert. Wir würden gerne wissen, ob du weiterhin Interesse an einem ehrenamtlichen Engagement hast.\n\nFalls ja, antworte einfach auf diese E-Mail, und wir versuchen, eine passende Möglichkeit für dich zu finden.\n\nNeed4Deed`,
 };
 
-export const ACCOMPANY_NOT_FOUND_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject:
-      "Accompanying to an appointment on {{ appointmentDate }} in {{ appointmentDistrict }} for {{ clientName }}",
-    text: `Dear {{ contactpersonName }},\n\nUnfortunately, we were unable to find a volunteer for this appointment. We have now called off our search.\n\nBest regards,\nNeed4Deed`,
-  },
-  [Lang.DE]: {
-    subject:
-      "Begleitung zum Termin am {{ appointmentDate }} in {{ appointmentDistrict }} für {{ clientName }}",
-    text: `Hallo {{ contactpersonName }},\n\nleider hat sich niemand für die Sprachmittlung gemeldet. Wir haben nun unsere Suche eingestellt.\n\nViele Grüße\nNeed4Deed`,
-  },
+export const ACCOMPANY_NOT_FOUND_BUILTIN: LocaleContent = {
+  subject:
+    "Begleitung zum Termin am {{ appointmentDate }} in {{ appointmentDistrict }} für {{ clientName }}",
+  text: `Hallo {{ contactpersonName }},\n \nleider hat sich niemand für die Sprachmittlung gemeldet. Wir haben nun unsere Suche eingestellt.\n \nViele Grüße\nNeed4Deed`,
 };
 
-export const REGULAR_UPDATE_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject: "Status of your volunteering opportunity — Need4Deed",
-    text: `Dear {{ contactpersonName }},\n\nWe are checking in to see if you are still looking for volunteers for "{{ volunteeringopportunityName }}".\n\nPlease let us know within two weeks. Otherwise we will mark this volunteering opportunity as inactive in our system.\n\nBest regards,\nNeed4Deed`,
-  },
-  [Lang.DE]: {
-    subject: "Aktualisierung der Gesuche bei Need4Deed",
-    text: `Hallo {{ contactpersonName }},\n\nwir möchten gerne wissen, ob das Gesuch "{{ volunteeringopportunityName }}" noch aktuell ist.\n\nSollten wir innerhalb von 2 Wochen keine Rückmeldung bekommen, werden wir das Gesuch als "Inaktiv" markieren.\n\nWir freuen uns darauf, von Dir zu hören.\n\nViele Grüße\nNeed4Deed`,
-  },
+export const REGULAR_UPDATE_BUILTIN: LocaleContent = {
+  subject: "Aktualisierung der Suche bei Need4Deed",
+  text: `Hallo {{ contactpersonName }},\n \nwir möchten gerne wissen, ob das Gesuch “{{ volunteeringopportunityName }}” noch aktuell ist.\n \nSollten wir innerhalb von 2 Wochen keine Rückmeldung bekommen, werden wir das Gesuch als “Inaktiv” markieren.\n \nWir freuen uns darauf, von Dir zu hören.\n \nViele Grüße\nNeed4Deed`,
 };
 
-export const INTRODUCTION_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject:
-      "Introduction — {{ volunteerName }} & {{ volunteeringopportunityName }}",
-    text: `Dear {{ contactpersonName }}, dear {{ volunteerName }},\n\nWe are delighted to introduce you to each other for the volunteering opportunity "{{ volunteeringopportunityName }}".\n\n{{ volunteerName }} speaks {{ volunteerLanguage }} and has the following skills: {{ volunteerSkills }}.\nAvailability: {{ volSchedule }}\n\n{{ statmentOnCertificates }}\n\nVolunteer contact:\n{{ volunteerName }}\n{{ volunteerEmail }}\n{{ volunteerPhone }}\n\nCenter contact:\n{{ contactpersonName }}\n{{ contactpersonEmail }}\n{{ contactpersonPhone }}\n{{ agentAddress }}\n\nPlease feel free to get in touch with each other directly to arrange the details. If you have any questions, do not hesitate to contact us.\n\nBest regards,\nNeed4Deed`,
-  },
-  [Lang.DE]: {
-    subject:
-      "Vorstellung — {{ volunteerName }} & {{ volunteeringopportunityName }}",
-    text: `Hallo {{ contactpersonName }}, hallo {{ volunteerName }},\n\nwir freuen uns, euch für das Gesuch „{{ volunteeringopportunityName }}" miteinander bekannt zu machen.\n\n{{ volunteerName }} spricht {{ volunteerLanguage }} und hat folgende Fähigkeiten: {{ volunteerSkills }}.\nVerfügbarkeit: {{ volSchedule }}\n\n{{ statmentOnCertificates }}\n\nKontaktdaten Ehrenamt:\n{{ volunteerName }}\n{{ volunteerEmail }}\n{{ volunteerPhone }}\n\nKontaktdaten Unterkunft:\n{{ contactpersonName }}\n{{ contactpersonEmail }}\n{{ contactpersonPhone }}\n{{ agentAddress }}\n\nIhr könnt gerne direkt miteinander in Kontakt treten, um die Details zu klären. Bei Fragen stehen wir gerne zur Verfügung.\n\nViele Grüße\nNeed4Deed`,
-  },
+export const INTRODUCTION_BUILTIN: LocaleContent = {
+  subject:
+    "Vorstellung — {{ volunteerName }} & {{ volunteeringopportunityName }}",
+  text: `Hallo {{ contactpersonName }}, hallo {{ volunteerName }},\n \nwir möchten euch gerne für die Aktivität „{{ volunteeringopportunityName }}“ einander vorstellen. \n \n{{ volunteerName }} spricht {{ volunteerLanguage }}, hat folgende Fähigkeiten: {{ volunteerSkills }}, die für diese ehrenamtliche Tätigkeit nützlich sein können. \n{{ volunteerName }} ist an folgenden Tagen und zu folgenden Uhrzeiten verfügbar: {{ volSchedule }}.\n \n{{ statmentOnCertificates }}\n \nDie Kontaktdaten von {{ volunteerName }} sind:\n{{ volunteerName }}\n{{ volunteerEmail }}\n{{ volunteerPhone }}\n \nDie Kontaktdaten der Einrichtung sind:\n{{ contactpersonName }}\n{{ contactpersonEmail }}\n{{ contactpersonPhone }}\n{{ agentAddress }}\n \nEs wäre super, wenn Ihr einen Kennenlernentermin vereinbart, um alles in Detail zu besprechen. Bei Fragen könnt ihr euch gerne bei uns melden.\n \nViele Grüße\nNeed4Deed\ncontact@need4deed.org`,
 };
 
-export const ACCOMPANY_MATCH_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject:
-      "Accompanying to an appointment on {{ appointmentDate }} in {{ appointmentDistrict }} for {{ clientName }}",
-    text: `Dear {{ contactpersonName }},\n\n{{ volunteerName }} would be glad to provide interpreting support for this appointment. {{ volunteerName }} speaks {{ volunteerLanguage }}.\n\n{{ volunteerName }} has already received {{ clientName }}'s contact details and will get in touch with them shortly.\n\n{{ contactSharing }}\n\nBest regards,\nNeed4Deed`,
-  },
-  [Lang.DE]: {
-    subject:
-      "Begleitung zum Termin am {{ appointmentDate }} in {{ appointmentDistrict }} für {{ clientName }}",
-    text: `Hallo {{ contactpersonName }},\n\n{{ volunteerName }} übernimmt gerne die Sprachmittlung für diesen Termin. {{ volunteerName }} spricht {{ volunteerLanguage }}.\n\n{{ volunteerName }} hat schon die Kontaktdaten von {{ clientName }} bekommen und meldet sich zeitnah bei der Person.\n\n{{ contactSharing }}\n\nViele Grüße\nNeed4Deed`,
-  },
+export const ACCOMPANY_MATCH_BUILTIN: LocaleContent = {
+  subject:
+    "Begleitung zum Termin am {{ appointmentDate }} in {{ appointmentDistrict }} für {{ clientName }}",
+  text: `Hallo {{ contactpersonName }},\n \n{{ volunteerName }} übernimmt gerne die Unterstützung bei dem Termin am {{ appointmentDate }}. {{ volunteerName }} spricht {{ volunteerLanguage }}.\n \n{{ volunteerName }} hat schon die Kontaktdaten von {{ clientName }} bekommen und meldet sich zeitnah bei der Person.\n \n{{ contactSharing }}\n \nViele Grüße\nNeed4Deed`,
 };
 
-export const SUGGESTION_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject: "Volunteering opportunity match — Need4Deed",
-    text: `Dear {{ volunteerName }},\n\nWe have found a volunteering opportunity that matches your profile.\n\nOpportunity: {{ opportunityName }}\nPostcode: {{ plz }}\nSchedule: {{ schedule }}\n\nIf you are interested, please reply to this email.\n\nBest regards,\nNeed4Deed`,
-  },
-  [Lang.DE]: {
-    subject: "Möglicher Einsatz — Need4Deed",
-    text: `Hallo {{ volunteerName }},\n\nwir haben eine ehrenamtliche Möglichkeit gefunden, die zu deinem Profil passt.\n\nGesuch: {{ opportunityName }}\nPostleitzahl: {{ plz }}\nZeiten: {{ schedule }}\n\nFalls du Interesse hast, antworte bitte auf diese E-Mail.\n\nViele Grüße\nNeed4Deed`,
-  },
+export const SUGGESTION_BUILTIN: LocaleContent = {
+  subject: "Volunteering opportunity match — Need4Deed",
+  text: `Dear {{ volunteerName }},\n \nWe have an opportunity that may interest you: {{ opportunityName }}, in Berlin {{ plz }} taking place on {{ schedule }}. If you'd like to volunteer, please reply to volunteer@need4deed.org in the next 10 days.\n\nThe Need4Deed Team :)\nvolunteer@need4deed.org\n\nHallo {{ volunteerName }},\n\nWir haben eine Möglichkeit, die dich interessieren könnte: {{ opportunityName }}, in Berlin {{ plz }}, am {{ schedule }}.\nWenn du dich ehrenamtlich engagieren möchtest, antworte bitte innerhalb der nächsten 10 Tage an volunteer@need4deed.org.\n\nDas Need4Deed-Team :)\nvolunteer@need4deed.org`,
 };
 
-export const NEW_REGULAR_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject: "Your request to Need4Deed",
-    text: `Dear {{ contactpersonName }},\n\nThank you for sending us your volunteering opportunity "{{ volunteeringopportunityName }}".\n\nWe will start looking for volunteers as soon as possible.\n\nWe will let you know when we find someone and introduce the volunteer to you.\n\nBest regards,\nNeed4Deed`,
-  },
-  [Lang.DE]: {
-    subject: "Deine Anfrage bei Need4Deed",
-    text: `Hallo {{ contactpersonName }},\n\nvielen Dank für deine Anfrage zu "{{ volunteeringopportunityName }}".\n\nWir fangen bald mit der Suche an.\n\nWenn wir jemanden gefunden haben, melden wir uns bei dir und stellen dir die Person vor.\n\nViele Grüße\nNeed4Deed`,
-  },
+export const NEW_REGULAR_BUILTIN: LocaleContent = {
+  subject: "Deine Anfrage bei Need4Deed",
+  text: `Hallo {{ contactpersonName }},\n \nvielen Dank für deine Anfrage zu “{{ volunteeringopportunityName }}”.\n \nWir fangen bald mit der Suche an.\n \nWenn wir jemanden gefunden haben, melden wir uns bei dir und stellen dir die Person vor.\n \nViele Grüße\nNeed4Deed\ncontact@need4deed.org`,
 };
 
-export const NEW_ACCOMPANYING_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject:
-      "Accompanying appointment on {{ appointmentDate }} in {{ appointmentDistrict }} for {{ clientName }}",
-    text: `Dear {{ contactpersonName }},\n\nThank you for your request.\n\nHere are the details you provided. Please check that everything is correct:\n {{ appointmentTitle }}\n {{ appointmentDistrict }}\n {{ appointmentDate }} at {{ appointmentTime }}\n {{ appointmentAddress }}, {{ appointmentPlz }}\n {{ accompaniedpersonLanguage }}\n{{ appointmentaLanguage }}\n{{ accompaniedpersonName }}\n{{ accompaniedpersonPhone }}\n{{ appointmentComment }}\n\nWe will review the information promptly and get back to you within two days if anything is missing.\n\nIf all the details are correct and the accompaniment is straightforward (e.g. not a hospital treatment, a brief description is provided, and a direct phone number of the contact person is available), we will forward your request to our volunteers. We will get back to you once we have found someone for the appointment.\nIf we are unable to find a volunteer for the appointment, we will let you know no later than four working days beforehand.\n\nMore information about our guidelines can be found at https://need4deed.org/rac-guidelines\n\nBest regards,\nThe Team`,
-  },
-  [Lang.DE]: {
-    subject:
-      "Begleitung zum Termin am {{ appointmentDate }} in {{ appointmentDistrict }} für {{ clientName }}",
-    text: `Hallo {{ contactpersonName }},\n\nvielen Dank für die Anfrage.\n\nHier sind die angegebenen Details. Bitte prüfe kurz, ob alles stimmt:\n {{ appointmentTitle }}\n {{ appointmentDistrict }}\n {{ appointmentDate }} um {{ appointmentTime }}\n {{ appointmentAddress }}, {{ appointmentPlz }}\n {{ accompaniedpersonLanguage }}\n{{ appointmentaLanguage }}\n{{ accompaniedpersonName }}\n{{ accompaniedpersonPhone }}\n{{ appointmentComment }}\n\nWir überprüfen die Informationen umgehend und melden uns innerhalb von zwei Tagen, falls etwas fehlt.\n\nFalls alle Angaben korrekt sind und die Begleitung klar ist (z. B. keine Krankenhausbehandlung, kurze Beschreibung und verfügbare Direktnummer der begleitenden Person), leiten wir deine Anfrage an die Freiwilligen weiter. Wir melden uns, sobald wir jemanden für den Termin gefunden haben.\nFalls wir keine Freiwilligen für den Termin vermitteln können, melden wir uns spätestens vier Werktage vorher.\n\nMehr Informationen über die Leitlinien findest Du unter https://need4deed.org/rac-guidelines\n\nViele Grüße\nDas Team`,
-  },
+export const NEW_ACCOMPANYING_BUILTIN: LocaleContent = {
+  subject:
+    "Begleitung zum Termin am {{ appointmentDate }} in {{ appointmentDistrict }} für {{ clientName }}",
+  text: `Hallo {{ contactpersonName }},\n \nvielen Dank für die Anfrage.\n \nHier sind die angegebenen Details. Bitte prüfe kurz, ob alles stimmt:\nDatum, Uhrzeit: {{ appointmentDate }} um {{ appointmentTime }}\nName der Person: {{ accompaniedpersonName }}\nRufnummer der Person: {{ accompaniedpersonPhone }}\nAdresse: {{ appointmentAddress }}, {{ appointmentPlz }}\nSprachen: {{ accompaniedpersonLanguage }}, {{ appointmentaLanguage }}\nZusätzliche Informationen: {{ appointmentComment }}\n \nWir überprüfen die Informationen umgehend und melden uns innerhalb von zwei Tagen, falls etwas fehlt.\n \nWir überprüfen, ob wir alle benötigte Informationen haben. Falls ja, leiten wir Deine Anfrage an die Freiwilligen weiter und melden uns bei Dir, sobald wir jemanden für den Termin gefunden haben. \nWenn nicht, werden wir uns bei Dir melden.\n\nFalls wir keine Freiwilligen für den Termin vermitteln können, melden wir uns spätestens vier Werktage vorher.\n \nMehr Informationen über die Leitlinien findest Du unter https://need4deed.org/rac-guidelines\n \nViele Grüße\nNeed4Deed`,
 };
 
-export const VERIFICATION_BUILTIN: Record<Lang, LocaleContent> = {
-  [Lang.EN]: {
-    subject: "Account Created",
-    text: `Your account has been created successfully. Please verify your email:\n{{verificationUrl}}`,
-    html: `<p>Your account has been created successfully. Please verify your email:</p><p><a href="{{verificationUrl}}">{{verificationUrl}}</a></p>`,
-  },
-  [Lang.DE]: {
-    subject: "Konto erstellt",
-    text: `Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail:\n{{verificationUrl}}`,
-    html: `<p>Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail:</p><p><a href="{{verificationUrl}}">{{verificationUrl}}</a></p>`,
-  },
+export const VERIFICATION_BUILTIN: LocaleContent = {
+  subject: "Verify your Need4Deed account email",
+  html: `<p>Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail-Adresse:</p><p><a href="{{verificationUrl}}">{{verificationUrl}}</a></p>\n\n\n\n<p>Your account has been created successfully. Please verify your email:</p><p><a href="{{verificationUrl}}">{{verificationUrl}}</a></p>`,
+  text: `Dein Konto wurde erfolgreich erstellt. Bitte bestätige deine E-Mail-Adresse:\n{{verificationUrl}}\n\nYour account has been created successfully. Please verify your email:\n{{verificationUrl}}`,
 };
 
 export const PASSWORD_RESET_BUILTIN: Record<Lang, LocaleContent> = {

--- a/src/services/notify/email-template.ts
+++ b/src/services/notify/email-template.ts
@@ -82,6 +82,21 @@ export function resolveContent(
   return candidates.find(isValid) ?? builtin[locale] ?? builtin[DEFAULT_LOCALE];
 }
 
+/**
+ * Like resolveContent(), but for templates that were never split by
+ * recipient locale in the first place — the manifest (or its fallback) is a
+ * single flat LocaleContent used as-is, regardless of who's receiving it.
+ * No locale to resolve, so there's nothing to guess wrong.
+ */
+export function resolveFlatContent(
+  manifest: Manifest | null,
+  builtin: LocaleContent,
+): LocaleContent {
+  return manifest && isFlatContent(manifest) && isValid(manifest)
+    ? manifest
+    : builtin;
+}
+
 async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   const timeout = new Promise<never>((_resolve, reject) => {

--- a/src/services/notify/events/email-accompany-match.ts
+++ b/src/services/notify/events/email-accompany-match.ts
@@ -1,4 +1,3 @@
-import { Lang } from "need4deed-sdk";
 import {
   emailAccompanyMatchManifestUrl,
   emailFromContact,
@@ -11,8 +10,7 @@ import { ACCOMPANY_MATCH_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -22,21 +20,18 @@ export function resetAccompanyMatchTemplateCache(): void {
   loader.resetCache();
 }
 
+// German-only — accompanymatch.json is no longer split by recipient locale
+// (see be#838); its recipients (RAC contact persons) are always German-speaking.
 function resolveContactSharing(
   shareContact: boolean,
   volunteerName: string,
   volunteerEmail: string,
   volunteerPhone: string,
-  lang: Lang,
 ): string {
   if (shareContact) {
-    return lang === Lang.DE
-      ? `${volunteerName}s Kontaktdaten findest Du unten: ${volunteerEmail} ${volunteerPhone} Sollte es zur Terminabsage kommen, lass uns bitte wissen. Falls es zu einer kurzfristigen Absage kommt, kontaktiere ${volunteerName} gerne direkt. Gib bitte die Kontaktdaten des Sprachmittlers auf keinen Fall an die zu begleitende Person weiter.`
-      : `You can find ${volunteerName}'s contact details below: ${volunteerEmail} ${volunteerPhone} Please let us know if the appointment is cancelled. If it is cancelled at short notice, feel free to contact ${volunteerName} directly. Please do not, under any circumstances, pass the interpreter's contact details on to the person being accompanied.`;
+    return `${volunteerName}s Kontaktdaten findest Du unten: ${volunteerEmail} ${volunteerPhone} Sollte es zur Terminabsage kommen, lass uns bitte wissen. Falls es zu einer kurzfristigen Absage kommt, kontaktiere ${volunteerName} gerne direkt. Gib bitte die Kontaktdaten des Sprachmittlers auf keinen Fall an die zu begleitende Person weiter.`;
   }
-  return lang === Lang.DE
-    ? `Nach der Absprache mit ${volunteerName} dürfen wir Dir leider die Kontaktdaten nicht weitergeben. Sollte es zur Terminabsage kommen, lass uns bitte wissen. Für Fragen stehe ich Dir gerne zur Verfügung.`
-    : `As agreed with ${volunteerName}, we are unfortunately unable to share their contact details with you. Please let us know if the appointment is cancelled. I am happy to help if you have any questions.`;
+  return `Nach der Absprache mit ${volunteerName} dürfen wir Dir leider die Kontaktdaten nicht weitergeben. Sollte es zur Terminabsage kommen, lass uns bitte wissen. Für Fragen stehe ich Dir gerne zur Verfügung.`;
 }
 
 export async function sendEmailAccompanyMatch(
@@ -87,16 +82,14 @@ export async function sendEmailAccompanyMatch(
   const appointmentDistrict =
     opportunity.district?.title ?? accompanying?.postcode?.value ?? "";
 
-  const locale = resolveLocale(contactPerson.users?.[0]?.language);
   const contactSharing = resolveContactSharing(
     volunteer.shareContact ?? true,
     volunteerName,
     volunteerEmail,
     volunteerPhone,
-    locale,
   );
 
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,
     volunteerName,

--- a/src/services/notify/events/email-accompany-not-found.ts
+++ b/src/services/notify/events/email-accompany-not-found.ts
@@ -8,8 +8,7 @@ import { ACCOMPANY_NOT_FOUND_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -44,8 +43,7 @@ export async function sendEmailAccompanyNotFound(
     opportunity.district?.title ?? accompanying?.postcode?.value ?? "";
   const clientName = accompanying?.name ?? "";
 
-  const locale = resolveLocale(opportunity.contactPerson?.users?.[0]?.language);
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,
     appointmentDate,

--- a/src/services/notify/events/email-introduction.ts
+++ b/src/services/notify/events/email-introduction.ts
@@ -1,4 +1,4 @@
-import { DocumentStatusType, Lang, VolunteerStateCGCType } from "need4deed-sdk";
+import { DocumentStatusType, VolunteerStateCGCType } from "need4deed-sdk";
 import {
   emailFromContact,
   emailFromNotify,
@@ -12,8 +12,7 @@ import { INTRODUCTION_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -23,11 +22,12 @@ export function resetIntroductionTemplateCache(): void {
   loader.resetCache();
 }
 
+// German-only, matching introduction.json's certificateStatements block —
+// this template is no longer split by recipient locale (see be#838).
 function resolveStatmentOnCertificates(
   statusCGC: DocumentStatusType,
   statusCgcProcess: VolunteerStateCGCType | null | undefined,
   statusVaccination: DocumentStatusType,
-  lang: Lang,
 ): string {
   const cgcNo = statusCGC === DocumentStatusType.NO;
   const cgcYes = statusCGC === DocumentStatusType.YES;
@@ -36,34 +36,22 @@ function resolveStatmentOnCertificates(
   const vaccinationYes = statusVaccination === DocumentStatusType.YES;
 
   if (cgcNo && missing && vaccinationYes) {
-    return lang === Lang.DE
-      ? "Das erweiterte Führungszeugnis beantragen wir sofort. Der Masernschutznachweis liegt vor."
-      : "We will apply for the certificate of good conduct (das erweiterte Führungszeugnis) for them. Proof of measles vaccination has been provided.";
+    return "Das erweiterte Führungszeugnis beantragen wir sofort. Der Masernschutznachweis liegt vor.";
   }
   if (cgcNo && missing && !vaccinationYes) {
-    return lang === Lang.DE
-      ? "Das erweiterte Führungszeugnis beantragen wir sofort."
-      : "We will apply for the certificate of good conduct (das erweiterte Führungszeugnis) for them.";
+    return "Das erweiterte Führungszeugnis beantragen wir sofort.";
   }
   if (cgcNo && uploaded && vaccinationYes) {
-    return lang === Lang.DE
-      ? "Das erweiterte Führungszeugnis haben wir bereits beantragt. Der Masernschutznachweis liegt vor."
-      : "We have applied for the certificate of good conduct (das erweiterte Führungszeugnis) for them. Proof of measles vaccination has been provided.";
+    return "Das erweiterte Führungszeugnis haben wir bereits beantragt. Der Masernschutznachweis liegt vor.";
   }
   if (cgcNo && uploaded && !vaccinationYes) {
-    return lang === Lang.DE
-      ? "Das erweiterte Führungszeugnis haben wir bereits beantragt."
-      : "We have applied for the certificate of good conduct (das erweiterte Führungszeugnis) for them.";
+    return "Das erweiterte Führungszeugnis haben wir bereits beantragt.";
   }
   if (cgcYes && vaccinationYes) {
-    return lang === Lang.DE
-      ? "Das erweiterte Führungszeugnis sowie der Masernschutznachweis liegen vor."
-      : "They have already gotten their certificate of good conduct (das erweiterte Führungszeugnis). Proof of measles vaccination has been provided.";
+    return "Das erweiterte Führungszeugnis sowie der Masernschutznachweis liegen vor.";
   }
   if (cgcYes && !vaccinationYes) {
-    return lang === Lang.DE
-      ? "Das erweiterte Führungszeugnis liegt vor."
-      : "They have already gotten their certificate of good conduct (das erweiterte Führungszeugnis).";
+    return "Das erweiterte Führungszeugnis liegt vor.";
   }
   return "";
 }
@@ -84,7 +72,6 @@ export async function sendEmailIntroduction(
 
   const volunteer = ov.volunteer;
   const opportunity = ov.opportunity;
-  const locale = resolveLocale(volunteer.person?.users?.[0]?.language);
 
   const volunteerName = volunteer.person.name;
   const contactpersonName = contactPerson.name;
@@ -120,10 +107,9 @@ export async function sendEmailIntroduction(
     volunteer.statusCGC,
     volunteer.statusCgcProcess,
     volunteer.statusVaccination,
-    locale,
   );
 
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,
     volunteerName,

--- a/src/services/notify/events/email-new-accompanying.ts
+++ b/src/services/notify/events/email-new-accompanying.ts
@@ -10,8 +10,7 @@ import { NEW_ACCOMPANYING_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -62,8 +61,7 @@ export async function sendEmailNewAccompanying(
   const accompaniedpersonPhone = accompanying?.phone ?? "";
   const appointmentComment = opportunity.info ?? "";
 
-  const locale = resolveLocale(contactPerson.users?.[0]?.language);
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,
     appointmentDate,

--- a/src/services/notify/events/email-new-regular.ts
+++ b/src/services/notify/events/email-new-regular.ts
@@ -9,8 +9,7 @@ import { NEW_REGULAR_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -35,8 +34,7 @@ export async function sendEmailNewRegular(
   const contactpersonName = contactPerson.name;
   const volunteeringopportunityName = opportunity.title;
 
-  const locale = resolveLocale(contactPerson.users?.[0]?.language);
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,
     volunteeringopportunityName,

--- a/src/services/notify/events/email-post-match-checkup.ts
+++ b/src/services/notify/events/email-post-match-checkup.ts
@@ -8,8 +8,7 @@ import { POST_MATCH_CHECKUP_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -31,8 +30,7 @@ export async function sendEmailPostMatchCheckup(
   }
 
   const volunteerName = ov.volunteer.person.name;
-  const locale = resolveLocale(ov.volunteer.person?.users?.[0]?.language);
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, { volunteerName });
 
   await email.send({

--- a/src/services/notify/events/email-regular-update.ts
+++ b/src/services/notify/events/email-regular-update.ts
@@ -8,8 +8,7 @@ import { REGULAR_UPDATE_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -33,8 +32,7 @@ export async function sendEmailRegularUpdate(
   const contactpersonName = opportunity.contactPerson!.name;
   const volunteeringopportunityName = opportunity.title;
 
-  const locale = resolveLocale(opportunity.contactPerson?.users?.[0]?.language);
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     contactpersonName,
     volunteeringopportunityName,

--- a/src/services/notify/events/email-stale.ts
+++ b/src/services/notify/events/email-stale.ts
@@ -8,8 +8,7 @@ import { STALE_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -31,8 +30,7 @@ export async function sendEmailStale(
   }
 
   const volunteerName = ov.volunteer.person.name;
-  const locale = resolveLocale(ov.volunteer.person?.users?.[0]?.language);
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, { volunteerName });
 
   await email.send({

--- a/src/services/notify/events/email-suggestion.ts
+++ b/src/services/notify/events/email-suggestion.ts
@@ -9,8 +9,7 @@ import { SUGGESTION_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailTransport } from "../types";
 
@@ -39,8 +38,7 @@ export async function sendEmailSuggestion(
       .map((t) => String(t))
       .join(", ") || "";
 
-  const locale = resolveLocale(ov.volunteer.person?.users?.[0]?.language);
-  const content = resolveContent(await loader.load(), locale, BUILTIN);
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, text, html } = fillTemplate(content, {
     volunteerName,
     opportunityName,

--- a/src/services/notify/events/email-verification.ts
+++ b/src/services/notify/events/email-verification.ts
@@ -10,8 +10,7 @@ import { VERIFICATION_BUILTIN as BUILTIN } from "../builtin-content";
 import {
   createManifestLoader,
   fillTemplate,
-  resolveContent,
-  resolveLocale,
+  resolveFlatContent,
 } from "../email-template";
 import type { EmailMessage, EmailTransport } from "../types";
 
@@ -46,11 +45,7 @@ export async function sendEmailVerification(
 
   logger.debug(`sendEmailVerification: ${user.email}, url: ${url}`);
 
-  const content = resolveContent(
-    await loader.load(),
-    resolveLocale(user.language),
-    BUILTIN,
-  );
+  const content = resolveFlatContent(await loader.load(), BUILTIN);
   const { subject, html, text } = fillTemplate(content, {
     verificationUrl: url,
   });

--- a/src/test/services/notify/email-flat-events.test.ts
+++ b/src/test/services/notify/email-flat-events.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchJsonFromUrl } from "../../../data/utils";
+import {
+  ACCOMPANY_MATCH_BUILTIN,
+  ACCOMPANY_NOT_FOUND_BUILTIN,
+  INTRODUCTION_BUILTIN,
+  NEW_REGULAR_BUILTIN,
+  POST_MATCH_CHECKUP_BUILTIN,
+  REGULAR_UPDATE_BUILTIN,
+  STALE_BUILTIN,
+  SUGGESTION_BUILTIN,
+} from "../../../services/notify/builtin-content";
+import {
+  resetAccompanyMatchTemplateCache,
+  sendEmailAccompanyMatch,
+} from "../../../services/notify/events/email-accompany-match";
+import {
+  resetAccompanyNotFoundTemplateCache,
+  sendEmailAccompanyNotFound,
+} from "../../../services/notify/events/email-accompany-not-found";
+import {
+  resetIntroductionTemplateCache,
+  sendEmailIntroduction,
+} from "../../../services/notify/events/email-introduction";
+import {
+  resetNewRegularTemplateCache,
+  sendEmailNewRegular,
+} from "../../../services/notify/events/email-new-regular";
+import {
+  resetPostMatchCheckupTemplateCache,
+  sendEmailPostMatchCheckup,
+} from "../../../services/notify/events/email-post-match-checkup";
+import {
+  resetRegularUpdateTemplateCache,
+  sendEmailRegularUpdate,
+} from "../../../services/notify/events/email-regular-update";
+import {
+  resetStaleTemplateCache,
+  sendEmailStale,
+} from "../../../services/notify/events/email-stale";
+import {
+  resetSuggestionTemplateCache,
+  sendEmailSuggestion,
+} from "../../../services/notify/events/email-suggestion";
+import type { EmailTransport } from "../../../services/notify/types";
+
+// Covers the 8 flat-content senders that (unlike email-verification and
+// email-new-accompanying) had no dedicated test at all — each only ever ran
+// through job tests with fastify.notify.* mocked out, so nothing exercised
+// resolveFlatContent()'s actual manifest-vs-builtin selection for them. See
+// be#838/be#839 review.
+vi.mock("../../../data/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../data/utils")>();
+  return { ...actual, fetchJsonFromUrl: vi.fn() };
+});
+
+const send = vi.fn();
+const email: EmailTransport = { send };
+
+function person(over: Record<string, unknown> = {}) {
+  // A plain object literal, not a `Person` instance, so `.name` (a getter on
+  // the real class computed from firstName/middleName/lastName) must be set
+  // explicitly here — otherwise it silently resolves to `undefined` instead
+  // of throwing, which a naive "no unresolved {{ }}" check wouldn't catch.
+  return {
+    firstName: "Test",
+    lastName: "Person",
+    name: "Test Person",
+    email: "person@example.com",
+    phone: "0301234567",
+    users: [],
+    ...over,
+  };
+}
+
+function volunteer(over: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    person: person({
+      firstName: "Vera",
+      lastName: "Volunteer",
+      name: "Vera Volunteer",
+      email: "vera@example.com",
+    }),
+    deal: {
+      postcode: { value: "10115" },
+      dealLanguage: [],
+      dealSkill: [],
+      dealTimeslot: [],
+    },
+    statusCGC: "no",
+    statusCgcProcess: "missing",
+    statusVaccination: "no",
+    shareContact: true,
+    ...over,
+  };
+}
+
+function opportunity(over: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    title: "Opportunity title",
+    info: "some info",
+    translationType: "Arabic",
+    contactPerson: person({
+      firstName: "Con",
+      lastName: "Tact",
+      name: "Con Tact",
+      email: "contact@example.com",
+    }),
+    district: { title: "Mitte" },
+    accompanying: {
+      name: "Client",
+      address: "Main street 1",
+      phone: "0309876543",
+      languageToTranslate: "Arabic",
+      postcode: { value: "10115" },
+    },
+    onetimer: { date: new Date("2026-03-05T13:30:00.000Z") },
+    ...over,
+  };
+}
+
+function ov(over: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    volunteerId: 1,
+    opportunityId: 1,
+    volunteer: volunteer(),
+    opportunity: opportunity(),
+    ...over,
+  };
+}
+
+const UNRESOLVED_PLACEHOLDER_RE = /\{\{\s*\w+\s*\}\}/;
+
+const CASES = [
+  {
+    name: "sendEmailStale",
+    builtin: STALE_BUILTIN,
+    resetCache: resetStaleTemplateCache,
+    send: () =>
+      sendEmailStale(
+        email,
+        ov() as unknown as Parameters<typeof sendEmailStale>[1],
+      ),
+  },
+  {
+    name: "sendEmailPostMatchCheckup",
+    builtin: POST_MATCH_CHECKUP_BUILTIN,
+    resetCache: resetPostMatchCheckupTemplateCache,
+    send: () =>
+      sendEmailPostMatchCheckup(
+        email,
+        ov() as unknown as Parameters<typeof sendEmailPostMatchCheckup>[1],
+      ),
+  },
+  {
+    name: "sendEmailSuggestion",
+    builtin: SUGGESTION_BUILTIN,
+    resetCache: resetSuggestionTemplateCache,
+    send: () =>
+      sendEmailSuggestion(
+        email,
+        ov() as unknown as Parameters<typeof sendEmailSuggestion>[1],
+      ),
+  },
+  {
+    name: "sendEmailIntroduction",
+    builtin: INTRODUCTION_BUILTIN,
+    resetCache: resetIntroductionTemplateCache,
+    send: () =>
+      sendEmailIntroduction(
+        email,
+        ov() as unknown as Parameters<typeof sendEmailIntroduction>[1],
+      ),
+  },
+  {
+    name: "sendEmailAccompanyMatch",
+    builtin: ACCOMPANY_MATCH_BUILTIN,
+    resetCache: resetAccompanyMatchTemplateCache,
+    send: () =>
+      sendEmailAccompanyMatch(
+        email,
+        ov() as unknown as Parameters<typeof sendEmailAccompanyMatch>[1],
+      ),
+  },
+  {
+    name: "sendEmailAccompanyNotFound",
+    builtin: ACCOMPANY_NOT_FOUND_BUILTIN,
+    resetCache: resetAccompanyNotFoundTemplateCache,
+    send: () =>
+      sendEmailAccompanyNotFound(
+        email,
+        opportunity() as unknown as Parameters<
+          typeof sendEmailAccompanyNotFound
+        >[1],
+      ),
+  },
+  {
+    name: "sendEmailRegularUpdate",
+    builtin: REGULAR_UPDATE_BUILTIN,
+    resetCache: resetRegularUpdateTemplateCache,
+    send: () =>
+      sendEmailRegularUpdate(
+        email,
+        opportunity() as unknown as Parameters<
+          typeof sendEmailRegularUpdate
+        >[1],
+      ),
+  },
+  {
+    name: "sendEmailNewRegular",
+    builtin: NEW_REGULAR_BUILTIN,
+    resetCache: resetNewRegularTemplateCache,
+    send: () =>
+      sendEmailNewRegular(
+        email,
+        opportunity() as unknown as Parameters<typeof sendEmailNewRegular>[1],
+      ),
+  },
+];
+
+describe.each(CASES)("$name", ({ resetCache, send: doSend }) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCache();
+  });
+
+  it("falls back to the real BUILTIN content with no unresolved placeholders", async () => {
+    vi.mocked(fetchJsonFromUrl).mockRejectedValue(new Error("no CDN in tests"));
+
+    await doSend();
+
+    const msg = send.mock.calls[0][0];
+    // builtin.subject/text may themselves contain {{ placeholders }} (e.g.
+    // accompanymatch's subject) — check the *sent* message resolved them,
+    // rather than exact-matching the raw, unfilled builtin content.
+    expect(msg.subject).not.toMatch(UNRESOLVED_PLACEHOLDER_RE);
+    expect(msg.subject).not.toContain("undefined");
+    expect(msg.text ?? "").not.toMatch(UNRESOLVED_PLACEHOLDER_RE);
+    expect(msg.text ?? "").not.toContain("undefined");
+    expect(msg.html ?? "").not.toMatch(UNRESOLVED_PLACEHOLDER_RE);
+  });
+
+  it("prefers a valid flat CDN manifest over the builtin fallback", async () => {
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue({
+      subject: "MANIFEST SUBJECT MARKER",
+      text: "manifest body, no placeholders",
+    });
+
+    await doSend();
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.subject).toBe("MANIFEST SUBJECT MARKER");
+  });
+});

--- a/src/test/services/notify/email-template.test.ts
+++ b/src/test/services/notify/email-template.test.ts
@@ -5,6 +5,7 @@ import {
   createManifestLoader,
   fillTemplate,
   resolveContent,
+  resolveFlatContent,
   resolveLocale,
   type LocaleContent,
 } from "../../../services/notify/email-template";
@@ -161,6 +162,31 @@ describe("resolveContent", () => {
     expect(resolveContent(manifest, Lang.DE, builtin).subject).toBe(
       "Builtin DE",
     );
+  });
+});
+
+// ─── resolveFlatContent ──────────────────────────────────────────────────────
+
+describe("resolveFlatContent", () => {
+  const flatBuiltin: LocaleContent = { subject: "Builtin", text: "fallback" };
+
+  it("uses the flat manifest as-is when valid", () => {
+    const manifest = { subject: "Flat subject", text: "flat body" };
+    expect(resolveFlatContent(manifest, flatBuiltin)).toEqual(manifest);
+  });
+
+  it("falls back to builtin when manifest is null", () => {
+    expect(resolveFlatContent(null, flatBuiltin)).toEqual(flatBuiltin);
+  });
+
+  it("falls back to builtin when the flat manifest is invalid (no body)", () => {
+    const manifest = { subject: "no body" };
+    expect(resolveFlatContent(manifest, flatBuiltin)).toEqual(flatBuiltin);
+  });
+
+  it("falls back to builtin when the manifest is unexpectedly locale-keyed", () => {
+    const manifest = { [Lang.EN]: { subject: "en", text: "en body" } };
+    expect(resolveFlatContent(manifest, flatBuiltin)).toEqual(flatBuiltin);
   });
 });
 

--- a/src/test/services/notify/email-verification.test.ts
+++ b/src/test/services/notify/email-verification.test.ts
@@ -1,4 +1,4 @@
-import { Lang, UserRole } from "need4deed-sdk";
+import { UserRole } from "need4deed-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { urlEmailVerification } from "../../../config/constants";
 import { fetchJsonFromUrl } from "../../../data/utils";
@@ -16,17 +16,11 @@ const deps = { email: { send }, jwt: { sign: () => "tok" } } as any;
 const user = (over: any = {}) => ({ id: 1, email: "u@x.de", ...over });
 const expectedUrl = `${urlEmailVerification}/tok`;
 
+// Flat — this template is no longer split by recipient locale (be#838).
 const manifest = {
-  en: {
-    subject: "Verify your account",
-    html: '<a href="{{verificationUrl}}">{{verificationUrl}}</a>',
-    text: "verify: {{verificationUrl}}",
-  },
-  de: {
-    subject: "Konto bestätigen",
-    html: '<a href="{{verificationUrl}}">{{verificationUrl}}</a>',
-    text: "bestätige: {{verificationUrl}}",
-  },
+  subject: "Verify your account",
+  html: '<a href="{{verificationUrl}}">{{verificationUrl}}</a>',
+  text: "verify: {{verificationUrl}}",
 };
 
 beforeEach(() => {
@@ -35,31 +29,23 @@ beforeEach(() => {
 });
 
 describe("sendEmailVerification", () => {
-  it("uses the manifest entry for the user's locale and substitutes the URL", async () => {
+  it("uses the flat manifest entry and substitutes the URL", async () => {
     vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
 
-    await sendEmailVerification(deps, user({ language: Lang.DE }));
+    await sendEmailVerification(deps, user());
 
     const msg = send.mock.calls[0][0];
-    expect(msg.subject).toBe("Konto bestätigen");
-    expect(msg.text).toBe(`bestätige: ${expectedUrl}`);
+    expect(msg.subject).toBe("Verify your account");
+    expect(msg.text).toBe(`verify: ${expectedUrl}`);
     expect(msg.html).toBe(`<a href="${expectedUrl}">${expectedUrl}</a>`);
     expect(msg.html).not.toContain("{{verificationUrl}}");
-  });
-
-  it("falls back to the default locale (de) for an unsupported language", async () => {
-    vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
-
-    await sendEmailVerification(deps, user({ language: "fr" }));
-
-    expect(send.mock.calls[0][0].subject).toBe("Konto bestätigen");
   });
 
   it("caches the manifest within TTL (single fetch across two sends)", async () => {
     vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
 
-    await sendEmailVerification(deps, user({ language: Lang.EN }));
-    await sendEmailVerification(deps, user({ language: Lang.DE }));
+    await sendEmailVerification(deps, user());
+    await sendEmailVerification(deps, user());
 
     expect(fetchJsonFromUrl).toHaveBeenCalledTimes(1);
   });
@@ -67,22 +53,22 @@ describe("sendEmailVerification", () => {
   it("falls back to built-in content when the manifest fetch fails, and still sends", async () => {
     vi.mocked(fetchJsonFromUrl).mockRejectedValue(new Error("CDN down"));
 
-    await sendEmailVerification(deps, user({ language: Lang.DE }));
+    await sendEmailVerification(deps, user());
 
     const msg = send.mock.calls[0][0];
-    expect(msg.subject).toBe("Konto erstellt"); // built-in de
+    expect(msg.subject).toBe("Verify your Need4Deed account email");
     expect(msg.text).toContain(expectedUrl);
     expect(msg.text).not.toContain("{{verificationUrl}}");
   });
 
   it("falls back to built-in when the manifest entry is invalid (missing body)", async () => {
-    vi.mocked(fetchJsonFromUrl).mockResolvedValue({
-      en: { subject: "no body here" },
-    });
+    vi.mocked(fetchJsonFromUrl).mockResolvedValue({ subject: "no body here" });
 
-    await sendEmailVerification(deps, user({ language: Lang.EN }));
+    await sendEmailVerification(deps, user());
 
-    expect(send.mock.calls[0][0].subject).toBe("Account Created"); // built-in en
+    expect(send.mock.calls[0][0].subject).toBe(
+      "Verify your Need4Deed account email",
+    );
   });
 
   it("throws when the user has no email", async () => {
@@ -94,10 +80,7 @@ describe("sendEmailVerification", () => {
   it("appends ?role=agent to the URL for AGENT users", async () => {
     vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
 
-    await sendEmailVerification(
-      deps,
-      user({ role: UserRole.AGENT, language: Lang.EN }),
-    );
+    await sendEmailVerification(deps, user({ role: UserRole.AGENT }));
 
     const msg = send.mock.calls[0][0];
     expect(msg.text).toContain(`${expectedUrl}?role=agent`);
@@ -106,10 +89,7 @@ describe("sendEmailVerification", () => {
   it("does not append a role param for non-agent users", async () => {
     vi.mocked(fetchJsonFromUrl).mockResolvedValue(manifest);
 
-    await sendEmailVerification(
-      deps,
-      user({ role: UserRole.USER, language: Lang.EN }),
-    );
+    await sendEmailVerification(deps, user({ role: UserRole.USER }));
 
     const msg = send.mock.calls[0][0];
     expect(msg.text).toContain(expectedUrl);


### PR DESCRIPTION
## Summary

`dev/files/manifests/need4deed_email_templates.docx` + sibling `*.json` files (copies of the live CDN content) show that none of the 10 volunteering/accompanying/verification notify templates are locale-keyed anymore. Each is a single flat body:

- **Bilingual** (English + German concatenated in one body): `stale`, `checkup`, `suggestion`, `verification` — all sent to recipients whose language can never be reliably known (volunteers with no `User` row; brand-new accounts). This is the actual fix for the "why does this always come in English" issue from #830 — instead of guessing, just send both languages.
- **German-only**: `confirmation`, `confirmationaccompanying`, `update`, `accompanymatch`, `accompanynotfound`, `introduction` — the RAC/contact-person workflow, whose recipients are always German-speaking coordinators.

`password-reset.json` was not among the provided files, so `email-password-reset.ts` is untouched and keeps its existing per-locale logic.

**Deploy-ordering note:** `resolveFlatContent()` only uses the live CDN manifest if it's already in the new flat shape (`isFlatContent()` check). If any of the 10 CDN files haven't been republished to match `dev/files/manifests/*.json` yet by the time this deploys, those emails will silently use the `BUILTIN` fallback instead of the live manifest until the CDN catches up — harmless content-wise (the fallback already mirrors the intended new copy), but worth knowing before someone tries to live-edit copy via the CDN and wonders why it's not taking effect.

## Changes

1. Added `resolveFlatContent(manifest, builtin)` to `email-template.ts`, alongside the existing `resolveContent(manifest, locale, builtin)` (kept for password-reset).
2. Removed the now-unused `resolveLocale(...)` calls from the 10 affected event files. `resolveStatmentOnCertificates` (`email-introduction.ts`) and `resolveContactSharing` (`email-accompany-match.ts`) drop their `lang` parameter too — both templates are German-only, so there was nothing left to branch on.
3. Updated the 10 corresponding `*_BUILTIN` fallback constants in `builtin-content.ts` from `Record<Lang, LocaleContent>` to flat `LocaleContent`. Verified byte-for-byte against the source JSON manifests, including preserved curly typographic quotes (“ ” / „ “) called out in the docx.
4. Added `email-flat-events.test.ts`: table-driven coverage for the 8 senders (`stale`, `post-match-checkup`, `suggestion`, `introduction`, `accompany-match`, `accompany-not-found`, `regular-update`, `new-regular`) that previously had no dedicated test at all — only exercised indirectly via job tests with `fastify.notify.*` mocked out. Asserts, per sender: the real `BUILTIN` fallback renders with no unresolved `{{ placeholders }}` and no stray `"undefined"` from a silently-unresolved var, and a valid flat CDN manifest is preferred over the fallback.

Not in scope: `email-password-reset.ts` (no manifest provided, unaffected).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:run` — full suite, 64 files / 551 tests, run repeatedly (pre-push hook included) to confirm stability
- [x] Verified every flat `*_BUILTIN` string matches its source `*.json` byte-for-byte via a small script comparing `subject`/`text`/`html` fields (including quote characters)
- [x] New `email-flat-events.test.ts` covers the 8 previously-untested senders (16 tests)