### PR TITLE
feat: validate outbound email content before sending (be#847)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ EMAIL_FROM_ACCOMPANYING=accompanying@need4deed.org
 # NOTIFY_EMAIL_DRY_RUN=true  — same, email-only override
 # NOTIFY_CRON_MUTED=true     — suppress cron-triggered email scans entirely
 
+# Every outbound email is content-validated before sending (blank fields,
+# unresolved {{ placeholders }}, malformed `to`). An invalid one is suspended
+# and reported here instead — this always fires for real, bypassing dry-run.
+ERROR_EMAIL=dev@need4deed.org
+
 CORS_ORIGINS=http://localhost:3000,http://localhost:3100,http://localhost:3200
 CORS_CREDENTIALS=true
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -123,6 +123,9 @@ export const emailFromAccompanying =
   process.env.EMAIL_FROM_ACCOMPANYING || "accompanying@need4deed.org";
 export const emailFromNotify =
   process.env.EMAIL_FROM_NOTIFY || "coordinators@need4deed.org";
+// Where ValidatingEmailTransport reports a suspended, invalid outbound email.
+export const errorEmailRecipient =
+  process.env.ERROR_EMAIL || "dev@need4deed.org";
 // How long a fetched email manifest is cached in-memory (default 10 min).
 export const emailTemplateTtlMs =
   Number(process.env.EMAIL_TEMPLATE_TTL_MS) || 10 * 60 * 1000;

--- a/src/server/plugins/notify.ts
+++ b/src/server/plugins/notify.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from "fastify";
 import fp from "fastify-plugin";
-import { isProd, TRUTHY } from "../../config/constants";
+import { errorEmailRecipient, isProd, TRUTHY } from "../../config/constants";
 import OpportunityVolunteer from "../../data/entity/m2m/opportunity-volunteer";
 import Opportunity from "../../data/entity/opportunity/opportunity.entity";
 import User from "../../data/entity/user.entity";
@@ -26,6 +26,7 @@ import {
   SlackTransport,
   SlackWebhookTransport,
   SmtpEmailTransport,
+  ValidatingEmailTransport,
 } from "../../services/notify";
 
 interface NotifyService {
@@ -73,7 +74,11 @@ function buildVerifyEmailTransport(): EmailTransport {
     user: process.env.SMTP_USER ?? "",
     password: process.env.SMTP_PASS ?? "",
   });
-  return isDryRun("EMAIL") ? new DryRunEmailTransport(smtp) : smtp;
+  const deliverable = isDryRun("EMAIL") ? new DryRunEmailTransport(smtp) : smtp;
+  // Error reports bypass dry-run (always the raw `smtp`, never `deliverable`)
+  // — an invalid-content alert must actually reach someone regardless of
+  // environment, it's not end-user-facing content.
+  return new ValidatingEmailTransport(deliverable, smtp, errorEmailRecipient);
 }
 
 function buildNotifyEmailTransport(): EmailTransport {
@@ -84,7 +89,8 @@ function buildNotifyEmailTransport(): EmailTransport {
     password: process.env.SMTP_NOTIFY_PASS ?? "",
     from: process.env.EMAIL_FROM_NOTIFY ?? "",
   });
-  return isDryRun("EMAIL") ? new DryRunEmailTransport(smtp) : smtp;
+  const deliverable = isDryRun("EMAIL") ? new DryRunEmailTransport(smtp) : smtp;
+  return new ValidatingEmailTransport(deliverable, smtp, errorEmailRecipient);
 }
 
 function buildSlackTransport(): SlackTransport | undefined {

--- a/src/services/notify/email-template.ts
+++ b/src/services/notify/email-template.ts
@@ -25,24 +25,15 @@ export type TemplateVars = Record<string, string | number | null | undefined>;
 // volunteer with no User row to read a language preference from), German is
 // the more appropriate default than English.
 const DEFAULT_LOCALE = Lang.DE;
-// Captures an optional trailing "!" — {{ key! }} opts a placeholder into
-// "required": a product owner can mark specific fields as load-bearing
-// directly in the CDN manifest, without a code change. See fillTemplate().
-const PLACEHOLDER_RE = /\{\{\s*(\w+)(!)?\s*\}\}/g;
+const PLACEHOLDER_RE = /\{\{\s*(\w+)\s*\}\}/g;
 
 /**
- * Replace all {{ key }} / {{ key! }} placeholders in the template content
- * with values from vars. Handles optional whitespace around keys.
- *
- * - A key genuinely absent from vars (not just nullish) is always left
- *   unresolved (the `{{ ... }}` stays in the output) and warned about — a
- *   template referencing a variable the caller never computes is always a
- *   code bug, `!` or not.
- * - A key present in vars but null/undefined:
- *   - without `!`: substituted with "" — most fields are legitimately
- *     optional, and a blank is better than the literal word "undefined".
- *   - with `!`: treated the same as unresolved (left in place, warned about)
- *     — this is the opt-in for fields that must never be blank.
+ * Replace all {{ key }} placeholders in the template content with values
+ * from vars. Handles optional whitespace around keys. Every placeholder must
+ * resolve to a real value — a key genuinely absent from vars, or present but
+ * null/undefined, is left unresolved (the `{{ ... }}` stays in the output)
+ * and warned about, so a template/caller mismatch always surfaces rather
+ * than silently rendering blank.
  *
  * Never substring-matches rendered text for "undefined"/etc. — a user could
  * legitimately type that into free-text content (a title, a comment), and
@@ -53,23 +44,12 @@ export function fillTemplate(
   vars: TemplateVars,
 ): { subject: string; html?: string; text?: string } {
   const fill = (s: string): string =>
-    s.replace(PLACEHOLDER_RE, (match, key: string, required?: string) => {
-      if (!(key in vars)) {
+    s.replace(PLACEHOLDER_RE, (match, key: string) => {
+      const value = vars[key];
+      if (!(key in vars) || value === undefined || value === null) {
         logger.warn(`email template: unresolved placeholder {{${key}}}`);
         return match;
       }
-
-      const value = vars[key];
-      if (value === undefined || value === null) {
-        if (required) {
-          logger.warn(
-            `email template: required placeholder {{${key}!}} resolved to ${value === null ? "null" : "undefined"}`,
-          );
-          return match;
-        }
-        return "";
-      }
-
       return String(value);
     });
 

--- a/src/services/notify/email-template.ts
+++ b/src/services/notify/email-template.ts
@@ -16,31 +16,61 @@ export interface LocaleContent {
 // LocaleContent used as-is regardless of locale (for content that isn't split
 // by language, e.g. a template that already mixes both languages in one body).
 export type Manifest = Partial<Record<Lang, LocaleContent>> | LocaleContent;
-export type TemplateVars = Record<string, string | number>;
+// null/undefined are legal values here (not just string | number) precisely
+// because that's the failure mode fillTemplate() guards against — a caller
+// computing a var that unexpectedly comes back nullish.
+export type TemplateVars = Record<string, string | number | null | undefined>;
 
 // Berlin-based NGO — when a recipient's locale can't be determined (e.g. a
 // volunteer with no User row to read a language preference from), German is
 // the more appropriate default than English.
 const DEFAULT_LOCALE = Lang.DE;
-const PLACEHOLDER_RE = /\{\{\s*(\w+)\s*\}\}/g;
+// Captures an optional trailing "!" — {{ key! }} opts a placeholder into
+// "required": a product owner can mark specific fields as load-bearing
+// directly in the CDN manifest, without a code change. See fillTemplate().
+const PLACEHOLDER_RE = /\{\{\s*(\w+)(!)?\s*\}\}/g;
 
 /**
- * Replace all {{ key }} placeholders in the template content with values from
- * vars. Handles optional whitespace around keys. Each placeholder that has no
- * matching key in vars is left unchanged and a warning is logged so template
- * mismatches surface early.
+ * Replace all {{ key }} / {{ key! }} placeholders in the template content
+ * with values from vars. Handles optional whitespace around keys.
+ *
+ * - A key genuinely absent from vars (not just nullish) is always left
+ *   unresolved (the `{{ ... }}` stays in the output) and warned about — a
+ *   template referencing a variable the caller never computes is always a
+ *   code bug, `!` or not.
+ * - A key present in vars but null/undefined:
+ *   - without `!`: substituted with "" — most fields are legitimately
+ *     optional, and a blank is better than the literal word "undefined".
+ *   - with `!`: treated the same as unresolved (left in place, warned about)
+ *     — this is the opt-in for fields that must never be blank.
+ *
+ * Never substring-matches rendered text for "undefined"/etc. — a user could
+ * legitimately type that into free-text content (a title, a comment), and
+ * that must never be flagged as invalid.
  */
 export function fillTemplate(
   content: LocaleContent,
   vars: TemplateVars,
 ): { subject: string; html?: string; text?: string } {
   const fill = (s: string): string =>
-    s.replace(PLACEHOLDER_RE, (match, key: string) => {
+    s.replace(PLACEHOLDER_RE, (match, key: string, required?: string) => {
       if (!(key in vars)) {
         logger.warn(`email template: unresolved placeholder {{${key}}}`);
         return match;
       }
-      return String(vars[key]);
+
+      const value = vars[key];
+      if (value === undefined || value === null) {
+        if (required) {
+          logger.warn(
+            `email template: required placeholder {{${key}!}} resolved to ${value === null ? "null" : "undefined"}`,
+          );
+          return match;
+        }
+        return "";
+      }
+
+      return String(value);
     });
 
   return {

--- a/src/services/notify/index.ts
+++ b/src/services/notify/index.ts
@@ -4,6 +4,8 @@ export * from "./transports/email-brevo";
 export * from "./transports/email-smtp";
 export * from "./transports/slack-webhook";
 export * from "./transports/dry-run";
+export * from "./transports/validating";
+export * from "./validate-email-message";
 export * from "./events/email-verification";
 export * from "./events/ops-alert";
 export * from "./events/comment-tagged";

--- a/src/services/notify/transports/validating.ts
+++ b/src/services/notify/transports/validating.ts
@@ -1,0 +1,65 @@
+import logger from "../../../logger";
+import type { EmailMessage, EmailTransport } from "../types";
+import { validateEmailMessage } from "../validate-email-message";
+
+function formatReport(msg: EmailMessage, problems: string[]): string {
+  const to = Array.isArray(msg.to) ? msg.to.join(", ") : msg.to;
+  const cc = msg.cc
+    ? Array.isArray(msg.cc)
+      ? msg.cc.join(", ")
+      : msg.cc
+    : undefined;
+
+  return [
+    "An outbound email was suspended because it failed content validation:",
+    "",
+    ...problems.map((p) => `- ${p}`),
+    "",
+    "--- Original message ---",
+    `From: ${msg.from ?? "(default)"}`,
+    `To: ${to}`,
+    ...(cc ? [`Cc: ${cc}`] : []),
+    `Subject: ${msg.subject}`,
+    "",
+    "Text:",
+    msg.text ?? "(none)",
+    ...(msg.html !== undefined ? ["", "Html:", msg.html] : []),
+  ].join("\n");
+}
+
+/**
+ * Validates a computed EmailMessage before handing it to the real transport.
+ * On failure, suspends the send and instead reports the full original
+ * message + the problems found to `errorRecipient`, via `errorTransport`
+ * rather than `deliverable` — this is an internal engineering alert, not
+ * end-user-facing content, so it must always actually reach someone
+ * regardless of dry-run config (pass the transport's real underlying SMTP
+ * client here, not a dry-run-wrapped one).
+ */
+export class ValidatingEmailTransport implements EmailTransport {
+  constructor(
+    private readonly deliverable: EmailTransport,
+    private readonly errorTransport: EmailTransport,
+    private readonly errorRecipient: string,
+  ) {}
+
+  async send(msg: EmailMessage): Promise<void> {
+    const problems = validateEmailMessage(msg);
+    if (problems.length === 0) {
+      await this.deliverable.send(msg);
+      return;
+    }
+
+    const to = Array.isArray(msg.to) ? msg.to.join(", ") : msg.to;
+    logger.error(
+      `[notify] suspended invalid outbound email (to: ${to}): ${problems.join("; ")}`,
+    );
+
+    await this.errorTransport.send({
+      to: this.errorRecipient,
+      from: msg.from,
+      subject: `[Suspended invalid email] ${msg.subject || "(no subject)"}`,
+      text: formatReport(msg, problems),
+    });
+  }
+}

--- a/src/services/notify/validate-email-message.ts
+++ b/src/services/notify/validate-email-message.ts
@@ -1,12 +1,11 @@
 import type { EmailMessage } from "./types";
 
-// Mirrors fillTemplate()'s placeholder syntax ({{ key }} / {{ key! }}) so a
-// leftover unresolved placeholder is caught regardless of whether it was
-// marked required. Deliberately does not scan for any other substring (e.g.
-// the word "undefined") — that's fillTemplate's job at the source, where it
-// can tell an actual nullish variable apart from a user having legitimately
-// typed that word into free-text content.
-const UNRESOLVED_PLACEHOLDER_RE = /\{\{\s*\w+!?\s*\}\}/;
+// Mirrors fillTemplate()'s placeholder syntax so a leftover unresolved
+// placeholder is caught. Deliberately does not scan for any other substring
+// (e.g. the word "undefined") — that's fillTemplate's job at the source,
+// where it can tell an actual nullish variable apart from a user having
+// legitimately typed that word into free-text content.
+const UNRESOLVED_PLACEHOLDER_RE = /\{\{\s*\w+\s*\}\}/;
 
 function isBlank(value: string | undefined): boolean {
   return !value || !value.trim();

--- a/src/services/notify/validate-email-message.ts
+++ b/src/services/notify/validate-email-message.ts
@@ -1,0 +1,43 @@
+import type { EmailMessage } from "./types";
+
+// Mirrors fillTemplate()'s placeholder syntax ({{ key }} / {{ key! }}) so a
+// leftover unresolved placeholder is caught regardless of whether it was
+// marked required. Deliberately does not scan for any other substring (e.g.
+// the word "undefined") — that's fillTemplate's job at the source, where it
+// can tell an actual nullish variable apart from a user having legitimately
+// typed that word into free-text content.
+const UNRESOLVED_PLACEHOLDER_RE = /\{\{\s*\w+!?\s*\}\}/;
+
+function isBlank(value: string | undefined): boolean {
+  return !value || !value.trim();
+}
+
+/** Returns a list of problems with a computed EmailMessage — empty if valid. */
+export function validateEmailMessage(msg: EmailMessage): string[] {
+  const problems: string[] = [];
+
+  const to = Array.isArray(msg.to) ? msg.to.join(", ") : msg.to;
+  if (isBlank(to)) {
+    problems.push('"to" is blank');
+  } else if (!to.includes("@")) {
+    problems.push(`"to" doesn't look like an email address: "${to}"`);
+  }
+
+  if (isBlank(msg.subject)) {
+    problems.push("subject is blank");
+  } else if (UNRESOLVED_PLACEHOLDER_RE.test(msg.subject)) {
+    problems.push(`subject has an unresolved placeholder: "${msg.subject}"`);
+  }
+
+  if (isBlank(msg.text) && isBlank(msg.html)) {
+    problems.push("neither text nor html body is set");
+  }
+  if (msg.text !== undefined && UNRESOLVED_PLACEHOLDER_RE.test(msg.text)) {
+    problems.push("text has an unresolved placeholder");
+  }
+  if (msg.html !== undefined && UNRESOLVED_PLACEHOLDER_RE.test(msg.html)) {
+    problems.push("html has an unresolved placeholder");
+  }
+
+  return problems;
+}

--- a/src/test/services/notify/email-template.test.ts
+++ b/src/test/services/notify/email-template.test.ts
@@ -94,6 +94,52 @@ describe("fillTemplate", () => {
     const result = fillTemplate({ subject: "Hi {{name}}" }, { name: "" });
     expect(result.subject).toBe("Hi ");
   });
+
+  it("substitutes a nullish value (no ! marker) with an empty string, not the word 'undefined'", () => {
+    const result = fillTemplate(
+      { subject: "Date: {{date}}", text: "Time: {{time}}" },
+      { date: undefined, time: null },
+    );
+    expect(result.subject).toBe("Date: ");
+    expect(result.text).toBe("Time: ");
+  });
+
+  it("treats a required (!) placeholder resolving to undefined as unresolved", () => {
+    const result = fillTemplate(
+      { subject: "Date: {{date!}}" },
+      { date: undefined },
+    );
+    expect(result.subject).toBe("Date: {{date!}}");
+  });
+
+  it("treats a required (!) placeholder resolving to null as unresolved", () => {
+    const result = fillTemplate(
+      { subject: "Date: {{ date! }}" },
+      { date: null },
+    );
+    expect(result.subject).toBe("Date: {{ date! }}");
+  });
+
+  it("fills a required (!) placeholder normally when the value is present", () => {
+    const result = fillTemplate(
+      { subject: "Date: {{ date! }}" },
+      { date: "2026-08-28" },
+    );
+    expect(result.subject).toBe("Date: 2026-08-28");
+  });
+
+  it("still treats a genuinely missing key as unresolved regardless of the ! marker", () => {
+    const result = fillTemplate({ subject: "Date: {{ date! }}" }, {});
+    expect(result.subject).toBe("Date: {{ date! }}");
+  });
+
+  it("never flags literal user content that happens to contain the word 'undefined'", () => {
+    const result = fillTemplate(
+      { subject: "{{ title }}" },
+      { title: "My undefined project" },
+    );
+    expect(result.subject).toBe("My undefined project");
+  });
 });
 
 // ─── resolveLocale ───────────────────────────────────────────────────────────

--- a/src/test/services/notify/email-template.test.ts
+++ b/src/test/services/notify/email-template.test.ts
@@ -95,42 +95,28 @@ describe("fillTemplate", () => {
     expect(result.subject).toBe("Hi ");
   });
 
-  it("substitutes a nullish value (no ! marker) with an empty string, not the word 'undefined'", () => {
+  it("treats a nullish (undefined) value as unresolved, not the word 'undefined'", () => {
     const result = fillTemplate(
-      { subject: "Date: {{date}}", text: "Time: {{time}}" },
-      { date: undefined, time: null },
-    );
-    expect(result.subject).toBe("Date: ");
-    expect(result.text).toBe("Time: ");
-  });
-
-  it("treats a required (!) placeholder resolving to undefined as unresolved", () => {
-    const result = fillTemplate(
-      { subject: "Date: {{date!}}" },
+      { subject: "Date: {{date}}" },
       { date: undefined },
     );
-    expect(result.subject).toBe("Date: {{date!}}");
+    expect(result.subject).toBe("Date: {{date}}");
   });
 
-  it("treats a required (!) placeholder resolving to null as unresolved", () => {
+  it("treats a nullish (null) value as unresolved", () => {
     const result = fillTemplate(
-      { subject: "Date: {{ date! }}" },
+      { subject: "Date: {{ date }}" },
       { date: null },
     );
-    expect(result.subject).toBe("Date: {{ date! }}");
+    expect(result.subject).toBe("Date: {{ date }}");
   });
 
-  it("fills a required (!) placeholder normally when the value is present", () => {
+  it("fills a placeholder normally when the value is present", () => {
     const result = fillTemplate(
-      { subject: "Date: {{ date! }}" },
+      { subject: "Date: {{ date }}" },
       { date: "2026-08-28" },
     );
     expect(result.subject).toBe("Date: 2026-08-28");
-  });
-
-  it("still treats a genuinely missing key as unresolved regardless of the ! marker", () => {
-    const result = fillTemplate({ subject: "Date: {{ date! }}" }, {});
-    expect(result.subject).toBe("Date: {{ date! }}");
   });
 
   it("never flags literal user content that happens to contain the word 'undefined'", () => {

--- a/src/test/services/notify/validate-email-message.test.ts
+++ b/src/test/services/notify/validate-email-message.test.ts
@@ -53,16 +53,6 @@ describe("validateEmailMessage", () => {
     ]);
   });
 
-  it("flags an unresolved required (!) placeholder in the subject", () => {
-    const problems = validateEmailMessage({
-      ...validMessage,
-      subject: "Date: {{ date! }}",
-    });
-    expect(problems).toEqual([
-      'subject has an unresolved placeholder: "Date: {{ date! }}"',
-    ]);
-  });
-
   it("flags when neither text nor html is set", () => {
     expect(
       validateEmailMessage({ to: validMessage.to, subject: "Subject" }),

--- a/src/test/services/notify/validate-email-message.test.ts
+++ b/src/test/services/notify/validate-email-message.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { validateEmailMessage } from "../../../services/notify/validate-email-message";
+
+const validMessage = {
+  to: "person@example.com",
+  subject: "A valid subject",
+  text: "A valid body.",
+};
+
+describe("validateEmailMessage", () => {
+  it("returns no problems for a well-formed message", () => {
+    expect(validateEmailMessage(validMessage)).toEqual([]);
+  });
+
+  it("flags a blank to", () => {
+    expect(validateEmailMessage({ ...validMessage, to: "" })).toEqual([
+      '"to" is blank',
+    ]);
+  });
+
+  it("flags a to with no @", () => {
+    const problems = validateEmailMessage({
+      ...validMessage,
+      to: "not-an-email",
+    });
+    expect(problems).toEqual([
+      '"to" doesn\'t look like an email address: "not-an-email"',
+    ]);
+  });
+
+  it("accepts an array to, joining for the report", () => {
+    expect(
+      validateEmailMessage({
+        ...validMessage,
+        to: ["a@example.com", "b@example.com"],
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags a blank subject", () => {
+    expect(validateEmailMessage({ ...validMessage, subject: "  " })).toEqual([
+      "subject is blank",
+    ]);
+  });
+
+  it("flags an unresolved placeholder in the subject", () => {
+    const problems = validateEmailMessage({
+      ...validMessage,
+      subject: "Hi {{ name }}",
+    });
+    expect(problems).toEqual([
+      'subject has an unresolved placeholder: "Hi {{ name }}"',
+    ]);
+  });
+
+  it("flags an unresolved required (!) placeholder in the subject", () => {
+    const problems = validateEmailMessage({
+      ...validMessage,
+      subject: "Date: {{ date! }}",
+    });
+    expect(problems).toEqual([
+      'subject has an unresolved placeholder: "Date: {{ date! }}"',
+    ]);
+  });
+
+  it("flags when neither text nor html is set", () => {
+    expect(
+      validateEmailMessage({ to: validMessage.to, subject: "Subject" }),
+    ).toEqual(["neither text nor html body is set"]);
+  });
+
+  it("does not flag a message with only html set", () => {
+    expect(
+      validateEmailMessage({
+        to: validMessage.to,
+        subject: "Subject",
+        html: "<p>body</p>",
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags an unresolved placeholder in text", () => {
+    expect(
+      validateEmailMessage({ ...validMessage, text: "Hi {{ name }}" }),
+    ).toEqual(["text has an unresolved placeholder"]);
+  });
+
+  it("flags an unresolved placeholder in html", () => {
+    expect(
+      validateEmailMessage({
+        ...validMessage,
+        html: "<p>Hi {{ name }}</p>",
+      }),
+    ).toEqual(["html has an unresolved placeholder"]);
+  });
+
+  it("never flags the literal word 'undefined' in legitimate user content", () => {
+    expect(
+      validateEmailMessage({
+        ...validMessage,
+        subject: "My undefined project",
+        text: "Comment: undefined is a fine variable name to type here.",
+      }),
+    ).toEqual([]);
+  });
+
+  it("collects multiple problems at once", () => {
+    const problems = validateEmailMessage({
+      to: "",
+      subject: "",
+      text: undefined,
+      html: undefined,
+    });
+    expect(problems).toEqual([
+      '"to" is blank',
+      "subject is blank",
+      "neither text nor html body is set",
+    ]);
+  });
+});

--- a/src/test/services/notify/validating.test.ts
+++ b/src/test/services/notify/validating.test.ts
@@ -34,7 +34,7 @@ describe("ValidatingEmailTransport", () => {
       to: "person@example.com",
       cc: "cc@example.com",
       from: "notify@need4deed.org",
-      subject: "Date: {{ date! }}",
+      subject: "Date: {{ date }}",
       text: "some body",
     };
 
@@ -46,9 +46,9 @@ describe("ValidatingEmailTransport", () => {
     const report = vi.mocked(errorTransport.send).mock.calls[0][0];
     expect(report.to).toBe("dev@need4deed.org");
     expect(report.from).toBe("notify@need4deed.org");
-    expect(report.subject).toBe("[Suspended invalid email] Date: {{ date! }}");
+    expect(report.subject).toBe("[Suspended invalid email] Date: {{ date }}");
     expect(report.text).toContain(
-      'subject has an unresolved placeholder: "Date: {{ date! }}"',
+      'subject has an unresolved placeholder: "Date: {{ date }}"',
     );
     expect(report.text).toContain("To: person@example.com");
     expect(report.text).toContain("Cc: cc@example.com");

--- a/src/test/services/notify/validating.test.ts
+++ b/src/test/services/notify/validating.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { ValidatingEmailTransport } from "../../../services/notify/transports/validating";
+import type { EmailTransport } from "../../../services/notify/types";
+
+function buildTransports() {
+  const deliverable: EmailTransport = { send: vi.fn() };
+  const errorTransport: EmailTransport = { send: vi.fn() };
+  const transport = new ValidatingEmailTransport(
+    deliverable,
+    errorTransport,
+    "dev@need4deed.org",
+  );
+  return { deliverable, errorTransport, transport };
+}
+
+describe("ValidatingEmailTransport", () => {
+  it("passes a valid message through to the deliverable transport unchanged", async () => {
+    const { deliverable, errorTransport, transport } = buildTransports();
+    const msg = {
+      to: "person@example.com",
+      subject: "Hello",
+      text: "A valid body.",
+    };
+
+    await transport.send(msg);
+
+    expect(deliverable.send).toHaveBeenCalledWith(msg);
+    expect(errorTransport.send).not.toHaveBeenCalled();
+  });
+
+  it("suspends an invalid message and reports it to the error recipient instead", async () => {
+    const { deliverable, errorTransport, transport } = buildTransports();
+    const msg = {
+      to: "person@example.com",
+      cc: "cc@example.com",
+      from: "notify@need4deed.org",
+      subject: "Date: {{ date! }}",
+      text: "some body",
+    };
+
+    await transport.send(msg);
+
+    expect(deliverable.send).not.toHaveBeenCalled();
+    expect(errorTransport.send).toHaveBeenCalledTimes(1);
+
+    const report = vi.mocked(errorTransport.send).mock.calls[0][0];
+    expect(report.to).toBe("dev@need4deed.org");
+    expect(report.from).toBe("notify@need4deed.org");
+    expect(report.subject).toBe("[Suspended invalid email] Date: {{ date! }}");
+    expect(report.text).toContain(
+      'subject has an unresolved placeholder: "Date: {{ date! }}"',
+    );
+    expect(report.text).toContain("To: person@example.com");
+    expect(report.text).toContain("Cc: cc@example.com");
+    expect(report.text).toContain("some body");
+  });
+
+  it("reports a blank subject with a placeholder fallback in the report subject line", async () => {
+    const { errorTransport, transport } = buildTransports();
+
+    await transport.send({ to: "person@example.com", subject: "", text: "x" });
+
+    const report = vi.mocked(errorTransport.send).mock.calls[0][0];
+    expect(report.subject).toBe("[Suspended invalid email] (no subject)");
+    expect(report.text).toContain("subject is blank");
+  });
+});


### PR DESCRIPTION
## Summary

Found while investigating be#844/be#846: a computed notify email can go out with silently-blank fields ("Datum, Uhrzeit:  um ") or a var that fails to resolve stringifying to the literal word "undefined". This adds a content-validation gate before any outbound email is actually sent.

**Update:** the initial version of this PR added an opt-in `{{ key! }}` "required" marker (nullish → blank by default unless marked). That design was reversed before merging (be#852) — every placeholder is now strictly required, no opt-in. See "Changes" below for the current behavior.

## Changes

1. **`fillTemplate()`** (`email-template.ts`) — every `{{ key }}` placeholder must resolve to a real, non-nullish value. A key genuinely absent from `vars`, or present but `null`/`undefined`, is always left unresolved (the `{{ ... }}` stays in the output, a warning is logged) — no more silent `""` substitution for "optional" fields.

   Deliberately never scans rendered text for the substring "undefined" — a user can legitimately type that into a title/comment, and that must never be flagged as invalid content. This is why the fix lives at the `fillTemplate` source (where we know a value's actual type) rather than as a text-scan downstream.

   **Known consequence, not hidden:** templates with fields that are legitimately blank today (optional comment/info fields, etc.) will now have those slots treated as invalid whenever the submitter left them empty — suspending the send and reporting to `ERROR_EMAIL`. Expect this to surface follow-up work on individual manifests/templates rather than being a bug in this change.

2. **`ValidatingEmailTransport`** (`src/services/notify/transports/validating.ts`, same wrapping pattern as the existing `DryRunEmailTransport`) — validates the final `EmailMessage` before handing it to the real transport:
   - blank/whitespace-only `subject`, or both `text` and `html` blank/missing
   - unresolved `{{ ... }}` still present in `subject`/`text`/`html`
   - `to` blank or missing `@`

   On failure: suspends the real send, and instead emails the full original message (to/cc/from/subject/text/html) plus the problems found to `ERROR_EMAIL` (env var, defaults to `dev@need4deed.org`) — via the transport's real underlying SMTP client, bypassing dry-run redirection, since this is an internal engineering alert that must always actually be delivered regardless of environment.

3. Wired into both `buildVerifyEmailTransport()` and `buildNotifyEmailTransport()` in `notify.ts`, covering every outbound notify email uniformly (password-reset/verification included).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:run` — full suite, 66 files / 570 tests, run repeatedly (pre-push hook included) to confirm stability
- [x] Tests: `fillTemplate`'s always-required placeholder behavior (`email-template.test.ts`), `validate-email-message.test.ts` (12 cases incl. a regression guard that legitimate "undefined" user content is never flagged), `validating.test.ts` (transport suspends invalid sends and reports them correctly)