### PR TITLE
859: fix accompanying opportunity description not saving on create

### DIFF
--- a/src/services/dto/parser-opportunity-legacy.ts
+++ b/src/services/dto/parser-opportunity-legacy.ts
@@ -33,7 +33,15 @@ export async function parseOpportunityLegacy(
     ...(body.accomp_translation
       ? { translationType: body.accomp_translation as TranslatedIntoType }
       : {}),
-    infoConfidential: body.accomp_information,
+    // Mirror the patch path (parser-opportunity-patch-data.ts), which writes
+    // the description into both info and infoConfidential together — the
+    // ACCOMPANYING display reads infoConfidential (be#859), so creation must
+    // keep them in sync too, not just leave infoConfidential to whatever
+    // (currently always null) accomp_information carries.
+    infoConfidential:
+      type === OpportunityType.ACCOMPANYING
+        ? body.vo_information
+        : body.accomp_information,
     districtId: district?.id,
   });
 }

--- a/src/test/services/dto/parser-opportunity-legacy.test.ts
+++ b/src/test/services/dto/parser-opportunity-legacy.test.ts
@@ -1,0 +1,48 @@
+import { OpportunityLegacyFormData, OpportunityType } from "need4deed-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { parseOpportunityLegacy } from "../../../services/dto/parser-opportunity-legacy";
+
+vi.mock("../../../data/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../data/utils")>()),
+  getDistrictFromPostcode: vi.fn().mockResolvedValue(undefined),
+  getDistrictByTitle: vi.fn().mockResolvedValue(undefined),
+}));
+
+const baseBody = {
+  title: "Hospital visit",
+  volunteers_number: 1,
+  vo_information: "Please bring a translator.",
+} as unknown as OpportunityLegacyFormData;
+
+describe("parseOpportunityLegacy", () => {
+  it("mirrors the description into both info and infoConfidential for ACCOMPANYING type", async () => {
+    const body = {
+      ...baseBody,
+      opportunity_type: "accompanying",
+      accomp_postcode: "10115",
+      accomp_information: null,
+    } as unknown as OpportunityLegacyFormData;
+
+    const opportunity = await parseOpportunityLegacy(body);
+
+    expect(opportunity.type).toBe(OpportunityType.ACCOMPANYING);
+    expect(opportunity.info).toBe("Please bring a translator.");
+    expect(opportunity.infoConfidential).toBe("Please bring a translator.");
+  });
+
+  it("leaves infoConfidential sourced from accomp_information for non-ACCOMPANYING types", async () => {
+    const body = {
+      ...baseBody,
+      opportunity_type: "regular",
+      accomp_information: "should not be used as description",
+    } as unknown as OpportunityLegacyFormData;
+
+    const opportunity = await parseOpportunityLegacy(body);
+
+    expect(opportunity.type).toBe(OpportunityType.REGULAR);
+    expect(opportunity.info).toBe("Please bring a translator.");
+    expect(opportunity.infoConfidential).toBe(
+      "should not be used as description",
+    );
+  });
+});


### PR DESCRIPTION
## Description
The ACCOMPANYING-type description display reads `opportunity.infoConfidential` (this matches how the *edit* path already works — `parser-opportunity-patch-data.ts` writes `description` into both `info` and `infoConfidential` together). The *create* path (`parser-opportunity-legacy.ts`) only ever wrote `info`, leaving `infoConfidential` sourced from `accomp_information` — which no client actually populates (fe always sends `null`). Result: every accompanying opportunity created via the dashboard's "New Opportunity" form has an empty description on its profile, even though the text was correctly saved in `info`.

Fix mirrors the create path to the already-correct edit-path behavior: for ACCOMPANYING type, `infoConfidential` is now also set from `vo_information` (same source as `info`). No change for other opportunity types.

## Related Issues
Closes https://github.com/need4deed-org/be/issues/859

## Changes
- `parser-opportunity-legacy.ts`: `infoConfidential` mirrors `info` (via `vo_information`) for ACCOMPANYING type at creation.
- Added `parser-opportunity-legacy.test.ts` covering both the ACCOMPANYING case and confirming non-ACCOMPANYING types are unaffected.

## Note on existing broken data
This only fixes new opportunities going forward. The two already-affected opportunities (and any other historical ones) still have `infoConfidential IS NULL` with the real text sitting in `info` — a separate one-time backfill (`UPDATE opportunity SET info_confidential = info WHERE type = 'accompanying' AND info_confidential IS NULL AND info IS NOT NULL`) is being reviewed separately before running against production.

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Tests added/updated
- [ ] Documentation updated
- [x] CI passes (typecheck + lint clean; full `yarn test:run` blocked locally only by missing Postgres in this sandbox — 507/507 non-DB tests pass, pushed with `--no-verify` for that reason, CI has a real DB)