### PR TITLE
fix: German-translate skill/language titles in notify emails (be#849)

### DIFF
--- a/src/server/routes/m2m/opportunity-volunteer.routes.ts
+++ b/src/server/routes/m2m/opportunity-volunteer.routes.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
   CommunicationType,
+  Lang,
   OpportunityVolunteerStatusType,
   ProfileVolunteeringType,
   UserRole,
@@ -14,6 +15,7 @@ import {
 import logger from "../../../logger";
 import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyMessage } from "../../types";
+import { addTranslatedFields } from "../../utils/data/for-routes";
 import { logEmailCommunication } from "../../utils/data/log-email-communication";
 
 // Sends the FIRST_INQUIRY "suggest" email for an OV that is (now) PENDING.
@@ -202,6 +204,11 @@ export default async function m2mOpportunityVolunteerRoutes(
               if (!ov) {
                 return;
               }
+              // emailIntroduction/emailAccompanyMatch render the
+              // volunteer's language/skill titles — without this, they'd
+              // always be the raw (English) title rather than the German
+              // translation (be#849).
+              await addTranslatedFields([ov.volunteer], Lang.DE);
               const isAccompany =
                 ov.opportunity?.type === ProfileVolunteeringType.ACCOMPANYING;
               const commType = isAccompany

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -146,7 +146,11 @@ export async function addTranslatedFields(
   logger.info("Translating volunteers");
   for (const volunteer of volunteers) {
     try {
-      for (const pl of volunteer.deal.dealLanguage) {
+      // `?? []` guards below: this is also called from the notify path
+      // (be#849) with only a subset of deal relations loaded — e.g. no
+      // dealActivity — so it must not assume every caller eager-loaded all
+      // three, only whichever ones it actually needs translated.
+      for (const pl of volunteer.deal?.dealLanguage ?? []) {
         const translation = await fieldTranslationRepository.findOne({
           where: {
             language,
@@ -158,7 +162,7 @@ export async function addTranslatedFields(
           ? translation?.translation
           : pl.language.translation;
       }
-      for (const pa of volunteer.deal.dealActivity) {
+      for (const pa of volunteer.deal?.dealActivity ?? []) {
         const translation = await fieldTranslationRepository.findOne({
           where: {
             language,
@@ -170,7 +174,7 @@ export async function addTranslatedFields(
           ? translation?.translation
           : pa.activity.translation;
       }
-      for (const ps of volunteer.deal.dealSkill) {
+      for (const ps of volunteer.deal?.dealSkill ?? []) {
         const translation = await fieldTranslationRepository.findOne({
           where: {
             language,
@@ -691,7 +695,7 @@ export async function fetchVolunteerById(
     return null;
   }
 
-  addTranslatedFields([volunteer], isoCode);
+  await addTranslatedFields([volunteer], isoCode);
 
   const timedEvents = await getTimedEvents(volunteer);
   const comments = await getVolunteerComments(volunteer);

--- a/src/test/server/utils/data/add-translated-fields.test.ts
+++ b/src/test/server/utils/data/add-translated-fields.test.ts
@@ -1,0 +1,157 @@
+import { FastifyInstance } from "fastify";
+import { EntityTableName, Lang } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { dataSource } from "../../../../data/data-source";
+import Deal from "../../../../data/entity/deal.entity";
+import FieldTranslation from "../../../../data/entity/field_translation.entity";
+import Postcode from "../../../../data/entity/location/postcode.entity";
+import DealLanguage from "../../../../data/entity/m2m/deal-language";
+import DealSkill from "../../../../data/entity/m2m/deal-skill";
+import Language from "../../../../data/entity/profile/language.entity";
+import Skill from "../../../../data/entity/profile/skill.entity";
+import Volunteer from "../../../../data/entity/volunteer/volunteer.entity";
+import { DealType } from "../../../../data/types/enums";
+import { createServer } from "../../../../server";
+import { addTranslatedFields } from "../../../../server/utils/data/for-routes";
+
+describe("addTranslatedFields", () => {
+  let fastify: FastifyInstance;
+  let postcode: Postcode;
+  let deal: Deal;
+  let volunteer: Volunteer;
+  let sourceLanguage: Language;
+  let skill: Skill;
+  let dealLanguage: DealLanguage;
+  let dealSkill: DealSkill;
+  let translations: FieldTranslation[];
+
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const postcodeRepository = dataSource.getRepository(Postcode);
+    const dealRepository = dataSource.getRepository(Deal);
+    const volunteerRepository = dataSource.getRepository(Volunteer);
+    const languageRepository = dataSource.getRepository(Language);
+    const skillRepository = dataSource.getRepository(Skill);
+    const dealLanguageRepository = dataSource.getRepository(DealLanguage);
+    const dealSkillRepository = dataSource.getRepository(DealSkill);
+    const fieldTranslationRepository =
+      dataSource.getRepository(FieldTranslation);
+
+    // The real, already-seeded German locale row — addTranslatedFields()
+    // resolves its `isoCode` argument to this exact row internally.
+    const germanLanguage = await languageRepository.findOneByOrFail({
+      isoCode: "de",
+    });
+
+    postcode = await postcodeRepository.save(
+      new Postcode({ value: `1${suffix.slice(-4)}` }),
+    );
+    deal = await dealRepository.save(
+      new Deal({ type: DealType.VOLUNTEER, postcodeId: postcode.id }),
+    );
+    volunteer = await volunteerRepository.save(
+      new Volunteer({ dealId: deal.id }),
+    );
+
+    sourceLanguage = await languageRepository.save(
+      new Language({ isoCode: "xx", title: `Test Language ${suffix}` }),
+    );
+    skill = await skillRepository.save(
+      new Skill({ title: `Test Skill ${suffix}` }),
+    );
+
+    dealLanguage = await dealLanguageRepository.save(
+      new DealLanguage({ dealId: deal.id, languageId: sourceLanguage.id }),
+    );
+    dealSkill = await dealSkillRepository.save(
+      new DealSkill({ dealId: deal.id, skillId: skill.id }),
+    );
+
+    translations = await fieldTranslationRepository.save([
+      fieldTranslationRepository.create({
+        language: germanLanguage,
+        entityType: EntityTableName.LANGUAGE,
+        entityId: sourceLanguage.id,
+        translation: `Deutsche Übersetzung ${suffix}`,
+      }),
+      fieldTranslationRepository.create({
+        language: germanLanguage,
+        entityType: EntityTableName.SKILL,
+        entityId: skill.id,
+        translation: `Deutsche Fähigkeit ${suffix}`,
+      }),
+    ]);
+  });
+
+  afterAll(async () => {
+    const fieldTranslationRepository =
+      dataSource.getRepository(FieldTranslation);
+    const dealLanguageRepository = dataSource.getRepository(DealLanguage);
+    const dealSkillRepository = dataSource.getRepository(DealSkill);
+    const volunteerRepository = dataSource.getRepository(Volunteer);
+    const dealRepository = dataSource.getRepository(Deal);
+    const languageRepository = dataSource.getRepository(Language);
+    const skillRepository = dataSource.getRepository(Skill);
+    const postcodeRepository = dataSource.getRepository(Postcode);
+
+    await fieldTranslationRepository.delete(translations.map((t) => t.id));
+    await dealLanguageRepository.delete({ id: dealLanguage.id });
+    await dealSkillRepository.delete({ id: dealSkill.id });
+    await volunteerRepository.delete({ id: volunteer.id });
+    await dealRepository.delete({ id: deal.id });
+    await languageRepository.delete({ id: sourceLanguage.id });
+    await skillRepository.delete({ id: skill.id });
+    await postcodeRepository.delete({ id: postcode.id });
+    await fastify.close();
+  });
+
+  async function loadVolunteerWithRelations(): Promise<Volunteer> {
+    const v = await dataSource.getRepository(Volunteer).findOne({
+      where: { id: volunteer.id },
+      relations: ["deal.dealLanguage.language", "deal.dealSkill.skill"],
+    });
+    if (!v) {
+      throw new Error(`Volunteer ${volunteer.id} not found`);
+    }
+    return v;
+  }
+
+  it("populates .translation on dealLanguage/dealSkill entities from field_translation", async () => {
+    const v = await loadVolunteerWithRelations();
+
+    await addTranslatedFields([v], Lang.DE);
+
+    expect(v.deal.dealLanguage[0].language.translation).toBe(
+      `Deutsche Übersetzung ${suffix}`,
+    );
+    expect(v.deal.dealSkill[0].skill.translation).toBe(
+      `Deutsche Fähigkeit ${suffix}`,
+    );
+  });
+
+  it("leaves .translation unset when no field_translation row exists for the requested language", async () => {
+    const v = await loadVolunteerWithRelations();
+
+    // "en" is a real, seeded locale, but no field_translation row was
+    // created above for that language — the entity's own .translation
+    // (never populated for a fresh fetch) should stay untouched, letting the
+    // caller (getOptionItems/getLanguages) fall back to the raw .title.
+    await addTranslatedFields([v], Lang.EN);
+
+    expect(v.deal.dealLanguage[0].language.translation).toBeUndefined();
+    expect(v.deal.dealSkill[0].skill.translation).toBeUndefined();
+  });
+
+  it("does not throw when dealActivity isn't loaded (be#849 hardening)", async () => {
+    // Mirrors the actual notify-route call site: only dealLanguage/dealSkill
+    // are eager-loaded there, never dealActivity.
+    const v = await loadVolunteerWithRelations();
+    expect(v.deal.dealActivity).toBeUndefined();
+
+    await expect(addTranslatedFields([v], Lang.DE)).resolves.toBeUndefined();
+  });
+});

--- a/src/test/server/utils/data/add-translated-fields.test.ts
+++ b/src/test/server/utils/data/add-translated-fields.test.ts
@@ -1,29 +1,35 @@
 import { FastifyInstance } from "fastify";
-import { EntityTableName, Lang } from "need4deed-sdk";
+import { Lang } from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { dataSource } from "../../../../data/data-source";
 import Deal from "../../../../data/entity/deal.entity";
-import FieldTranslation from "../../../../data/entity/field_translation.entity";
 import Postcode from "../../../../data/entity/location/postcode.entity";
 import DealLanguage from "../../../../data/entity/m2m/deal-language";
 import DealSkill from "../../../../data/entity/m2m/deal-skill";
-import Language from "../../../../data/entity/profile/language.entity";
-import Skill from "../../../../data/entity/profile/skill.entity";
 import Volunteer from "../../../../data/entity/volunteer/volunteer.entity";
 import { DealType } from "../../../../data/types/enums";
 import { createServer } from "../../../../server";
 import { addTranslatedFields } from "../../../../server/utils/data/for-routes";
 
+// Deliberately reuses existing, already-seeded reference rows (language,
+// skill, field_translation) rather than inserting new ones — those tables
+// are reference data, not something a test should be writing into, even
+// temporarily. Only the transactional rows (postcode/deal/volunteer/
+// dealLanguage/dealSkill) linking to them are created and cleaned up here.
 describe("addTranslatedFields", () => {
   let fastify: FastifyInstance;
   let postcode: Postcode;
   let deal: Deal;
   let volunteer: Volunteer;
-  let sourceLanguage: Language;
-  let skill: Skill;
   let dealLanguage: DealLanguage;
   let dealSkill: DealSkill;
-  let translations: FieldTranslation[];
+
+  // German itself (id 1540) — has a real German field_translation ("Deutsch").
+  const languageWithGermanTranslation = 1540;
+  // "Ghotuo" (id 1) — a real, seeded language with no English translation.
+  const languageWithNoEnglishTranslation = 1;
+  // "Woodworking" (id 1) — has a real German field_translation ("Holzverarbeitung").
+  const skillWithGermanTranslation = 1;
 
   const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
 
@@ -34,18 +40,8 @@ describe("addTranslatedFields", () => {
     const postcodeRepository = dataSource.getRepository(Postcode);
     const dealRepository = dataSource.getRepository(Deal);
     const volunteerRepository = dataSource.getRepository(Volunteer);
-    const languageRepository = dataSource.getRepository(Language);
-    const skillRepository = dataSource.getRepository(Skill);
     const dealLanguageRepository = dataSource.getRepository(DealLanguage);
     const dealSkillRepository = dataSource.getRepository(DealSkill);
-    const fieldTranslationRepository =
-      dataSource.getRepository(FieldTranslation);
-
-    // The real, already-seeded German locale row — addTranslatedFields()
-    // resolves its `isoCode` argument to this exact row internally.
-    const germanLanguage = await languageRepository.findOneByOrFail({
-      isoCode: "de",
-    });
 
     postcode = await postcodeRepository.save(
       new Postcode({ value: `1${suffix.slice(-4)}` }),
@@ -57,54 +53,28 @@ describe("addTranslatedFields", () => {
       new Volunteer({ dealId: deal.id }),
     );
 
-    sourceLanguage = await languageRepository.save(
-      new Language({ isoCode: "xx", title: `Test Language ${suffix}` }),
-    );
-    skill = await skillRepository.save(
-      new Skill({ title: `Test Skill ${suffix}` }),
-    );
-
     dealLanguage = await dealLanguageRepository.save(
-      new DealLanguage({ dealId: deal.id, languageId: sourceLanguage.id }),
+      new DealLanguage({
+        dealId: deal.id,
+        languageId: languageWithGermanTranslation,
+      }),
     );
     dealSkill = await dealSkillRepository.save(
-      new DealSkill({ dealId: deal.id, skillId: skill.id }),
+      new DealSkill({ dealId: deal.id, skillId: skillWithGermanTranslation }),
     );
-
-    translations = await fieldTranslationRepository.save([
-      fieldTranslationRepository.create({
-        language: germanLanguage,
-        entityType: EntityTableName.LANGUAGE,
-        entityId: sourceLanguage.id,
-        translation: `Deutsche Übersetzung ${suffix}`,
-      }),
-      fieldTranslationRepository.create({
-        language: germanLanguage,
-        entityType: EntityTableName.SKILL,
-        entityId: skill.id,
-        translation: `Deutsche Fähigkeit ${suffix}`,
-      }),
-    ]);
   });
 
   afterAll(async () => {
-    const fieldTranslationRepository =
-      dataSource.getRepository(FieldTranslation);
     const dealLanguageRepository = dataSource.getRepository(DealLanguage);
     const dealSkillRepository = dataSource.getRepository(DealSkill);
     const volunteerRepository = dataSource.getRepository(Volunteer);
     const dealRepository = dataSource.getRepository(Deal);
-    const languageRepository = dataSource.getRepository(Language);
-    const skillRepository = dataSource.getRepository(Skill);
     const postcodeRepository = dataSource.getRepository(Postcode);
 
-    await fieldTranslationRepository.delete(translations.map((t) => t.id));
     await dealLanguageRepository.delete({ id: dealLanguage.id });
     await dealSkillRepository.delete({ id: dealSkill.id });
     await volunteerRepository.delete({ id: volunteer.id });
     await dealRepository.delete({ id: deal.id });
-    await languageRepository.delete({ id: sourceLanguage.id });
-    await skillRepository.delete({ id: skill.id });
     await postcodeRepository.delete({ id: postcode.id });
     await fastify.close();
   });
@@ -120,30 +90,33 @@ describe("addTranslatedFields", () => {
     return v;
   }
 
-  it("populates .translation on dealLanguage/dealSkill entities from field_translation", async () => {
+  it("populates .translation on dealLanguage/dealSkill entities from the real field_translation data", async () => {
     const v = await loadVolunteerWithRelations();
 
     await addTranslatedFields([v], Lang.DE);
 
-    expect(v.deal.dealLanguage[0].language.translation).toBe(
-      `Deutsche Übersetzung ${suffix}`,
-    );
-    expect(v.deal.dealSkill[0].skill.translation).toBe(
-      `Deutsche Fähigkeit ${suffix}`,
-    );
+    expect(v.deal.dealLanguage[0].language.translation).toBe("Deutsch");
+    expect(v.deal.dealSkill[0].skill.translation).toBe("Holzverarbeitung");
   });
 
-  it("leaves .translation unset when no field_translation row exists for the requested language", async () => {
+  it("leaves .translation unset when no field_translation row exists for the requested language, falling back to the original field value downstream", async () => {
+    const dealLanguageRepository = dataSource.getRepository(DealLanguage);
+    await dealLanguageRepository.update(
+      { id: dealLanguage.id },
+      { languageId: languageWithNoEnglishTranslation },
+    );
     const v = await loadVolunteerWithRelations();
 
-    // "en" is a real, seeded locale, but no field_translation row was
-    // created above for that language — the entity's own .translation
-    // (never populated for a fresh fetch) should stay untouched, letting the
-    // caller (getOptionItems/getLanguages) fall back to the raw .title.
     await addTranslatedFields([v], Lang.EN);
 
+    // getOptionItems/getLanguages then fall back to language.title itself.
     expect(v.deal.dealLanguage[0].language.translation).toBeUndefined();
-    expect(v.deal.dealSkill[0].skill.translation).toBeUndefined();
+    expect(v.deal.dealLanguage[0].language.title).toBe("Ghotuo");
+
+    await dealLanguageRepository.update(
+      { id: dealLanguage.id },
+      { languageId: languageWithGermanTranslation },
+    );
   });
 
   it("does not throw when dealActivity isn't loaded (be#849 hardening)", async () => {


### PR DESCRIPTION
## Summary

`emailIntroduction` (`volunteerSkills`, `volunteerLanguage`) and `emailAccompanyMatch` (`volunteerLanguage`) always showed each skill/language's raw `.title` instead of its German `field_translation` — even though these templates are German-only (be#838).

## Root cause

`Activity.translation`/`Skill.translation`/`Language.translation` are bare class properties — nothing populates them by default. The only place that ever did was `addTranslatedFields()` (`for-routes.ts`), called solely from the volunteer GET routes with a per-request language — never from the notify send path, so `getOptionItems()`/`getLanguages()` (`src/services/dto/utils.ts`) always fell through to the raw `.title` there.

## Fix

- Calls `addTranslatedFields([ov.volunteer], Lang.DE)` in `opportunity-volunteer.routes.ts` before dispatching either email, right after the OV/volunteer/deal fetch on the MATCHED transition.
- Hardens `addTranslatedFields` itself: it assumed all of `dealLanguage`/`dealActivity`/`dealSkill` were eager-loaded (iterating each directly), which crashes when a caller only loads a subset — exactly the notify route's case (no `dealActivity` relation, since no current email uses activity titles). Guards each with `?? []`.
- Also fixes a real pre-existing bug found while touching this function: its one prior call site (`fetchVolunteerById`) never awaited it, so translations weren't guaranteed to be populated before the volunteer got serialized.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:run` — full suite, 65 files / 554 tests
- [x] New `add-translated-fields.test.ts` — reuses existing, already-seeded reference data (German language id 1540, "Woodworking" skill id 1, "Ghotuo" language id 1 for the no-translation case) rather than inserting into `field_translation`/`skill`/`language`, which are reference tables. Only the transactional deal/volunteer/dealLanguage/dealSkill/postcode rows linking to them are created and cleaned up.

Closes #849