### PR TITLE
fix: derive accompanying email's appointment language from the deal (be#856)

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -4,6 +4,7 @@ import {
   ApiOpportunityPatch,
   CommunicationType,
   EntityTableName,
+  Lang,
   OpportunityFormDataWithAgentSubmitter,
   OpportunityLegacyFormData,
   OpportunityLegacyType,
@@ -74,6 +75,7 @@ import {
   upsertOnetimer,
   writeOpportunityLegacy,
 } from "../../utils";
+import { addTranslatedFields } from "../../utils/data/for-routes";
 import { logEmailCommunication } from "../../utils/data/log-email-communication";
 import {
   makePiiSerialization,
@@ -488,6 +490,7 @@ export default async function opportunityRoutes(
                 "accompanying",
                 "accompanying.postcode",
                 "onetimer",
+                "deal.dealLanguage.language",
                 "submittedByPerson",
                 "submittedByPerson.users",
                 "contactPerson",
@@ -496,7 +499,14 @@ export default async function opportunityRoutes(
                 "agent.agentPerson.person.users",
                 "district",
               ],
-              (opp) => fastify.notify.emailNewAccompanying(opp),
+              async (opp) => {
+                // The email's appointment-language field is the deal's own
+                // requested languages, German-translated via field_translation
+                // (be#856) — not the accompanying.languageToTranslate label
+                // used elsewhere in the same email.
+                await addTranslatedFields([opp], Lang.DE);
+                await fastify.notify.emailNewAccompanying(opp);
+              },
               "emailNewAccompanying",
             );
           } catch (err) {

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -27,6 +27,7 @@ import { BadRequestError, NotFoundError } from "../../../config";
 import { defaultPageSize } from "../../../config/constants";
 import { dataSource } from "../../../data/data-source";
 import Comment from "../../../data/entity/comment.entity";
+import Deal from "../../../data/entity/deal.entity";
 import Document from "../../../data/entity/document.entity";
 import FieldTranslation from "../../../data/entity/field_translation.entity";
 import Address from "../../../data/entity/location/address.entity";
@@ -125,8 +126,11 @@ export async function getInstanceByTranslation<
   return null;
 }
 
+// Volunteer and Opportunity both structurally satisfy this shape, so either
+// can be passed directly — a Volunteer's own deal, or an Opportunity's
+// posting-side deal, use the same field_translation lookup (be#856).
 export async function addTranslatedFields(
-  volunteers: Volunteer[],
+  entities: { id: number; deal?: Deal }[],
   isoCode: Lang,
 ) {
   let language: Language;
@@ -143,14 +147,14 @@ export async function addTranslatedFields(
     logger.warn(`Error loading language: ${error}`);
     throw new Error(error.message);
   }
-  logger.info("Translating volunteers");
-  for (const volunteer of volunteers) {
+  logger.info("Translating deal fields");
+  for (const entity of entities) {
     try {
-      // `?? []` guards below: this is also called from the notify path
-      // (be#849) with only a subset of deal relations loaded — e.g. no
+      // `?? []` guards below: this is also called from notify paths (be#849,
+      // be#856) with only a subset of deal relations loaded — e.g. no
       // dealActivity — so it must not assume every caller eager-loaded all
       // three, only whichever ones it actually needs translated.
-      for (const pl of volunteer.deal?.dealLanguage ?? []) {
+      for (const pl of entity.deal?.dealLanguage ?? []) {
         const translation = await fieldTranslationRepository.findOne({
           where: {
             language,
@@ -162,7 +166,7 @@ export async function addTranslatedFields(
           ? translation?.translation
           : pl.language.translation;
       }
-      for (const pa of volunteer.deal?.dealActivity ?? []) {
+      for (const pa of entity.deal?.dealActivity ?? []) {
         const translation = await fieldTranslationRepository.findOne({
           where: {
             language,
@@ -174,7 +178,7 @@ export async function addTranslatedFields(
           ? translation?.translation
           : pa.activity.translation;
       }
-      for (const ps of volunteer.deal?.dealSkill ?? []) {
+      for (const ps of entity.deal?.dealSkill ?? []) {
         const translation = await fieldTranslationRepository.findOne({
           where: {
             language,
@@ -188,7 +192,7 @@ export async function addTranslatedFields(
       }
     } catch (error) {
       logger.warn(
-        `Error occurred while adding translations to a volunteer id:${volunteer.id} ${error}`,
+        `Error occurred while adding translations to entity id:${entity.id} ${error}`,
       );
     }
   }

--- a/src/services/notify/events/email-new-accompanying.ts
+++ b/src/services/notify/events/email-new-accompanying.ts
@@ -68,15 +68,19 @@ export async function sendEmailNewAccompanying(
   const clientName = accompanying?.name ?? "";
   const appointmentTitle = opportunity.title;
   const appointmentAddress = accompanying?.address ?? "";
-  // Both slots come from the same submission field (be#846) — there's no
-  // second, independently-set value anywhere in the codebase today
-  // (opportunity.translationType has no other reader or writer besides this
-  // one email). Mapped to the same human-readable label rather than left as
-  // the raw enum value ("deutsche").
+  // accompaniedpersonLanguage: the translation requirement for the
+  // accompanied person (be#846). appointmentaLanguage: the deal's own
+  // requested languages — a distinct concept, German-translated via
+  // field_translation by the caller before this function runs (be#856).
   const accompaniedpersonLanguage = translationLabel(
     accompanying?.languageToTranslate,
   );
-  const appointmentaLanguage = accompaniedpersonLanguage;
+  const appointmentaLanguage = (opportunity.deal?.dealLanguage ?? [])
+    .map(
+      (dealLanguage) =>
+        dealLanguage.language.translation ?? dealLanguage.language.title,
+    )
+    .join(", ");
   const accompaniedpersonName = accompanying?.name ?? "";
   const accompaniedpersonPhone = accompanying?.phone ?? "";
   const appointmentComment = opportunity.info ?? "";

--- a/src/test/services/notify/email-new-accompanying.test.ts
+++ b/src/test/services/notify/email-new-accompanying.test.ts
@@ -82,11 +82,34 @@ describe("sendEmailNewAccompanying", () => {
     expect(msg.text).not.toContain("deutsche");
   });
 
-  it("renders the same label for both language slots (single source of truth)", async () => {
-    await sendEmailNewAccompanying(email, buildOpportunity());
+  // be#856: appointmentaLanguage previously aliased accompaniedpersonLanguage
+  // (the be#846 fix collapsed two distinct concepts into one to kill the
+  // duplicated-raw-enum bug). It must instead reflect the deal's own
+  // requested languages, independent of the translation-requirement label.
+  it("derives appointmentaLanguage from the deal's own dealLanguage entries, translated (be#856)", async () => {
+    await sendEmailNewAccompanying(
+      email,
+      buildOpportunity({
+        deal: {
+          dealLanguage: [
+            { language: { title: "German", translation: "Deutsch" } },
+            { language: { title: "English", translation: undefined } },
+          ],
+        },
+      }),
+    );
 
     const msg = send.mock.calls[0][0];
-    expect(msg.text).toContain("Deutsch oder Englisch, Deutsch oder Englisch");
+    expect(msg.text).toContain(
+      "Sprachen: Deutsch oder Englisch, Deutsch, English",
+    );
+  });
+
+  it("renders an empty appointmentaLanguage when the deal has no languages", async () => {
+    await sendEmailNewAccompanying(email, buildOpportunity({ deal: {} }));
+
+    const msg = send.mock.calls[0][0];
+    expect(msg.text).toContain("Sprachen: Deutsch oder Englisch, \n");
   });
 
   it("renders an empty label when languageToTranslate is unset", async () => {


### PR DESCRIPTION
## Summary

Fixes be#856. The NEW_ACCOMPANYING email's "Sprachen: X, Y" line rendered the same value twice: `Sprachen: Deutsch oder Englisch, Deutsch oder Englisch`. The be#846 fix mapped the raw enum value to a human-readable label but aliased both template slots to that single value — they represent different concepts:

- `accompaniedpersonLanguage` — the translation requirement for the accompanied person (`accompanying.languageToTranslate`). Unchanged, still correct.
- `appointmentaLanguage` — should be the opportunity's own deal languages (`deal.dealLanguage[].language`), German-translated via `field_translation`, independent of the translation-requirement label.

## Changes

- `src/server/utils/data/for-routes.ts`: generalized `addTranslatedFields()` to accept `{ id, deal }`-shaped entities instead of `Volunteer[]` specifically — `Opportunity` satisfies the same shape, so the existing field_translation lookup (be#849) is reused rather than duplicated.
- `src/server/routes/opportunity/opportunity.routes.ts`: added the missing `deal.dealLanguage.language` relation to the ACCOMPANYING email's eager-load list, and call `addTranslatedFields([opp], Lang.DE)` before `emailNewAccompanying`.
- `src/services/notify/events/email-new-accompanying.ts`: `appointmentaLanguage` is now built from `opportunity.deal?.dealLanguage`, using each language's German translation with a fallback to its original title.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:run` — full suite, 66 files / 572 tests
- [x] Updated `email-new-accompanying.test.ts`: replaced the test that asserted the old (buggy) "same label twice" behavior with tests asserting `appointmentaLanguage` is derived from `deal.dealLanguage`, translated with fallback, and empty when the deal has no languages.
- [x] Confirmed `add-translated-fields.test.ts` (Volunteer-based) still passes unchanged against the generalized signature.
- [x] Verified regression: reverted the fix locally, confirmed the new tests fail (still duplicated), restored it and confirmed they pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)