### PR TITLE
fix: add new appreciation values to request validation schema

### DIFF
--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -347,7 +347,16 @@
     "VolunteerStateAppreciationType": {
       "$id": "VolunteerStateAppreciationType",
       "type": "string",
-      "enum": ["t-shirt", "benefit-card", "tote-bag"]
+       "enum": [
+    "t-shirt",
+    "benefit-card",
+    "tote-bag",
+    "need4deed-certificate",
+    "cap",
+    "notebook",
+    "city-certificate"
+  ]
+
     },
     "VolunteerStateTypeType": {
       "$id": "VolunteerStateTypeType",


### PR DESCRIPTION
  ## Description
 The four new appreciation options (Need4Deed certificate, cap, notebook, city certificate) cannot be saved. The API rejects them with a 400 before the handler runs.

be#795 added those values to the SDK and to the database migration, but the request validation schema in `sdk-types.json` still listed only the original three, so every request with a new value was thrown out at validation.

Tested locally: with the values added, the four new options save and persist correctly.

## Related Issues

 Closes #837 
 Unblocks need4deed-org/fe#910

## Changes
 - Added the four new appreciation values to `VolunteerStateAppreciationType` in `src/server/schema/sdk-types.json`



## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

