### PR TITLE
feat: make agent operator (organization) editable via PATCH /agent/:id

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.139",
+    "need4deed-sdk": "0.0.141",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/routes/organization.routes.ts
+++ b/src/server/routes/organization.routes.ts
@@ -1,16 +1,38 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiOrganizationPatch, UserRole } from "need4deed-sdk";
+import {
+  ApiOrganizationGetList,
+  ApiOrganizationPatch,
+  UserRole,
+} from "need4deed-sdk";
 import { NotFoundError } from "../../config";
+import { dtoOrganizationGetList } from "../../services";
 import { idParamSchema, responseSchema } from "../schema";
-import { ParamsId, ReplyMessage } from "../types";
+import { ParamsId, ReplyData } from "../types";
 
 export default async function organizationRoutes(
   fastify: FastifyInstance,
   _options: FastifyPluginOptions,
 ) {
-  fastify.addHook(
-    "onRequest",
-    fastify.authenticate({ role: UserRole.COORDINATOR }),
+  // GET is open to any logged-in user — it's just a dropdown of organization
+  // names (e.g. for the agent "operator" picker, be#843), no PII. Writes stay
+  // COORDINATOR-only, gated per-route below.
+  fastify.addHook("onRequest", fastify.authenticate());
+
+  fastify.get<{ Reply: ReplyData<ApiOrganizationGetList[]> }>(
+    "/",
+    {
+      schema: { response: responseSchema("ApiOrganizationGetList#", true) },
+    },
+    async (_request, reply) => {
+      const organizations = await fastify.db.organizationRepository.find({
+        order: { title: "ASC" },
+      });
+
+      return reply.status(200).send({
+        message: "Organizations found.",
+        data: organizations.map(dtoOrganizationGetList),
+      });
+    },
   );
 
   fastify.patch<{
@@ -20,7 +42,11 @@ export default async function organizationRoutes(
   }>(
     "/:id",
     {
-      schema: { params: idParamSchema, response: responseSchema({ statusCode: 204 }) },
+      preHandler: fastify.authenticate({ role: UserRole.COORDINATOR }),
+      schema: {
+        params: idParamSchema,
+        response: responseSchema({ statusCode: 204 }),
+      },
     },
     async (request, reply) => {
       const { id } = request.params;

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -347,16 +347,15 @@
     "VolunteerStateAppreciationType": {
       "$id": "VolunteerStateAppreciationType",
       "type": "string",
-       "enum": [
-    "t-shirt",
-    "benefit-card",
-    "tote-bag",
-    "need4deed-certificate",
-    "cap",
-    "notebook",
-    "city-certificate"
-  ]
-
+      "enum": [
+        "t-shirt",
+        "benefit-card",
+        "tote-bag",
+        "need4deed-certificate",
+        "cap",
+        "notebook",
+        "city-certificate"
+      ]
     },
     "VolunteerStateTypeType": {
       "$id": "VolunteerStateTypeType",
@@ -1400,6 +1399,9 @@
         },
         "districtId": {
           "type": "number"
+        },
+        "organizationId": {
+          "type": "number"
         }
       }
     },
@@ -1568,6 +1570,20 @@
           "type": "string"
         }
       }
+    },
+    "ApiOrganizationGetList": {
+      "$id": "ApiOrganizationGetList",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": ["id", "title"],
+      "additionalProperties": false
     },
     "ApiCommentTaggedPerson": {
       "$id": "ApiCommentTaggedPerson",

--- a/src/services/dto/dto-organization.ts
+++ b/src/services/dto/dto-organization.ts
@@ -1,0 +1,11 @@
+import { ApiOrganizationGetList } from "need4deed-sdk";
+import Organization from "../../data/entity/organization.entity";
+
+export function dtoOrganizationGetList(
+  organization: Organization,
+): ApiOrganizationGetList {
+  return {
+    id: organization.id,
+    title: organization.title,
+  };
+}

--- a/src/services/dto/index.ts
+++ b/src/services/dto/index.ts
@@ -5,6 +5,7 @@ export * from "./dto-comment";
 export * from "./dto-communication";
 export * from "./dto-opportunity";
 export * from "./dto-opportunity-volunteer";
+export * from "./dto-organization";
 export * from "./dto-person";
 export * from "./dto-volunteer";
 export * from "./parser-accompanying-legacy";

--- a/src/services/dto/parser-agent.ts
+++ b/src/services/dto/parser-agent.ts
@@ -15,6 +15,7 @@ export function parseAgentPatch(agent: ApiAgentPatch): Partial<Agent> {
     info: agent.about,
     website: agent.website,
     agentTypeId: agent.typeId,
+    organizationId: agent.organizationId,
     trustLevel: agent.trustLevel,
     // GET emits volunteerSearch while PATCH uses statusSearch; accept either
     // so round-tripped fields aren't silently dropped.

--- a/src/test/server/routes/agent.routes.test.ts
+++ b/src/test/server/routes/agent.routes.test.ts
@@ -3,11 +3,13 @@ import { AgentMembershipStatus, AgentRoleType, UserRole } from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accessCookieName } from "../../../config/constants";
 import { dataSource } from "../../../data/data-source";
+import Address from "../../../data/entity/location/address.entity";
 import District from "../../../data/entity/location/district.entity";
 import Postcode from "../../../data/entity/location/postcode.entity";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
 import DistrictPostcode from "../../../data/entity/m2m/district-postcode";
 import Agent from "../../../data/entity/opportunity/agent.entity";
+import Organization from "../../../data/entity/organization.entity";
 import Person from "../../../data/entity/person.entity";
 import User from "../../../data/entity/user.entity";
 import { hashPassword } from "../../../data/utils";
@@ -289,6 +291,51 @@ describe("PATCH /agent/:id organization details", () => {
       payload: { title: `Updated by admin ${agent.id}` },
     });
     expect(res.statusCode).toBe(204);
+  });
+
+  // Regression test for be#843: the operator (Träger, e.g. IB/DRK/Albatros)
+  // field on an agent's profile is Agent.organizationId, which was missing
+  // end-to-end from the PATCH contract and so silently failed to save.
+  it("saves organizationId — the operator (Träger) field (be#843)", async () => {
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+    const addressRepository = dataSource.getRepository(Address);
+    const organizationRepository = dataSource.getRepository(Organization);
+
+    const address = await addressRepository.save(
+      new Address({ postcodeId: postcode.id }),
+    );
+    const organization = await organizationRepository.save(
+      new Organization({
+        title: `Test Operator ${suffix}`,
+        addressId: address.id,
+        personId: memberPerson.id,
+      }),
+    );
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/agent/${agent.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { organizationId: organization.id },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.agentRepository.findOneByOrFail({
+      id: agent.id,
+    });
+    expect(updated.organizationId).toBe(organization.id);
+
+    // organizationId is a no-cascade FK on Agent — clear it before deleting
+    // the Organization row, or the delete violates the constraint.
+    await fastify.db.agentRepository.update(
+      { id: agent.id },
+      { organizationId: null },
+    );
+    await organizationRepository.delete({ id: organization.id });
+    await addressRepository.delete({ id: address.id });
   });
 
   // District must always be derived from postcode, never independently

--- a/src/test/server/routes/organization.routes.test.ts
+++ b/src/test/server/routes/organization.routes.test.ts
@@ -1,0 +1,203 @@
+import { FastifyInstance } from "fastify";
+import { UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import { dataSource } from "../../../data/data-source";
+import Address from "../../../data/entity/location/address.entity";
+import Organization from "../../../data/entity/organization.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("organization.routes", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  let ownerPerson: Person;
+  let agentCookie: string;
+  let coordinatorCookie: string;
+
+  let addressA: Address;
+  let addressB: Address;
+  let orgA: Organization;
+  let orgB: Organization;
+
+  async function login(email: string): Promise<string> {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email, password: PASSWORD },
+    });
+    return getCookie(res.cookies, accessCookieName);
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+    const addressRepository = dataSource.getRepository(Address);
+    const organizationRepository = dataSource.getRepository(Organization);
+
+    ownerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Org", lastName: "Owner" }),
+    );
+
+    addressA = await addressRepository.save(
+      new Address({ postcodeId: postcode.id }),
+    );
+    addressB = await addressRepository.save(
+      new Address({ postcodeId: postcode.id }),
+    );
+    // Titles deliberately out of alphabetical creation order, to assert the
+    // list route sorts rather than returning insertion order.
+    orgB = await organizationRepository.save(
+      new Organization({
+        title: `Z Test Org ${suffix}`,
+        addressId: addressB.id,
+        personId: ownerPerson.id,
+      }),
+    );
+    orgA = await organizationRepository.save(
+      new Organization({
+        title: `A Test Org ${suffix}`,
+        addressId: addressA.id,
+        personId: ownerPerson.id,
+      }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `org-agent-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: ownerPerson.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `org-coordinator-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+      }),
+    );
+    agentCookie = await login(`org-agent-${suffix}@test.need4deed.org`);
+    coordinatorCookie = await login(
+      `org-coordinator-${suffix}@test.need4deed.org`,
+    );
+  });
+
+  afterAll(async () => {
+    const addressRepository = dataSource.getRepository(Address);
+    const organizationRepository = dataSource.getRepository(Organization);
+
+    await fastify.db.userRepository.delete({ personId: ownerPerson.id });
+    await organizationRepository.delete({ id: orgA.id });
+    await organizationRepository.delete({ id: orgB.id });
+    await fastify.db.personRepository.delete({ id: ownerPerson.id });
+    await addressRepository.delete({ id: addressA.id });
+    await addressRepository.delete({ id: addressB.id });
+    await fastify.close();
+  });
+
+  describe("GET /organization", () => {
+    it("rejects an unauthenticated request", async () => {
+      const res = await fastify.inject({ method: "GET", url: "/organization" });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("allows any authenticated role (e.g. AGENT) to list organizations — it's just a name dropdown, no PII", async () => {
+      const res = await fastify.inject({
+        method: "GET",
+        url: "/organization",
+        cookies: { [accessCookieName]: agentCookie },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const titles = res.json().data.map((org: { title: string }) => org.title);
+      expect(titles).toContain(orgA.title);
+      expect(titles).toContain(orgB.title);
+    });
+
+    it("returns organizations sorted by title ascending, and only id/title fields", async () => {
+      const res = await fastify.inject({
+        method: "GET",
+        url: "/organization",
+        cookies: { [accessCookieName]: coordinatorCookie },
+      });
+
+      const data: { id: number; title: string }[] = res.json().data;
+      const indexA = data.findIndex((org) => org.id === orgA.id);
+      const indexB = data.findIndex((org) => org.id === orgB.id);
+      expect(indexA).toBeLessThan(indexB);
+
+      const found = data.find((org) => org.id === orgA.id);
+      expect(Object.keys(found ?? {}).sort()).toEqual(["id", "title"]);
+    });
+  });
+
+  describe("PATCH /organization/:id", () => {
+    it("rejects an unauthenticated request", async () => {
+      const res = await fastify.inject({
+        method: "PATCH",
+        url: `/organization/${orgA.id}`,
+        payload: { title: "Nope" },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("rejects a non-COORDINATOR role (e.g. AGENT)", async () => {
+      const res = await fastify.inject({
+        method: "PATCH",
+        url: `/organization/${orgA.id}`,
+        cookies: { [accessCookieName]: agentCookie },
+        payload: { title: "Nope" },
+      });
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("404s for a nonexistent organization id", async () => {
+      const res = await fastify.inject({
+        method: "PATCH",
+        url: "/organization/999999999",
+        cookies: { [accessCookieName]: coordinatorCookie },
+        payload: { title: "Nope" },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("allows a COORDINATOR to patch organization fields", async () => {
+      const res = await fastify.inject({
+        method: "PATCH",
+        url: `/organization/${orgA.id}`,
+        cookies: { [accessCookieName]: coordinatorCookie },
+        payload: { website: "https://updated.example.org" },
+      });
+      expect(res.statusCode).toBe(204);
+
+      const updated = await dataSource
+        .getRepository(Organization)
+        .findOneByOrFail({ id: orgA.id });
+      expect(updated.website).toBe("https://updated.example.org");
+    });
+  });
+});

--- a/src/test/services/dto/parser-agent.test.ts
+++ b/src/test/services/dto/parser-agent.test.ts
@@ -14,6 +14,7 @@ describe("parseAgentPatch", () => {
       about: "A non-profit focused on disaster recovery.",
       website: "https://example.org",
       typeId: 1,
+      organizationId: 7,
       trustLevel: "unknown" as AgentTrustType,
       statusSearch: "agent-not-needed" as AgentVolunteerSearchType,
       statusEngagement: "agent-new" as AgentEngagementStatusType,
@@ -29,6 +30,7 @@ describe("parseAgentPatch", () => {
       info: "A non-profit focused on disaster recovery.",
       website: "https://example.org",
       agentTypeId: 1,
+      organizationId: 7,
       trustLevel: "unknown",
       searchStatus: "agent-not-needed",
       engagementStatus: "agent-new",
@@ -73,5 +75,11 @@ describe("parseAgentPatch", () => {
     const agent: ApiAgentPatch = { districtId: 42 };
 
     expect(parseAgentPatch(agent)).not.toHaveProperty("districtId");
+  });
+
+  it("maps organizationId — the operator (Träger) field on an agent's profile (be#843)", () => {
+    const agent: ApiAgentPatch = { organizationId: 9 };
+
+    expect(parseAgentPatch(agent).organizationId).toBe(9);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.139:
-  version "0.0.139"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.139.tgz#34ca63577a104dcaa3353d3b1c6c9661da182c40"
-  integrity sha512-gU3wlLF4sUxz9azKUBcceuiOgUmt1Q6Km6sXvVWzSDbZa7BieXu9Xr2Lz7NQDVZxMM817nDt5y8CLfrKBexvrw==
+need4deed-sdk@0.0.141:
+  version "0.0.141"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.141.tgz#f8f62efc5f48e99f03e935a0e7dba3970d7ba7bd"
+  integrity sha512-zGjp4hiArKMfWumv/dhQqulMOf4FL9DxKTkorEzI/bHOE7BV2zoQqUa3zlt6RRI5CX1I8065PatiAB98ImCtkg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

Closes #843. Depends on need4deed-sdk@0.0.141 (need4deed-org/sdk#193), already published.

The dashboard's "Operator" (Träger, e.g. IB/DRK/Albatros) field on an agent's profile is `Agent.organizationId` — the column/relation already existed on the entity, but the field was missing end-to-end from the PATCH contract, so edits silently failed to save.

## Changes

- Bumped `need4deed-sdk` to `0.0.141` (adds `AgentPatch.organizationId` and `ApiOrganizationGetList`).
- `parseAgentPatch()` now maps `organizationId` straight through, same as the existing `agentTypeId`/`typeId` pattern (unlike `districtId`, which is deliberately excluded — see the comment in `parser-agent.ts`).
- Added `organizationId` to the `AgentProps` JSON schema (`sdk-types.json`) backing `PATCH /agent/:id`'s body validation, and added an `ApiOrganizationGetList` schema definition.
- Added `GET /organization` — lists organizations (`id`, `title`) sorted by title, for `fe` to populate the operator dropdown (tracked separately in fe#885). Deliberately open to any authenticated user rather than COORDINATOR-only: it's just organization names, no PII, and AGENT-role users editing their own agent's profile need it too. `PATCH /organization/:id` stays COORDINATOR-only via its own `preHandler`.
- New DTO `dtoOrganizationGetList`.
- Cleaned up a pre-existing unused `ReplyMessage` import in `organization.routes.ts` while touching the file.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint` (no new errors)
- [x] `yarn test:run` — 73 files / 614 tests pass (run twice, including the pre-push hook)
- [x] New tests: `organizationId` mapping in `parser-agent.test.ts`; `organizationId` round-trip via `PATCH /agent/:id` in `agent.routes.test.ts`; full `organization.routes.test.ts` (new file) covering `GET /organization` auth/sort/shape and `PATCH /organization/:id` auth/404/save