### PR TITLE
fix: stop new agent contacts from retroactively attaching to existing requests (be#833)

### DIFF
--- a/src/data/migrations/1786096580655-backfill-opportunity-contact-person.ts
+++ b/src/data/migrations/1786096580655-backfill-opportunity-contact-person.ts
@@ -1,0 +1,87 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// One-shot data migration for be#833: freeze contact_person_id on every
+// opportunity that doesn't have one yet, so it stops being recomputed live.
+//
+// Bug: getOpportunityContact (src/services/dto/dto-opportunity.ts) falls back,
+// on every read, to the opportunity's agent's *current* representative
+// whenever contact_person_id is null. Historically almost no creation path
+// set contact_person_id (only the legacy public form does), so most
+// opportunities depend on that live fallback — meaning adding a brand new
+// contact to an agent (especially its first, or one marked
+// volunteer-coordinator) instantly changes the displayed/emailed contact for
+// every one of that agent's pre-existing opportunities.
+//
+// This migration snapshots today's resolution for each affected row so it
+// stops drifting: the submitter, if they're currently a member of the
+// opportunity's agent; else the agent's volunteer-coordinator; else the
+// agent's earliest-registered contact (mirroring Agent.representative,
+// src/data/entity/opportunity/agent.entity.ts:121-129, which has no
+// deterministic ordering of its own, so "earliest by id" approximates its
+// typical unordered-query result). This does NOT correct any opportunity
+// that is already showing a wrong contact today — that still requires the
+// existing manual relink tool (be#824, PATCH /opportunity/:id contact.id) —
+// it only stops today's value from being disturbed by future contact changes.
+//
+// Idempotent: only touches opportunities whose contact_person_id is null.
+// Self-contained: raw SQL only, no entities/app helpers/SDK enums.
+// 'volunteer-coordinator' is the AgentRoleType.VOLUNTEER_COORDINATOR value at
+// this migration; hardcoded so a later enum rename can't alter what this
+// historical migration reads.
+export class BackfillOpportunityContactPerson1786096580655
+  implements MigrationInterface
+{
+  name = "BackfillOpportunityContactPerson1786096580655";
+
+  private static readonly RESOLVED_CONTACT_SQL = `
+    COALESCE(
+      (
+        SELECT o.submitted_by_person_id
+        WHERE o.submitted_by_person_id IS NOT NULL
+          AND EXISTS (
+            SELECT 1 FROM agent_person ap
+            WHERE ap.agent_id = o.agent_id
+              AND ap.person_id = o.submitted_by_person_id
+          )
+      ),
+      (
+        SELECT ap.person_id FROM agent_person ap
+        WHERE ap.agent_id = o.agent_id AND ap.role = 'volunteer-coordinator'
+        ORDER BY ap.id ASC LIMIT 1
+      ),
+      (
+        SELECT ap.person_id FROM agent_person ap
+        WHERE ap.agent_id = o.agent_id
+        ORDER BY ap.id ASC LIMIT 1
+      )
+    )
+  `;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const result = await queryRunner.query(`
+      UPDATE opportunity o
+      SET contact_person_id = ${BackfillOpportunityContactPerson1786096580655.RESOLVED_CONTACT_SQL}
+      WHERE o.contact_person_id IS NULL
+        AND o.agent_id IS NOT NULL
+    `);
+    console.warn(
+      `[backfill-opportunity-contact-person] updated ${result[1] ?? "unknown"} row(s)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Narrow the reversal to opportunities whose current contact_person_id
+    // still equals what up()'s resolution would produce today. A row that
+    // up() left untouched (already had a stored contact from the legacy
+    // route or a manual relink) is only nulled here if it happens to
+    // coincidentally match that formula. Not perfectly correct, but much
+    // closer to "undo what up() did" than a blanket UPDATE (same tradeoff as
+    // 1780169787517-backfill-opportunity-submitted-by-person.ts).
+    await queryRunner.query(`
+      UPDATE opportunity o
+      SET contact_person_id = NULL
+      WHERE o.agent_id IS NOT NULL
+        AND o.contact_person_id = ${BackfillOpportunityContactPerson1786096580655.RESOLVED_CONTACT_SQL}
+    `);
+  }
+}

--- a/src/data/utils/get-opportunity-representative-person.ts
+++ b/src/data/utils/get-opportunity-representative-person.ts
@@ -1,23 +1,30 @@
 import Opportunity from "../entity/opportunity/opportunity.entity";
 import Person from "../entity/person.entity";
 
-// Resolves the person to notify/contact for an opportunity: the submitter,
-// else the legacy contact person (kept for opportunities that predate
-// `submittedByPerson`), else the opportunity's agent's current
-// representative. Requires `submittedByPerson`, `contactPerson`, and
+// Resolves the person to notify/contact for an opportunity: the stored
+// contact person (the authoritative value — set at creation or via a manual
+// relink, be#824), else the submitter, else the opportunity's agent's
+// current representative. Requires `submittedByPerson`, `contactPerson`, and
 // `agent.agentPerson.person` to be eager-loaded as needed by the caller.
 //
+// contactPerson is checked first (be#833): it's the one value here that's
+// either explicitly set or deliberately corrected by staff, so it must win
+// over the submitter and can't be allowed to drift with agent.representative
+// — a live, unstable value that changes as soon as the agent's contact list
+// changes, which would otherwise silently redirect notifications for old
+// opportunities to whoever was just added.
+//
 // Prefers whichever candidate actually has an email over just the first
-// non-null one: a submitter can be a Person with no email of its own (e.g.
-// an internal coordinator account, whose email lives on their User row, not
-// their Person row) — in that case we still want to fall through to a
-// representative we can actually reach.
+// non-null one: a person can have no email of its own (e.g. an internal
+// coordinator account, whose email lives on their User row, not their Person
+// row) — in that case we still want to fall through to someone we can
+// actually reach.
 export function getOpportunityRepresentativePerson(
   opportunity: Opportunity,
 ): Person | undefined {
   const candidates = [
-    opportunity.submittedByPerson,
     opportunity.contactPerson,
+    opportunity.submittedByPerson,
     opportunity.agent?.representative?.person,
   ];
   return candidates.find((person) => person?.email) ?? candidates.find(Boolean);

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -383,7 +383,7 @@ export default async function opportunityRoutes(
       }
       const agent = await fastify.db.agentRepository.findOne({
         where: { id: agentId },
-        relations: ["address.postcode"],
+        relations: ["address.postcode", "agentPerson"],
       });
       if (!agent) {
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
@@ -447,6 +447,19 @@ export default async function opportunityRoutes(
       // Submitter: the explicit body value, else the authenticated caller.
       opportunity.submittedByPersonId =
         body.submitted_by_id ?? request.authUser?.personId;
+      // Snapshot the contact at creation time (be#833): if this is left null,
+      // getOpportunityContact falls back at *read* time to agent.representative,
+      // which drifts every time the agent's contact list changes — so an
+      // unrelated request years later can silently reattribute this
+      // opportunity to whoever was just added. Freeze it now to whoever is
+      // actually the submitter's agent membership, or the agent's current
+      // representative if the submitter isn't one (e.g. a coordinator
+      // creating on the agent's behalf).
+      opportunity.contactPersonId = agent.agentPerson?.some(
+        (ap) => ap.personId === opportunity.submittedByPersonId,
+      )
+        ? opportunity.submittedByPersonId
+        : agent.representative?.personId;
 
       const { addDistrictToOpportunity } = getDistrictToOpportunityHandler();
       Object.assign(opportunity, await addDistrictToOpportunity(opportunity));

--- a/src/test/data/utils/get-opportunity-representative-person.test.ts
+++ b/src/test/data/utils/get-opportunity-representative-person.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { getOpportunityRepresentativePerson } from "../../../data/utils/get-opportunity-representative-person";
+
+describe("getOpportunityRepresentativePerson", () => {
+  it("prefers the stored contactPerson over submittedByPerson (be#833)", () => {
+    // A manual relink (be#824) or the creation-time snapshot (be#833) is the
+    // authoritative, deliberately-set value — it must win even though the
+    // submitter also has an email.
+    const opportunity = {
+      contactPerson: { id: 1, email: "contact@center.de" },
+      submittedByPerson: { id: 2, email: "submitter@center.de" },
+      agent: { representative: { person: { id: 3, email: "rep@center.de" } } },
+    };
+
+    const result = getOpportunityRepresentativePerson(opportunity as any);
+
+    expect(result?.id).toBe(1);
+  });
+
+  it("falls back to submittedByPerson when there is no stored contactPerson", () => {
+    const opportunity = {
+      contactPerson: undefined,
+      submittedByPerson: { id: 2, email: "submitter@center.de" },
+      agent: { representative: { person: { id: 3, email: "rep@center.de" } } },
+    };
+
+    const result = getOpportunityRepresentativePerson(opportunity as any);
+
+    expect(result?.id).toBe(2);
+  });
+
+  it("falls back to the agent representative when neither contactPerson nor submittedByPerson is set", () => {
+    const opportunity = {
+      contactPerson: undefined,
+      submittedByPerson: undefined,
+      agent: { representative: { person: { id: 3, email: "rep@center.de" } } },
+    };
+
+    const result = getOpportunityRepresentativePerson(opportunity as any);
+
+    expect(result?.id).toBe(3);
+  });
+
+  it("skips a candidate with no email in favor of one that has it", () => {
+    const opportunity = {
+      contactPerson: { id: 1, email: undefined },
+      submittedByPerson: { id: 2, email: "submitter@center.de" },
+      agent: { representative: { person: { id: 3, email: "rep@center.de" } } },
+    };
+
+    const result = getOpportunityRepresentativePerson(opportunity as any);
+
+    expect(result?.id).toBe(2);
+  });
+
+  it("falls back to a candidate without an email when none has one", () => {
+    const opportunity = {
+      contactPerson: { id: 1, email: undefined },
+      submittedByPerson: undefined,
+      agent: { representative: undefined },
+    };
+
+    const result = getOpportunityRepresentativePerson(opportunity as any);
+
+    expect(result?.id).toBe(1);
+  });
+});

--- a/src/test/server/routes/opportunity-create.routes.test.ts
+++ b/src/test/server/routes/opportunity-create.routes.test.ts
@@ -1,10 +1,11 @@
 import { FastifyInstance } from "fastify";
-import { OpportunityLegacyType, UserRole } from "need4deed-sdk";
+import { AgentRoleType, OpportunityLegacyType, UserRole } from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accessCookieName } from "../../../config/constants";
 import { dataSource } from "../../../data/data-source";
 import Deal from "../../../data/entity/deal.entity";
 import Address from "../../../data/entity/location/address.entity";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Agent from "../../../data/entity/opportunity/agent.entity";
 import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
@@ -327,5 +328,154 @@ describe("POST /opportunity persists onetimer on creation (be#844)", () => {
     expect(new Date(onetimer.date).toISOString().slice(0, 10)).toBe(
       eventDateTime.toISOString().slice(0, 10),
     );
+  });
+});
+
+// Regression test for be#833: adding a new contact to an agent must not
+// retroactively change which contact an already-existing opportunity shows.
+// POST /opportunity now snapshots contact_person_id at creation time instead
+// of leaving it null (which used to make getOpportunityContact re-derive it,
+// live, from the agent's *current* representative on every read).
+describe("POST /opportunity freezes contact_person_id at creation (be#833)", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let agent: Agent;
+  let addressId: number;
+  let existingContact: Person;
+  const createdOpportunityIds: number[] = [];
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const addressRepository = getRepository(dataSource, Address);
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+    const address = await addressRepository.save(
+      new Address({ postcodeId: postcode.id }),
+    );
+    addressId = address.id;
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (contact-freeze) ${suffix}`, addressId }),
+    );
+
+    existingContact = await fastify.db.personRepository.save(
+      new Person({
+        firstName: "Alice",
+        lastName: "Existing",
+        email: `alice-contact-freeze-${suffix}@test.need4deed.org`,
+      }),
+    );
+    await getRepository(dataSource, AgentPerson).save(
+      new AgentPerson({
+        agentId: agent.id,
+        personId: existingContact.id,
+        role: AgentRoleType.VOLUNTEER_COORDINATOR,
+      }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-contact-freeze-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-contact-freeze-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(res.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    for (const id of createdOpportunityIds) {
+      const opportunity = await fastify.db.opportunityRepository.findOne({
+        where: { id },
+      });
+      await fastify.db.opportunityRepository.delete({ id });
+      if (opportunity?.dealId) {
+        await getRepository(dataSource, Deal).delete({
+          id: opportunity.dealId,
+        });
+      }
+    }
+    await getRepository(dataSource, AgentPerson).delete({ agentId: agent.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: existingContact.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await getRepository(dataSource, Address).delete({ id: addressId });
+    await fastify.close();
+  });
+
+  it("sets contact_person_id to the agent's representative at creation, and it stays put after a new contact is added", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/opportunity/",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        title: `Test Opportunity (contact-freeze) ${suffix}`,
+        opportunity_type: OpportunityLegacyType.VOLUNTEERING,
+        volunteers_number: 1,
+        category: "",
+        category_id: "",
+        language: "en",
+        agent_id: agent.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const createdId = res.json().data.id;
+    createdOpportunityIds.push(createdId);
+
+    const opportunityRepository = getRepository(dataSource, Opportunity);
+    const savedBefore = await opportunityRepository.findOneOrFail({
+      where: { id: createdId },
+    });
+    // The coordinator who created this isn't an agent member, so contact
+    // resolves to the agent's sole (volunteer-coordinator) contact.
+    expect(savedBefore.contactPersonId).toBe(existingContact.id);
+
+    // Now add a brand new contact to the agent, with the same role — this is
+    // exactly the action the bug report describes as retroactively hijacking
+    // the contact shown on already-existing requests.
+    const newContact = await fastify.db.personRepository.save(
+      new Person({ firstName: "Bob", lastName: "NewContact" }),
+    );
+    await getRepository(dataSource, AgentPerson).save(
+      new AgentPerson({
+        agentId: agent.id,
+        personId: newContact.id,
+        role: AgentRoleType.VOLUNTEER_COORDINATOR,
+      }),
+    );
+
+    const savedAfter = await opportunityRepository.findOneOrFail({
+      where: { id: createdId },
+    });
+    expect(savedAfter.contactPersonId).toBe(existingContact.id);
+
+    await getRepository(dataSource, AgentPerson).delete({
+      agentId: agent.id,
+      personId: newContact.id,
+    });
+    await fastify.db.personRepository.delete({ id: newContact.id });
   });
 });

--- a/src/test/server/routes/opportunity-create.routes.test.ts
+++ b/src/test/server/routes/opportunity-create.routes.test.ts
@@ -342,6 +342,8 @@ describe("POST /opportunity freezes contact_person_id at creation (be#833)", () 
 
   let coordinatorPerson: Person;
   let coordinatorCookie: string;
+  let memberPerson: Person;
+  let memberCookie: string;
   let agent: Agent;
   let addressId: number;
   let existingContact: Person;
@@ -402,6 +404,42 @@ describe("POST /opportunity freezes contact_person_id at creation (be#833)", () 
       },
     });
     coordinatorCookie = getCookie(res.cookies, accessCookieName);
+
+    // A genuine member of the agent, distinct from its volunteer-coordinator
+    // representative — used to prove the "submitter is an agent member"
+    // branch stores the submitter, not the representative.
+    memberPerson = await fastify.db.personRepository.save(
+      new Person({
+        firstName: "Carol",
+        lastName: "Member",
+        email: `carol-contact-freeze-${suffix}@test.need4deed.org`,
+      }),
+    );
+    await getRepository(dataSource, AgentPerson).save(
+      new AgentPerson({
+        agentId: agent.id,
+        personId: memberPerson.id,
+        role: AgentRoleType.SOCIAL_WORKER,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `member-contact-freeze-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: memberPerson.id,
+      }),
+    );
+    const memberRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `member-contact-freeze-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    memberCookie = getCookie(memberRes.cookies, accessCookieName);
   });
 
   afterAll(async () => {
@@ -419,6 +457,8 @@ describe("POST /opportunity freezes contact_person_id at creation (be#833)", () 
     await getRepository(dataSource, AgentPerson).delete({ agentId: agent.id });
     await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
     await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.userRepository.delete({ personId: memberPerson.id });
+    await fastify.db.personRepository.delete({ id: memberPerson.id });
     await fastify.db.personRepository.delete({ id: existingContact.id });
     await fastify.db.agentRepository.delete({ id: agent.id });
     await getRepository(dataSource, Address).delete({ id: addressId });
@@ -477,5 +517,36 @@ describe("POST /opportunity freezes contact_person_id at creation (be#833)", () 
       personId: newContact.id,
     });
     await fastify.db.personRepository.delete({ id: newContact.id });
+  });
+
+  it("sets contact_person_id to the submitter when they are a genuine agent member, not the representative", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/opportunity/",
+      cookies: { [accessCookieName]: memberCookie },
+      payload: {
+        title: `Test Opportunity (contact-freeze member) ${suffix}`,
+        opportunity_type: OpportunityLegacyType.VOLUNTEERING,
+        volunteers_number: 1,
+        category: "",
+        category_id: "",
+        language: "en",
+        agent_id: agent.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const createdId = res.json().data.id;
+    createdOpportunityIds.push(createdId);
+
+    const opportunityRepository = getRepository(dataSource, Opportunity);
+    const saved = await opportunityRepository.findOneOrFail({
+      where: { id: createdId },
+    });
+    // The creator (memberPerson) is an agent member in their own right, so
+    // contact resolves to them directly, not to the volunteer-coordinator
+    // representative (existingContact).
+    expect(saved.contactPersonId).toBe(memberPerson.id);
+    expect(saved.contactPersonId).not.toBe(existingContact.id);
   });
 });


### PR DESCRIPTION
## Summary

Closes #833.

`Opportunity.contactPersonId` was almost never populated at creation (only the legacy public form set it) — so `getOpportunityContact` fell back **at read time** to the opportunity's agent's *current* representative (`Agent.representative`, an unstable getter over the agent's contact list). Adding a new contact to an agent — especially its first, or one marked `volunteer-coordinator` — instantly changed the displayed contact for every one of that agent's pre-existing, contact-less requests.

## Changes

- **`POST /opportunity`** now snapshots `contactPersonId` at creation time (the submitter, if they're currently an agent member; otherwise the agent's current representative), instead of leaving it `null` and letting it drift forever.
- **New data migration** (`1786096580655-backfill-opportunity-contact-person`) backfills `contact_person_id` for existing opportunities using the same resolution, so they stop drifting too. This does **not** retroactively correct any opportunity that's already showing a wrong contact today — staff still uses the existing relink tool (#824, `PATCH /opportunity/:id` with `contact.id`) for that; it only freezes things going forward.
- **`getOpportunityRepresentativePerson`** (used by the new-opportunity/accompany-match/introduction notification emails) now prioritizes the stored `contactPerson` over `submittedByPerson`, so a manual relink (or the new creation-time snapshot) is actually respected instead of being silently overridden by a live agent lookup.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint` (no new errors; pre-existing warnings only)
- [x] `yarn test:run` — 72 files / 604 tests pass
- [x] New regression test: creates an opportunity, records its `contact_person_id`, adds a brand-new agent contact, and asserts the opportunity's contact is unchanged
- [x] New unit tests for the reordered `getOpportunityRepresentativePerson` fallback chain
- [x] Verified `yarn migration:run` / `migration:revert` / re-run (idempotent, reverts cleanly) against local Docker Postgres