### PR TITLE
fix: persist onetimer on opportunity creation (be#844)

### DIFF
--- a/src/server/utils/data/write-opportunity-legacy.ts
+++ b/src/server/utils/data/write-opportunity-legacy.ts
@@ -6,6 +6,7 @@ import DealLanguage from "../../../data/entity/m2m/deal-language";
 import DealSkill from "../../../data/entity/m2m/deal-skill";
 import DealTimeslot from "../../../data/entity/m2m/deal-timeslot";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
+import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 
 export async function writeOpportunityLegacy(
@@ -27,6 +28,8 @@ export async function writeOpportunityLegacy(
       transactionalEntityManager.getRepository(DealDistrict);
     const accompanyingRepository =
       transactionalEntityManager.getRepository(Accompanying);
+    const onetimerRepository =
+      transactionalEntityManager.getRepository(Onetimer);
 
     await dealRepository.save(opportunity.deal);
 
@@ -59,6 +62,10 @@ export async function writeOpportunityLegacy(
 
     if (opportunity.accompanying) {
       await accompanyingRepository.save(opportunity.accompanying);
+    }
+
+    if (opportunity.onetimer) {
+      await onetimerRepository.save(opportunity.onetimer);
     }
 
     await opportunityRepository.save(opportunity);

--- a/src/test/server/routes/opportunity-create.routes.test.ts
+++ b/src/test/server/routes/opportunity-create.routes.test.ts
@@ -5,6 +5,7 @@ import { accessCookieName } from "../../../config/constants";
 import { dataSource } from "../../../data/data-source";
 import Address from "../../../data/entity/location/address.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
+import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import Person from "../../../data/entity/person.entity";
 import Activity from "../../../data/entity/profile/activity.entity";
@@ -150,5 +151,159 @@ describe("POST /opportunity resolves activities/skills/languages by id", () => {
     expect(saved.deal.dealLanguage.map((dl) => dl.language.id)).toEqual([
       language.id,
     ]);
+  });
+});
+
+// Regression test for be#844: Opportunity.onetimer had no explicit save in
+// writeOpportunityLegacy (unlike Opportunity.accompanying), so a freshly
+// built (no-id) Onetimer was silently dropped and onetimerId stayed null on
+// creation, for both ACCOMPANYING and EVENTS-type opportunities.
+describe("POST /opportunity persists onetimer on creation (be#844)", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let agent: Agent;
+  let addressId: number;
+  let postcodeValue: string;
+  const createdOpportunityIds: number[] = [];
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const addressRepository = getRepository(dataSource, Address);
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+    postcodeValue = postcode.value;
+    const address = await addressRepository.save(
+      new Address({ postcodeId: postcode.id }),
+    );
+    addressId = address.id;
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({
+        title: `Test Agent (onetimer-create) ${suffix}`,
+        addressId: address.id,
+      }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-onetimer-create-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-onetimer-create-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(res.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    for (const id of createdOpportunityIds) {
+      const opportunity = await fastify.db.opportunityRepository.findOne({
+        where: { id },
+      });
+      await fastify.db.opportunityRepository.delete({ id });
+      if (opportunity?.onetimerId) {
+        await fastify.db.onetimerRepository.delete({
+          id: opportunity.onetimerId,
+        });
+      }
+    }
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await getRepository(dataSource, Address).delete({ id: addressId });
+    await fastify.close();
+  });
+
+  it("creates and links a onetimer for an ACCOMPANYING-type opportunity", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/opportunity/",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        title: `Test Onetimer Accompanying ${suffix}`,
+        opportunity_type: OpportunityLegacyType.ACCOMPANYING,
+        volunteers_number: 1,
+        category: "",
+        category_id: "",
+        language: "en",
+        agent_id: agent.id,
+        accomp_address: "Teststraße 1",
+        accomp_postcode: postcodeValue,
+        accomp_datetime: "2026-08-28T13:55:00",
+        accomp_name: "John Doe",
+        accomp_phone: "420-024",
+        accomp_translation: "deutsche",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const createdId = res.json().data.id;
+    createdOpportunityIds.push(createdId);
+
+    const saved = await fastify.db.opportunityRepository.findOneOrFail({
+      where: { id: createdId },
+    });
+    expect(saved.onetimerId).toBeTruthy();
+
+    const onetimer = await getRepository(dataSource, Onetimer).findOneByOrFail({
+      id: saved.onetimerId,
+    });
+    expect(new Date(onetimer.date).toISOString().slice(0, 10)).toBe(
+      "2026-08-28",
+    );
+  });
+
+  it("creates and links a onetimer for an EVENTS-type opportunity", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/opportunity/",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        title: `Test Onetimer Events ${suffix}`,
+        opportunity_type: OpportunityLegacyType.VOLUNTEERING,
+        volunteers_number: 1,
+        category: "",
+        category_id: "",
+        language: "en",
+        agent_id: agent.id,
+        onetime_date_time: "2026-09-15T18:00:00",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const createdId = res.json().data.id;
+    createdOpportunityIds.push(createdId);
+
+    const saved = await fastify.db.opportunityRepository.findOneOrFail({
+      where: { id: createdId },
+    });
+    expect(saved.onetimerId).toBeTruthy();
+
+    const onetimer = await getRepository(dataSource, Onetimer).findOneByOrFail({
+      id: saved.onetimerId,
+    });
+    expect(new Date(onetimer.date).toISOString().slice(0, 10)).toBe(
+      "2026-09-15",
+    );
   });
 });

--- a/src/test/server/routes/opportunity-create.routes.test.ts
+++ b/src/test/server/routes/opportunity-create.routes.test.ts
@@ -3,7 +3,9 @@ import { OpportunityLegacyType, UserRole } from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accessCookieName } from "../../../config/constants";
 import { dataSource } from "../../../data/data-source";
+import Deal from "../../../data/entity/deal.entity";
 import Address from "../../../data/entity/location/address.entity";
+import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
@@ -220,7 +222,20 @@ describe("POST /opportunity persists onetimer on creation (be#844)", () => {
       const opportunity = await fastify.db.opportunityRepository.findOne({
         where: { id },
       });
+      // Deletion order matters: opportunity first (it holds the FKs), then
+      // its deal/accompanying/onetimer — deal_timeslot cascades with the
+      // deal, so no separate cleanup is needed for it.
       await fastify.db.opportunityRepository.delete({ id });
+      if (opportunity?.dealId) {
+        await getRepository(dataSource, Deal).delete({
+          id: opportunity.dealId,
+        });
+      }
+      if (opportunity?.accompanyingId) {
+        await getRepository(dataSource, Accompanying).delete({
+          id: opportunity.accompanyingId,
+        });
+      }
       if (opportunity?.onetimerId) {
         await fastify.db.onetimerRepository.delete({
           id: opportunity.onetimerId,
@@ -274,6 +289,13 @@ describe("POST /opportunity persists onetimer on creation (be#844)", () => {
   });
 
   it("creates and links a onetimer for an EVENTS-type opportunity", async () => {
+    // Unique per test run (not a fixed literal): buildDealTimeslots() also
+    // finds-or-creates a Timeslot row for this date, which we don't clean up
+    // below (matching existing convention elsewhere in this suite) — a fixed
+    // literal would keep matching the same row and mask the leftover Deal/
+    // DealTimeslot rows this regression guards against (be#844 review).
+    const eventDateTime = new Date(Date.now() + 200 * 24 * 60 * 60 * 1000);
+
     const res = await fastify.inject({
       method: "POST",
       url: "/opportunity/",
@@ -286,7 +308,7 @@ describe("POST /opportunity persists onetimer on creation (be#844)", () => {
         category_id: "",
         language: "en",
         agent_id: agent.id,
-        onetime_date_time: "2026-09-15T18:00:00",
+        onetime_date_time: eventDateTime.toISOString(),
       },
     });
 
@@ -303,7 +325,7 @@ describe("POST /opportunity persists onetimer on creation (be#844)", () => {
       id: saved.onetimerId,
     });
     expect(new Date(onetimer.date).toISOString().slice(0, 10)).toBe(
-      "2026-09-15",
+      eventDateTime.toISOString().slice(0, 10),
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes be#844. `Opportunity.onetimer` (like `Opportunity.accompanying`) is a plain `@ManyToOne` with no `cascade` option, so a freshly built (no-id) `Onetimer` was silently dropped when the parent `Opportunity` was saved — `onetimerId` stayed `null` with no error. This affected `POST /opportunity` and `POST /opportunity/legacy` identically for both ACCOMPANYING and EVENTS-type creation, since both funnel through `writeOpportunityLegacy`.

## Changes

- `write-opportunity-legacy.ts`: added an explicit `onetimerRepository.save(opportunity.onetimer)` before the parent `opportunityRepository.save(opportunity)`, mirroring the existing `accompanying` save.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:run` — full suite, 65 files / 559 tests
- [x] New regression tests in `opportunity-create.routes.test.ts` covering `POST /opportunity` creation for both ACCOMPANYING and EVENTS types, asserting a populated `onetimerId` and correct date. Verified both fail (onetimerId null) without the fix and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)