### PR TITLE
deploy-aits: fail loudly on a stuck rollout instead of reporting green

### DIFF
--- a/.github/workflows/deploy-aits.yaml
+++ b/.github/workflows/deploy-aits.yaml
@@ -34,4 +34,11 @@ jobs:
           host: ${{ secrets.AITS_HOST }}
           username: ubuntu
           key: ${{ secrets.AITS_SSH_KEY }}
-          script: kubectl rollout restart deployment/be -n n4d-dev
+          # rollout restart alone only proves the request was accepted, not that
+          # the new pod actually came up (be#868: a stuck/unschedulable pod left
+          # this reporting green for ~24h while AITS kept serving the old image).
+          # rollout status fails (and fails this step) if it doesn't roll out
+          # within the timeout.
+          script: |
+            kubectl rollout restart deployment/be -n n4d-dev
+            kubectl rollout status deployment/be -n n4d-dev --timeout=120s

--- a/.github/workflows/deploy-aits.yaml
+++ b/.github/workflows/deploy-aits.yaml
@@ -40,5 +40,6 @@ jobs:
           # rollout status fails (and fails this step) if it doesn't roll out
           # within the timeout.
           script: |
+            set -e
             kubectl rollout restart deployment/be -n n4d-dev
             kubectl rollout status deployment/be -n n4d-dev --timeout=120s


### PR DESCRIPTION
## Summary
- `kubectl rollout restart` only confirms the restart request was accepted — it does not wait for or verify that the new pod actually became ready.
- After the be#862/be#868 merge, the new `be` pod on AITS sat `Pending` for ~24h (node had no spare memory for the `RollingUpdate` strategy's surge pod), while `deploy-aits` kept reporting green and the old pod kept serving stale code the whole time.
- Root cause on the cluster side is fixed separately (switched the `be` Deployment's strategy from `RollingUpdate` to `Recreate` directly on AITS, since a single-replica dev box has no HA need for a surge pod and this node doesn't have room for one anyway).
- This PR is the CI-side safety net: add `kubectl rollout status deployment/be -n n4d-dev --timeout=120s` right after the restart, so a stuck/unschedulable rollout fails this workflow step instead of silently leaving AITS on the previous image.

## Test plan
- N/A (workflow-only change, no application code touched — existing `yarn test:run` suite passes unaffected, 74 files / 622 tests).
- Will be exercised for real on the next push to `develop`; a stuck rollout should now show as a failed `deploy-aits` run instead of a false-green one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)