### PR TITLE
opportunity status change atomically cascades agent.volunteerSearch server-side

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -663,6 +663,21 @@ export default async function opportunityRoutes(
         }
       }
 
+      // Resolved and validated up front (rather than inside the
+      // agentLinkId!==undefined block below) so the status-cascade transaction
+      // below can target whichever agent will actually own this opportunity
+      // once the request is applied — not the one it's being relinked away
+      // from (be#862 review).
+      if (agentLinkId !== undefined) {
+        const linkedAgent = await fastify.db.agentRepository.findOne({
+          where: { id: agentLinkId },
+        });
+        if (!linkedAgent) {
+          throw new NotFoundError(`Agent (id:${agentLinkId}) not found.`);
+        }
+      }
+      const effectiveAgentId = agentLinkId ?? opportunity.agentId;
+
       if (opportunityObj) {
         await dataSource.manager.transaction(async (manager) => {
           const success = await patchEntity(
@@ -682,18 +697,12 @@ export default async function opportunityRoutes(
             opportunityObj.status &&
             impliesAgentSearching(opportunityObj.status)
           ) {
-            await setAgentSearching(opportunity.agentId, manager);
+            await setAgentSearching(effectiveAgentId, manager);
           }
         });
       }
 
       if (agentLinkId !== undefined) {
-        const linkedAgent = await fastify.db.agentRepository.findOne({
-          where: { id: agentLinkId },
-        });
-        if (!linkedAgent) {
-          throw new NotFoundError(`Agent (id:${agentLinkId}) not found.`);
-        }
         // The opportunity's existing contact (if any) belongs to the *old*
         // agent and has no guaranteed relationship to the new one — clear it
         // rather than leave a stale cross-agent reference. If the request
@@ -717,10 +726,9 @@ export default async function opportunityRoutes(
       }
 
       if (contactLinkId !== undefined) {
-        // Evaluated after the agent relink above so a payload that relinks
-        // both `agent.id` and `contact.id` in one request validates the
-        // contact against the opportunity's *new* agent, not the old one.
-        const effectiveAgentId = agentLinkId ?? opportunity.agentId;
+        // effectiveAgentId already resolves to the *new* agent when this
+        // request also relinks `agent.id`, so a payload that relinks both in
+        // one go validates the contact against the new agent, not the old one.
         const agentContactMembership =
           await fastify.db.agentPersonRepository.findOneBy({
             agentId: effectiveAgentId,

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -693,7 +693,10 @@ export default async function opportunityRoutes(
           // An opportunity moving to a status that implies searching means
           // its agent is searching too (be#862) — cascaded here, atomically,
           // rather than as a second independent PATCH from the frontend.
+          // agentId is nullable (e.g. orphaned legacy rows) — skip the
+          // cascade rather than failing the whole status patch over it.
           if (
+            effectiveAgentId &&
             opportunityObj.status &&
             impliesAgentSearching(opportunityObj.status)
           ) {

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -678,8 +678,14 @@ export default async function opportunityRoutes(
       }
       const effectiveAgentId = agentLinkId ?? opportunity.agentId;
 
-      if (opportunityObj) {
-        await dataSource.manager.transaction(async (manager) => {
+      // The opportunity patch, the be#862 search-status cascade, and the
+      // agent relink all share one transaction — previously the relink was a
+      // separate statement issued after the cascade transaction committed, so
+      // a relink failure (e.g. a mid-flight delete of the target agent) could
+      // leave the status/cascade applied but the relink itself lost (be#868
+      // review).
+      await dataSource.manager.transaction(async (manager) => {
+        if (opportunityObj) {
           const success = await patchEntity(
             Opportunity,
             opportunityObj,
@@ -702,31 +708,40 @@ export default async function opportunityRoutes(
           ) {
             await setAgentSearching(effectiveAgentId, manager);
           }
-        });
-      }
+        }
 
-      if (agentLinkId !== undefined) {
-        // The opportunity's existing contact (if any) belongs to the *old*
-        // agent and has no guaranteed relationship to the new one — clear it
-        // rather than leave a stale cross-agent reference. If the request
-        // also carries `contact.id`, the contactLinkId branch below sets the
-        // real (validated-against-the-new-agent) value right after this.
-        const contactReset: Partial<Opportunity> =
-          contactLinkId === undefined ? { contactPersonId: null } : {};
-        const success = await patchEntity(
-          Opportunity,
-          { agentId: agentLinkId, ...contactReset } as Partial<Opportunity>,
-          opportunity.id,
-        );
-        if (!success) {
-          throw new BadRequestError("Relinking opportunity agent failed.");
+        if (agentLinkId !== undefined) {
+          // The opportunity's existing contact (if any) belongs to the *old*
+          // agent and has no guaranteed relationship to the new one — clear
+          // it rather than leave a stale cross-agent reference. If the
+          // request also carries `contact.id`, the contactLinkId branch
+          // below sets the real (validated-against-the-new-agent) value
+          // right after this.
+          const contactReset: Partial<Opportunity> =
+            contactLinkId === undefined ? { contactPersonId: null } : {};
+          const success = await patchEntity(
+            Opportunity,
+            { agentId: agentLinkId, ...contactReset } as Partial<Opportunity>,
+            opportunity.id,
+            manager,
+          );
+          if (!success) {
+            throw new BadRequestError("Relinking opportunity agent failed.");
+          }
+        } else if (agent) {
+          const success = await patchEntity(
+            Agent,
+            agent,
+            opportunity.agentId,
+            manager,
+          );
+          if (!success) {
+            throw new Error(
+              "Patching agent failed while patching opportunity.",
+            );
+          }
         }
-      } else if (agent) {
-        const success = await patchEntity(Agent, agent, opportunity.agentId);
-        if (!success) {
-          throw new Error("Patching agent failed while patching opportunity.");
-        }
-      }
+      });
 
       if (contactLinkId !== undefined) {
         // effectiveAgentId already resolves to the *new* agent when this

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -70,7 +70,9 @@ import {
   getOrCreateTimeslot,
   getPostcode,
   getSkipTake,
+  impliesAgentSearching,
   patchEntity,
+  setAgentSearching,
   updateOptionList,
   upsertOnetimer,
   writeOpportunityLegacy,
@@ -662,14 +664,27 @@ export default async function opportunityRoutes(
       }
 
       if (opportunityObj) {
-        const success = await patchEntity(
-          Opportunity,
-          opportunityObj,
-          opportunity.id,
-        );
-        if (!success) {
-          throw new Error("Patching opportunity failed.");
-        }
+        await dataSource.manager.transaction(async (manager) => {
+          const success = await patchEntity(
+            Opportunity,
+            opportunityObj,
+            opportunity.id,
+            manager,
+          );
+          if (!success) {
+            throw new Error("Patching opportunity failed.");
+          }
+
+          // An opportunity moving to a status that implies searching means
+          // its agent is searching too (be#862) — cascaded here, atomically,
+          // rather than as a second independent PATCH from the frontend.
+          if (
+            opportunityObj.status &&
+            impliesAgentSearching(opportunityObj.status)
+          ) {
+            await setAgentSearching(opportunity.agentId, manager);
+          }
+        });
       }
 
       if (agentLinkId !== undefined) {

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -678,11 +678,27 @@ export default async function opportunityRoutes(
       }
       const effectiveAgentId = agentLinkId ?? opportunity.agentId;
 
-      // The opportunity patch, the be#862 search-status cascade, and the
-      // agent relink all share one transaction — previously the relink was a
-      // separate statement issued after the cascade transaction committed, so
-      // a relink failure (e.g. a mid-flight delete of the target agent) could
-      // leave the status/cascade applied but the relink itself lost (be#868
+      // Also validated up front, same reasoning as agentLinkId above:
+      // effectiveAgentId already resolves to the *new* agent when this
+      // request also relinks `agent.id`, so a payload that relinks both in
+      // one go validates the contact against the new agent, not the old one.
+      if (contactLinkId !== undefined) {
+        const agentContactMembership =
+          await fastify.db.agentPersonRepository.findOneBy({
+            agentId: effectiveAgentId,
+            personId: contactLinkId,
+          });
+        if (!agentContactMembership) {
+          throw new NotFoundError(
+            `Contact (personId:${contactLinkId}) is not registered as a contact of this opportunity's agent.`,
+          );
+        }
+      }
+
+      // The opportunity patch, the be#862 search-status cascade, the agent
+      // relink, and the contact relink all share one transaction — each used
+      // to be a separate statement issued independently, so a failure partway
+      // through could leave some of these applied and others lost (be#868
       // review).
       await dataSource.manager.transaction(async (manager) => {
         if (opportunityObj) {
@@ -741,31 +757,22 @@ export default async function opportunityRoutes(
             );
           }
         }
-      });
 
-      if (contactLinkId !== undefined) {
-        // effectiveAgentId already resolves to the *new* agent when this
-        // request also relinks `agent.id`, so a payload that relinks both in
-        // one go validates the contact against the new agent, not the old one.
-        const agentContactMembership =
-          await fastify.db.agentPersonRepository.findOneBy({
-            agentId: effectiveAgentId,
-            personId: contactLinkId,
-          });
-        if (!agentContactMembership) {
-          throw new NotFoundError(
-            `Contact (personId:${contactLinkId}) is not registered as a contact of this opportunity's agent.`,
+        if (contactLinkId !== undefined) {
+          // Evaluated after the agent relink above so a payload that resets
+          // contactPersonId to null (contactReset, above) doesn't clobber the
+          // real value being set here.
+          const success = await patchEntity(
+            Opportunity,
+            { contactPersonId: contactLinkId } as Partial<Opportunity>,
+            opportunity.id,
+            manager,
           );
+          if (!success) {
+            throw new BadRequestError("Relinking opportunity contact failed.");
+          }
         }
-        const success = await patchEntity(
-          Opportunity,
-          { contactPersonId: contactLinkId } as Partial<Opportunity>,
-          opportunity.id,
-        );
-        if (!success) {
-          throw new BadRequestError("Relinking opportunity contact failed.");
-        }
-      }
+      });
 
       if (accompanying) {
         const appointmentPostcodeValue =

--- a/src/server/utils/data/for-routes.ts
+++ b/src/server/utils/data/for-routes.ts
@@ -1,4 +1,5 @@
 import {
+  AgentVolunteerSearchType,
   ApiAvailability,
   ApiDocumentGet,
   ApiOptionLists,
@@ -7,6 +8,7 @@ import {
   Lang,
   Occasionally,
   OccasionalType,
+  OpportunityStatusType,
   OptionById,
   OptionItem,
   SortOrder,
@@ -35,6 +37,7 @@ import District from "../../../data/entity/location/district.entity";
 import Postcode from "../../../data/entity/location/postcode.entity";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentService from "../../../data/entity/m2m/agent-service";
+import Agent from "../../../data/entity/opportunity/agent.entity";
 import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Option from "../../../data/entity/option.entity";
 import Person from "../../../data/entity/person.entity";
@@ -348,6 +351,31 @@ export async function patchEntity<E extends { id: number }>(
         );
       }
     });
+}
+
+// An opportunity looking for volunteers implies its agent is looking for
+// volunteers too (be#862). Kept as a set (rather than e.g. "!== INACTIVE/PAST")
+// so a future status added to the SDK doesn't silently start cascading.
+const AGENT_SEARCH_CASCADE_STATUSES = new Set<OpportunityStatusType>([
+  OpportunityStatusType.NEW,
+  OpportunityStatusType.ACTIVE,
+  OpportunityStatusType.SEARCHING,
+]);
+
+export function impliesAgentSearching(status: OpportunityStatusType): boolean {
+  return AGENT_SEARCH_CASCADE_STATUSES.has(status);
+}
+
+export async function setAgentSearching(
+  agentId: number,
+  manager: DataSource | EntityManager = dataSource,
+): Promise<void> {
+  await patchEntity(
+    Agent,
+    { searchStatus: AgentVolunteerSearchType.SEARCHING } as Partial<Agent>,
+    agentId,
+    manager,
+  );
 }
 
 export async function patchAddress(

--- a/src/server/utils/data/write-opportunity-legacy.ts
+++ b/src/server/utils/data/write-opportunity-legacy.ts
@@ -8,6 +8,7 @@ import DealTimeslot from "../../../data/entity/m2m/deal-timeslot";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import { setAgentSearching } from "./for-routes";
 
 export async function writeOpportunityLegacy(
   opportunity: Opportunity,
@@ -69,6 +70,11 @@ export async function writeOpportunityLegacy(
     }
 
     await opportunityRepository.save(opportunity);
+
+    // A newly-created opportunity always starts in a status that implies
+    // searching (be#862) — the create form has no field to set it otherwise,
+    // so the owning agent's volunteerSearch flips to SEARCHING unconditionally.
+    await setAgentSearching(opportunity.agentId, transactionalEntityManager);
   });
 
   return opportunity.id;

--- a/src/server/utils/data/write-opportunity-legacy.ts
+++ b/src/server/utils/data/write-opportunity-legacy.ts
@@ -1,3 +1,4 @@
+import { OpportunityStatusType } from "need4deed-sdk";
 import { dataSource } from "../../../data/data-source";
 import Deal from "../../../data/entity/deal.entity";
 import DealActivity from "../../../data/entity/m2m/deal-activity";
@@ -8,7 +9,7 @@ import DealTimeslot from "../../../data/entity/m2m/deal-timeslot";
 import Accompanying from "../../../data/entity/opportunity/accompanying.entity";
 import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
-import { setAgentSearching } from "./for-routes";
+import { impliesAgentSearching, setAgentSearching } from "./for-routes";
 
 export async function writeOpportunityLegacy(
   opportunity: Opportunity,
@@ -71,10 +72,18 @@ export async function writeOpportunityLegacy(
 
     await opportunityRepository.save(opportunity);
 
-    // A newly-created opportunity always starts in a status that implies
-    // searching (be#862) — the create form has no field to set it otherwise,
-    // so the owning agent's volunteerSearch flips to SEARCHING unconditionally.
-    await setAgentSearching(opportunity.agentId, transactionalEntityManager);
+    // opportunity.status is normally left undefined at this point (the
+    // create form has no field to set it, so it's the entity's DB-level
+    // default) — fall back to that same default explicitly rather than
+    // assuming "creation always implies searching", so this stays correct if
+    // that default, or a future caller passing an explicit status, changes
+    // (be#862 / be#868 review).
+    if (
+      opportunity.agentId &&
+      impliesAgentSearching(opportunity.status ?? OpportunityStatusType.NEW)
+    ) {
+      await setAgentSearching(opportunity.agentId, transactionalEntityManager);
+    }
   });
 
   return opportunity.id;

--- a/src/test/server/routes/opportunity-create.routes.test.ts
+++ b/src/test/server/routes/opportunity-create.routes.test.ts
@@ -1,5 +1,10 @@
 import { FastifyInstance } from "fastify";
-import { AgentRoleType, OpportunityLegacyType, UserRole } from "need4deed-sdk";
+import {
+  AgentRoleType,
+  AgentVolunteerSearchType,
+  OpportunityLegacyType,
+  UserRole,
+} from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accessCookieName } from "../../../config/constants";
 import { dataSource } from "../../../data/data-source";
@@ -548,5 +553,105 @@ describe("POST /opportunity freezes contact_person_id at creation (be#833)", () 
     // representative (existingContact).
     expect(saved.contactPersonId).toBe(memberPerson.id);
     expect(saved.contactPersonId).not.toBe(existingContact.id);
+  });
+});
+
+// Regression test for be#862: a newly-created opportunity always starts in a
+// status that implies searching, so the owning agent's volunteerSearch must
+// flip to SEARCHING atomically alongside the opportunity write, rather than
+// via a second, independent PATCH /agent/:id from the frontend.
+describe("POST /opportunity cascades a new agent to SEARCHING (be#862)", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let agent: Agent;
+  let addressId: number;
+  let createdOpportunityId: number;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const addressRepository = getRepository(dataSource, Address);
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+    const address = await addressRepository.save(
+      new Address({ postcodeId: postcode.id }),
+    );
+    addressId = address.id;
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({
+        title: `Test Agent (search-cascade-create) ${suffix}`,
+        addressId: address.id,
+      }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-search-cascade-create-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-search-cascade-create-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(res.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    if (createdOpportunityId) {
+      await fastify.db.opportunityRepository.delete({
+        id: createdOpportunityId,
+      });
+    }
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await getRepository(dataSource, Address).delete({ id: addressId });
+    await fastify.close();
+  });
+
+  it("flips the owning agent's volunteerSearch to SEARCHING", async () => {
+    expect(agent.searchStatus).toBe(AgentVolunteerSearchType.NOT_NEEDED);
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/opportunity/",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        title: `Test Opportunity (search-cascade-create) ${suffix}`,
+        opportunity_type: OpportunityLegacyType.VOLUNTEERING,
+        volunteers_number: 1,
+        category: "",
+        category_id: "",
+        language: "en",
+        agent_id: agent.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    createdOpportunityId = res.json().data.id;
+
+    const updatedAgent = await fastify.db.agentRepository.findOneByOrFail({
+      id: agent.id,
+    });
+    expect(updatedAgent.searchStatus).toBe(AgentVolunteerSearchType.SEARCHING);
   });
 });

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from "fastify";
 import {
   AgentRoleType,
+  AgentVolunteerSearchType,
   EntityTableName,
   OpportunityStatusType,
   OpportunityType,
@@ -394,6 +395,109 @@ describe("PATCH /opportunity/:id agent status update", () => {
       { id: ownOpportunity.id },
       { agentId: ownAgent.id, contactPersonId: agentContactPerson.id },
     );
+  });
+});
+
+// Regression test for be#862: this cascade used to be a second, independent
+// PATCH /agent/:id fired by the frontend after the opportunity PATCH
+// succeeded — non-atomic, and easy to forget for other callers. It now
+// happens server-side, in the same transaction as the opportunity patch.
+describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () => {
+  let fastify: FastifyInstance;
+
+  let agent: Agent;
+  let opportunity: Opportunity;
+  let deal: Deal;
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (search-cascade) ${suffix}` }),
+    );
+    deal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    opportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (search-cascade) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.INACTIVE,
+        agentId: agent.id,
+        dealId: deal.id,
+      }),
+    );
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-search-cascade-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-search-cascade-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(res.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    await fastify.db.opportunityRepository.delete({ id: opportunity.id });
+    await fastify.db.dealRepository.delete({ id: deal.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.close();
+  });
+
+  it("leaves the agent's volunteerSearch untouched when the opportunity moves to a non-searching status", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${opportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { statusOpportunity: OpportunityStatusType.PAST },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updatedAgent = await fastify.db.agentRepository.findOneByOrFail({
+      id: agent.id,
+    });
+    expect(updatedAgent.searchStatus).toBe(AgentVolunteerSearchType.NOT_NEEDED);
+  });
+
+  it("flips the agent's volunteerSearch to SEARCHING when the opportunity's status becomes ACTIVE", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${opportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { statusOpportunity: OpportunityStatusType.ACTIVE },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updatedAgent = await fastify.db.agentRepository.findOneByOrFail({
+      id: agent.id,
+    });
+    expect(updatedAgent.searchStatus).toBe(AgentVolunteerSearchType.SEARCHING);
   });
 });
 

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -406,6 +406,7 @@ describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () =>
   let fastify: FastifyInstance;
 
   let agent: Agent;
+  let newAgent: Agent;
   let opportunity: Opportunity;
   let deal: Deal;
   let coordinatorPerson: Person;
@@ -422,6 +423,9 @@ describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () =>
 
     agent = await fastify.db.agentRepository.save(
       new Agent({ title: `Test Agent (search-cascade) ${suffix}` }),
+    );
+    newAgent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (search-cascade-relink) ${suffix}` }),
     );
     deal = await fastify.db.dealRepository.save(
       new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
@@ -465,6 +469,7 @@ describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () =>
     await fastify.db.opportunityRepository.delete({ id: opportunity.id });
     await fastify.db.dealRepository.delete({ id: deal.id });
     await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.db.agentRepository.delete({ id: newAgent.id });
     await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
     await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
     await fastify.close();
@@ -498,6 +503,55 @@ describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () =>
       id: agent.id,
     });
     expect(updatedAgent.searchStatus).toBe(AgentVolunteerSearchType.SEARCHING);
+  });
+
+  // Regression test for the stale-agent bug caught in be#868 review: a
+  // request that relinks `agent.id` and sets a searching statusOpportunity in
+  // the same PATCH must cascade to the *new* agent, not the one the
+  // opportunity is being relinked away from.
+  it("cascades the newly-linked agent to SEARCHING, not the one it's being relinked away from", async () => {
+    // Reset both agents to a known, non-searching baseline first — the
+    // previous test already left `agent` at SEARCHING.
+    await fastify.db.agentRepository.update(
+      { id: agent.id },
+      { searchStatus: AgentVolunteerSearchType.NOT_NEEDED },
+    );
+    await fastify.db.agentRepository.update(
+      { id: newAgent.id },
+      { searchStatus: AgentVolunteerSearchType.NOT_NEEDED },
+    );
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${opportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        agent: { id: newAgent.id },
+        statusOpportunity: OpportunityStatusType.ACTIVE,
+      },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updatedOldAgent = await fastify.db.agentRepository.findOneByOrFail({
+      id: agent.id,
+    });
+    expect(updatedOldAgent.searchStatus).toBe(
+      AgentVolunteerSearchType.NOT_NEEDED,
+    );
+
+    const updatedNewAgent = await fastify.db.agentRepository.findOneByOrFail({
+      id: newAgent.id,
+    });
+    expect(updatedNewAgent.searchStatus).toBe(
+      AgentVolunteerSearchType.SEARCHING,
+    );
+
+    // Restore for isolation, though no later test in this describe depends
+    // on the opportunity's agent.
+    await fastify.db.opportunityRepository.update(
+      { id: opportunity.id },
+      { agentId: agent.id },
+    );
   });
 });
 

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -409,6 +409,8 @@ describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () =>
   let newAgent: Agent;
   let opportunity: Opportunity;
   let deal: Deal;
+  let orphanOpportunity: Opportunity;
+  let orphanDeal: Deal;
   let coordinatorPerson: Person;
   let coordinatorCookie: string;
 
@@ -437,6 +439,21 @@ describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () =>
         status: OpportunityStatusType.INACTIVE,
         agentId: agent.id,
         dealId: deal.id,
+      }),
+    );
+    // Mirrors a legacy/orphaned row with no owning agent (agent_id is
+    // nullable at the DB level) — the search-status cascade must not turn a
+    // previously-succeeding status PATCH into a 400 just because there's no
+    // agent to cascade to (be#868 review).
+    orphanDeal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    orphanOpportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (search-cascade-orphan) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.INACTIVE,
+        dealId: orphanDeal.id,
       }),
     );
 
@@ -468,6 +485,10 @@ describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () =>
   afterAll(async () => {
     await fastify.db.opportunityRepository.delete({ id: opportunity.id });
     await fastify.db.dealRepository.delete({ id: deal.id });
+    await fastify.db.opportunityRepository.delete({
+      id: orphanOpportunity.id,
+    });
+    await fastify.db.dealRepository.delete({ id: orphanDeal.id });
     await fastify.db.agentRepository.delete({ id: agent.id });
     await fastify.db.agentRepository.delete({ id: newAgent.id });
     await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
@@ -552,6 +573,24 @@ describe("PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)", () =>
       { id: opportunity.id },
       { agentId: agent.id },
     );
+  });
+
+  // Regression test for be#868 review: agent_id is nullable at the DB level
+  // (legacy/orphaned rows) — the cascade must not turn what would otherwise
+  // be a successful status patch into a 400 just because there's no agent.
+  it("still applies the status patch when the opportunity has no agent to cascade to", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/opportunity/${orphanOpportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { statusOpportunity: OpportunityStatusType.ACTIVE },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const updated = await fastify.db.opportunityRepository.findOneByOrFail({
+      id: orphanOpportunity.id,
+    });
+    expect(updated.status).toBe(OpportunityStatusType.ACTIVE);
   });
 });
 

--- a/src/test/server/utils/data/write-opportunity-legacy.test.ts
+++ b/src/test/server/utils/data/write-opportunity-legacy.test.ts
@@ -1,0 +1,74 @@
+import { OpportunityStatusType } from "need4deed-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Opportunity from "../../../../data/entity/opportunity/opportunity.entity";
+import { writeOpportunityLegacy } from "../../../../server/utils/data/write-opportunity-legacy";
+
+const setAgentSearchingMock = vi.fn();
+vi.mock("../../../../server/utils/data/for-routes", () => ({
+  impliesAgentSearching: (status: OpportunityStatusType) =>
+    [
+      OpportunityStatusType.NEW,
+      OpportunityStatusType.ACTIVE,
+      OpportunityStatusType.SEARCHING,
+    ].includes(status),
+  setAgentSearching: (...args: unknown[]) => setAgentSearchingMock(...args),
+}));
+
+const txnManager: any = {
+  getRepository: () => ({ save: vi.fn().mockResolvedValue(undefined) }),
+};
+vi.mock("../../../../data/data-source", () => ({
+  dataSource: {
+    manager: { transaction: async (cb: any) => cb(txnManager) },
+  },
+}));
+
+function makeOpportunity(overrides: Partial<Opportunity> = {}): Opportunity {
+  return new Opportunity({
+    id: 1,
+    deal: {
+      dealActivity: [],
+      dealSkill: [],
+      dealLanguage: [],
+      dealTimeslot: [],
+      dealDistrict: [],
+    } as any,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// Regression tests for be#868 review: the be#862 search-status cascade must
+// respect the opportunity's actual status (rather than assuming every create
+// implies searching) and must not blow up when there's no owning agent.
+describe("writeOpportunityLegacy cascades Agent.volunteerSearch (be#862/be#868)", () => {
+  it("cascades when status is left unset (defaults to NEW, which implies searching)", async () => {
+    const opportunity = makeOpportunity({ agentId: 42 });
+
+    await writeOpportunityLegacy(opportunity);
+
+    expect(setAgentSearchingMock).toHaveBeenCalledWith(42, txnManager);
+  });
+
+  it("does not cascade when created with a status that doesn't imply searching", async () => {
+    const opportunity = makeOpportunity({
+      agentId: 42,
+      status: OpportunityStatusType.INACTIVE,
+    });
+
+    await writeOpportunityLegacy(opportunity);
+
+    expect(setAgentSearchingMock).not.toHaveBeenCalled();
+  });
+
+  it("does not throw and does not cascade when the opportunity has no owning agent", async () => {
+    const opportunity = makeOpportunity();
+
+    await expect(writeOpportunityLegacy(opportunity)).resolves.toBe(1);
+
+    expect(setAgentSearchingMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Moves the be#862 cascade ("an opportunity looking for volunteers implies its agent is looking for volunteers") from a second, independent frontend `PATCH /agent/:id` call into the backend, atomically:

- `POST /opportunity`: sets the owning agent's `volunteerSearch` to `SEARCHING`, in the same transaction as `writeOpportunityLegacy`, when the created opportunity's status implies searching (`impliesAgentSearching(status ?? NEW)` — the create form has no field to set status explicitly, so this is effectively every create today, but the check is explicit rather than assumed).
- `PATCH /opportunity/:id`: when `statusOpportunity` is set to `NEW`/`ACTIVE`/`SEARCHING`, sets the opportunity's agent `volunteerSearch` to `SEARCHING`. The opportunity patch, the search-status cascade, the agent relink (`agent.id`), the free-text agent-title patch, and the contact relink (`contact.id`) all now share **one transaction**, so the whole PATCH commits or rolls back together.
- Adds `impliesAgentSearching`/`setAgentSearching` helpers (`src/server/utils/data/for-routes.ts`) shared by both routes.
- No SDK changes required — both fields already exist in the published contract.

Closes #862

### Edge cases handled (found in review)
- **Relink + status change in one request** now cascades to the *newly-linked* agent, not the one the opportunity is being relinked away from (agent existence is validated and the effective agent id resolved up front, before the transaction).
- **Nullable `agent_id`** (legacy/orphaned rows): the cascade is skipped rather than throwing, so a status-only PATCH on an agent-less opportunity still succeeds.
- **Fully atomic PATCH**: the agent relink write, the free-text agent-title patch, and the contact relink write (plus the contact-reset that comes with an agent relink) all now run inside the same transaction as the status patch and search cascade, instead of as separate statements issued independently — a failure partway through can no longer leave some of these applied and others lost. Read-side validation (agent exists, contact is a registered member of the effective agent) still happens up front, before the transaction opens.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (no new errors/warnings introduced)
- [x] `yarn test:run` — full suite passes (74 files / 622 tests)
- [x] Regression tests:
  - `POST /opportunity cascades a new agent to SEARCHING (be#862)`
  - `PATCH /opportunity/:id cascades Agent.volunteerSearch (be#862)` — status→SEARCHING, non-searching status is a no-op, relink targets the new agent (not the old one), and an agent-less opportunity still succeeds
  - `writeOpportunityLegacy cascades Agent.volunteerSearch (be#862/be#868)` — default-status cascades, explicit non-searching status skips, no-agent skips without throwing
  - Existing agent-relink / contact-relink coverage in `opportunity.routes.test.ts` re-verified unchanged after folding those writes into the shared transaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)