### PR TITLE
fix: map accompanying translation preference to a human-readable label (be#846)

### DIFF
--- a/src/services/notify/events/email-new-accompanying.ts
+++ b/src/services/notify/events/email-new-accompanying.ts
@@ -1,3 +1,4 @@
+import { TranslatedIntoType } from "need4deed-sdk";
 import {
   emailFromAccompanying,
   emailFromContact,
@@ -15,6 +16,18 @@ import {
 import type { EmailTransport } from "../types";
 
 const loader = createManifestLoader(emailNewAccompanyingManifestUrl);
+
+// Matches fe's own labels for these values (public/locales/de/translations.json)
+// — German-only since this template is (be#838).
+const TRANSLATION_LABELS: Record<TranslatedIntoType, string> = {
+  [TranslatedIntoType.DEUTSCHE]: "Nur Deutsch",
+  [TranslatedIntoType.ENGLISH_OK]: "Deutsch oder Englisch",
+  [TranslatedIntoType.NO_TRANSLATION]: "Keine Sprachmittlung (Wegbegleitung)",
+};
+
+function translationLabel(value: TranslatedIntoType | undefined): string {
+  return value ? (TRANSLATION_LABELS[value] ?? "") : "";
+}
 
 export function resetNewAccompanyingTemplateCache(): void {
   loader.resetCache();
@@ -55,8 +68,15 @@ export async function sendEmailNewAccompanying(
   const clientName = accompanying?.name ?? "";
   const appointmentTitle = opportunity.title;
   const appointmentAddress = accompanying?.address ?? "";
-  const accompaniedpersonLanguage = accompanying?.languageToTranslate ?? "";
-  const appointmentaLanguage = opportunity.translationType ?? "";
+  // Both slots come from the same submission field (be#846) — there's no
+  // second, independently-set value anywhere in the codebase today
+  // (opportunity.translationType has no other reader or writer besides this
+  // one email). Mapped to the same human-readable label rather than left as
+  // the raw enum value ("deutsche").
+  const accompaniedpersonLanguage = translationLabel(
+    accompanying?.languageToTranslate,
+  );
+  const appointmentaLanguage = accompaniedpersonLanguage;
   const accompaniedpersonName = accompanying?.name ?? "";
   const accompaniedpersonPhone = accompanying?.phone ?? "";
   const appointmentComment = opportunity.info ?? "";

--- a/src/test/services/notify/email-new-accompanying.test.ts
+++ b/src/test/services/notify/email-new-accompanying.test.ts
@@ -1,3 +1,4 @@
+import { TranslatedIntoType } from "need4deed-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchJsonFromUrl } from "../../../data/utils";
 import { sendEmailNewAccompanying } from "../../../services/notify/events/email-new-accompanying";
@@ -21,7 +22,6 @@ function buildOpportunity(over: Record<string, unknown> = {}) {
     id: 1,
     title: "Hospital visit",
     info: "some info",
-    translationType: "Arabic",
     contactPerson: {
       name: "Jane Doe",
       email: "jane@example.com",
@@ -32,7 +32,7 @@ function buildOpportunity(over: Record<string, unknown> = {}) {
       name: "Client Name",
       address: "Main street 1",
       phone: "123456",
-      languageToTranslate: "Arabic",
+      languageToTranslate: TranslatedIntoType.ENGLISH_OK,
       postcode: { value: "10115" },
     },
     onetimer: { date: new Date("2026-03-05T13:30:00.000Z") },
@@ -59,5 +59,46 @@ describe("sendEmailNewAccompanying", () => {
     const msg = send.mock.calls[0][0];
     expect(msg.text).not.toContain("{{ appointmentTime }}");
     expect(msg.text).not.toContain("{{ appointmentPlz }}");
+  });
+
+  // be#846: accompaniedpersonLanguage/appointmentaLanguage were raw enum
+  // values duplicated from the same source (opportunity.translationType has
+  // no other reader or writer anywhere in the codebase) — mapped to a
+  // human-readable label instead, from the one genuine source.
+  it("maps languageToTranslate to a human-readable label, not the raw enum value", async () => {
+    await sendEmailNewAccompanying(
+      email,
+      buildOpportunity({
+        accompanying: {
+          name: "Client Name",
+          languageToTranslate: TranslatedIntoType.DEUTSCHE,
+          postcode: { value: "10115" },
+        },
+      }),
+    );
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.text).toContain("Nur Deutsch");
+    expect(msg.text).not.toContain("deutsche");
+  });
+
+  it("renders the same label for both language slots (single source of truth)", async () => {
+    await sendEmailNewAccompanying(email, buildOpportunity());
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.text).toContain("Deutsch oder Englisch, Deutsch oder Englisch");
+  });
+
+  it("renders an empty label when languageToTranslate is unset", async () => {
+    await sendEmailNewAccompanying(
+      email,
+      buildOpportunity({
+        accompanying: { name: "Client Name", postcode: { value: "10115" } },
+      }),
+    );
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.text).not.toContain("undefined");
+    expect(msg.text).toContain("Sprachen: , ");
   });
 });


### PR DESCRIPTION
## Summary

`accompaniedpersonLanguage`/`appointmentaLanguage` in the confirmationaccompanying email were rendered as the raw `TranslatedIntoType` enum value ("deutsche") and were always identical.

Traced `opportunity.translationType`'s usage across the whole codebase — it has no reader or writer anywhere besides this one email variable, and is populated from the exact same `accomp_translation` payload field as `accompanying.languageToTranslate`, in the same parser call (`parser-opportunity-legacy.ts` / `parser-accompanying-legacy.ts`). There's no second, independently-set value anywhere to distinguish the two — this isn't two concepts that drifted apart, it's one concept exposed in two template slots.

## Fix

Map both slots to the same human-readable German label (matching `fe`'s own labels for these exact values — `public/locales/de/translations.json`), sourced once from `accompanying.languageToTranslate`:

- `deutsche` → "Nur Deutsch"
- `englishOk` → "Deutsch oder Englisch"
- `noTranslation` → "Keine Sprachmittlung (Wegbegleitung)"

Consistent identical output for both slots is the correct, honest state given the data model — not a bug to paper over with a fabricated second value. If a product decision later introduces a genuinely independent second field, this can be revisited.

Closes #846

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:run` — full suite, 64 files / 554 tests
- [x] New test cases: label mapping instead of raw enum value, both slots consistent from the single source, empty-label handling when unset