### PR TITLE
Add API key authentication for direct (non-login) API access

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
   "scripts": {
     "start": "ts-node src/index.ts",
     "seed": "ts-node src/data/seeds/run.ts",
+    "create-api-key": "ts-node src/data/scripts/create-api-key.ts",
+    "revoke-api-key": "ts-node src/data/scripts/revoke-api-key.ts",
     "dev": "nodemon",
     "typeorm": "typeorm-ts-node-commonjs -d src/data/data-source.ts",
     "migration:generate": "yarn typeorm migration:generate",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -141,6 +141,8 @@ export const pluginTimeout = 300 * 1000; // 30s in milliseconds
 
 export const accessCookieName = "access";
 export const refreshCookieName = "refresh";
+// Header for direct (non-login) API key auth — see src/server/plugins/jwt.ts.
+export const apiKeyHeaderName = "x-api-key";
 export const cookieOptions = {
   signed: TRUTHY.has(process.env.SIGN_COOKIES || ""),
   httpOnly: true,

--- a/src/data/data-source.ts
+++ b/src/data/data-source.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { DataSource } from "typeorm";
 import { isTest } from "../config";
+import ApiKey from "./entity/api-key.entity";
 import Comment from "./entity/comment.entity";
 import Communication from "./entity/communication.entity";
 import Config from "./entity/config.entity";
@@ -73,6 +74,7 @@ export const dataSource = new DataSource({
     AgentPostcode,
     AgentService,
     AgentType,
+    ApiKey,
     Appreciation,
     Category,
     Comment,

--- a/src/data/entity/api-key.entity.ts
+++ b/src/data/entity/api-key.entity.ts
@@ -1,0 +1,54 @@
+import { IsNotEmpty, IsString } from "class-validator";
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import User from "./user.entity";
+
+// Direct (non-login) API access for bot/automation consumers. Each key is
+// tied to a dedicated service User (role fixed at coordinator, no Person
+// attached) so the existing role-based authenticate() checks apply unchanged.
+// No self-service endpoints yet — minted/revoked via CLI (see
+// src/data/scripts/create-api-key.ts, revoke-api-key.ts).
+@Entity()
+export default class ApiKey {
+  constructor(apiKey?: Partial<ApiKey>) {
+    if (apiKey) {
+      Object.assign(this, apiKey);
+    }
+  }
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index({ unique: true })
+  @Column()
+  @IsNotEmpty()
+  @IsString()
+  label: string;
+
+  @Column()
+  @IsNotEmpty()
+  @IsString()
+  keyHash: string;
+
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: "user_id" })
+  user: User;
+
+  @Column()
+  userId: number;
+
+  @Column({ type: "timestamp", nullable: true })
+  revokedAt: Date | null;
+
+  @Column({ type: "timestamp", nullable: true })
+  lastUsedAt: Date | null;
+
+  @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
+  createdAt: Date;
+}

--- a/src/data/entity/api-key.entity.ts
+++ b/src/data/entity/api-key.entity.ts
@@ -34,6 +34,12 @@ export default class ApiKey {
   @IsString()
   label: string;
 
+  // SHA-256 hex digest of the raw key (see data/utils/hash-token.ts), not
+  // bcrypt: the raw key is a high-entropy random token, not a human
+  // password, so a fast deterministic hash is safe here and lets
+  // authenticate() resolve a key via an indexed exact match instead of a
+  // linear bcrypt.compare scan over every active key.
+  @Index({ unique: true })
   @Column()
   @IsNotEmpty()
   @IsString()

--- a/src/data/entity/api-key.entity.ts
+++ b/src/data/entity/api-key.entity.ts
@@ -10,8 +10,11 @@ import {
 import User from "./user.entity";
 
 // Direct (non-login) API access for bot/automation consumers. Each key is
-// tied to a dedicated service User (role fixed at coordinator, no Person
-// attached) so the existing role-based authenticate() checks apply unchanged.
+// tied to a dedicated service User minted with one of admin/coordinator/agent
+// as its role, so the existing role-based authenticate() checks apply
+// unchanged. An agent-role service user also gets a Person + AgentPerson
+// membership (see create-api-key.ts) since agent-scoped write routes check
+// membership, not just role.
 // No self-service endpoints yet — minted/revoked via CLI (see
 // src/data/scripts/create-api-key.ts, revoke-api-key.ts).
 @Entity()

--- a/src/data/migrations/1786691450063-add-api-key.ts
+++ b/src/data/migrations/1786691450063-add-api-key.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddApiKey1786691450063 implements MigrationInterface {
+  name = "AddApiKey1786691450063";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "api_key" ("id" SERIAL NOT NULL, "label" character varying NOT NULL, "key_hash" character varying NOT NULL, "user_id" integer NOT NULL, "revoked_at" TIMESTAMP, "last_used_at" TIMESTAMP, "created_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_b1bd840641b8acbaad89c3d8d11" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_14747b6de7344b8b456573605c" ON "api_key" ("label") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "api_key" ADD CONSTRAINT "FK_6a0830f03e537b239a53269b27d" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "api_key" DROP CONSTRAINT "FK_6a0830f03e537b239a53269b27d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_14747b6de7344b8b456573605c"`,
+    );
+    await queryRunner.query(`DROP TABLE "api_key"`);
+  }
+}

--- a/src/data/migrations/1786800615564-add-api-key.ts
+++ b/src/data/migrations/1786800615564-add-api-key.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class AddApiKey1786691450063 implements MigrationInterface {
-  name = "AddApiKey1786691450063";
+export class AddApiKey1786800615564 implements MigrationInterface {
+  name = "AddApiKey1786800615564";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
@@ -11,6 +11,9 @@ export class AddApiKey1786691450063 implements MigrationInterface {
       `CREATE UNIQUE INDEX "IDX_14747b6de7344b8b456573605c" ON "api_key" ("label") `,
     );
     await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_3c9751d2a6011ba13e27838105" ON "api_key" ("key_hash") `,
+    );
+    await queryRunner.query(
       `ALTER TABLE "api_key" ADD CONSTRAINT "FK_6a0830f03e537b239a53269b27d" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
   }
@@ -18,6 +21,9 @@ export class AddApiKey1786691450063 implements MigrationInterface {
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE "api_key" DROP CONSTRAINT "FK_6a0830f03e537b239a53269b27d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_3c9751d2a6011ba13e27838105"`,
     );
     await queryRunner.query(
       `DROP INDEX "public"."IDX_14747b6de7344b8b456573605c"`,

--- a/src/data/scripts/create-api-key.ts
+++ b/src/data/scripts/create-api-key.ts
@@ -1,0 +1,72 @@
+import "reflect-metadata";
+import * as crypto from "crypto";
+import { UserRole } from "need4deed-sdk";
+import { dataSource } from "../data-source";
+import ApiKey from "../entity/api-key.entity";
+import User from "../entity/user.entity";
+import { getRepository, hashPassword } from "../utils";
+
+// Mints a direct (non-login) API key for bot/automation access, scoped to
+// the coordinator role. No self-service endpoint yet — see be#875.
+// Usage: yarn create-api-key --label <bot-label>
+
+function parseArgs(): { label: string } {
+  const args = process.argv.slice(2);
+  const labelIndex = args.indexOf("--label");
+  const label = labelIndex !== -1 ? args[labelIndex + 1] : undefined;
+  if (!label) {
+    throw new Error("Usage: yarn create-api-key --label <bot-label>");
+  }
+  return { label };
+}
+
+async function main() {
+  const { label } = parseArgs();
+
+  await dataSource.initialize();
+  try {
+    const userRepository = getRepository(dataSource, User);
+    const apiKeyRepository = getRepository(dataSource, ApiKey);
+
+    const existing = await apiKeyRepository.findOne({ where: { label } });
+    if (existing) {
+      throw new Error(
+        `An API key with label "${label}" already exists. Revoke it first if you want to reissue.`,
+      );
+    }
+
+    // Service user has no Person and never logs in via password — the
+    // password column is NOT NULL, so a random, never-shared placeholder
+    // fills it rather than a guessable literal.
+    const placeholderPassword = crypto.randomBytes(32).toString("hex");
+    const user = await userRepository.save(
+      new User({
+        email: `api-key+${label}@bots.need4deed.org`,
+        password: await hashPassword(placeholderPassword),
+        role: UserRole.COORDINATOR,
+        isActive: true,
+      }),
+    );
+
+    const rawKey = `n4d_${crypto.randomBytes(32).toString("hex")}`;
+    await apiKeyRepository.save(
+      new ApiKey({
+        label,
+        keyHash: await hashPassword(rawKey),
+        userId: user.id,
+      }),
+    );
+
+    console.log(
+      `API key "${label}" created. Store it now — it will not be shown again:`,
+    );
+    console.log(rawKey);
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/src/data/scripts/create-api-key.ts
+++ b/src/data/scripts/create-api-key.ts
@@ -1,32 +1,55 @@
 import "reflect-metadata";
 import * as crypto from "crypto";
-import { UserRole } from "need4deed-sdk";
+import { AgentMembershipStatus, AgentRoleType, UserRole } from "need4deed-sdk";
 import { dataSource } from "../data-source";
 import ApiKey from "../entity/api-key.entity";
+import AgentPerson from "../entity/m2m/agent-person";
+import Agent from "../entity/opportunity/agent.entity";
+import Person from "../entity/person.entity";
 import User from "../entity/user.entity";
 import { getRepository, hashPassword } from "../utils";
 
-// Mints a direct (non-login) API key for bot/automation access, scoped to
-// the coordinator role. No self-service endpoint yet — see be#875.
-// Usage: yarn create-api-key --label <bot-label>
+// Mints a direct (non-login) API key for bot/automation access. No
+// self-service endpoint yet — see be#875.
+// Usage: yarn create-api-key --label <bot-label> --role <admin|coordinator|agent> [--agent-id <id>]
 
-function parseArgs(): { label: string } {
+const ALLOWED_ROLES = [UserRole.ADMIN, UserRole.COORDINATOR, UserRole.AGENT];
+
+function parseArgs(): { label: string; role: UserRole; agentId?: number } {
   const args = process.argv.slice(2);
-  const labelIndex = args.indexOf("--label");
-  const label = labelIndex !== -1 ? args[labelIndex + 1] : undefined;
-  if (!label) {
-    throw new Error("Usage: yarn create-api-key --label <bot-label>");
+  const get = (flag: string) => {
+    const index = args.indexOf(flag);
+    return index !== -1 ? args[index + 1] : undefined;
+  };
+
+  const label = get("--label");
+  const role = get("--role") as UserRole | undefined;
+  const agentIdRaw = get("--agent-id");
+
+  if (!label || !role || !ALLOWED_ROLES.includes(role)) {
+    throw new Error(
+      "Usage: yarn create-api-key --label <bot-label> --role <admin|coordinator|agent> [--agent-id <id>]",
+    );
   }
-  return { label };
+
+  if (role === UserRole.AGENT && !agentIdRaw) {
+    throw new Error(
+      "--agent-id is required for --role agent (agent-scoped write routes require an AgentPerson membership).",
+    );
+  }
+
+  return { label, role, agentId: agentIdRaw ? Number(agentIdRaw) : undefined };
 }
 
 async function main() {
-  const { label } = parseArgs();
+  const { label, role, agentId } = parseArgs();
 
   await dataSource.initialize();
   try {
     const userRepository = getRepository(dataSource, User);
     const apiKeyRepository = getRepository(dataSource, ApiKey);
+    const agentRepository = getRepository(dataSource, Agent);
+    const agentPersonRepository = getRepository(dataSource, AgentPerson);
 
     const existing = await apiKeyRepository.findOne({ where: { label } });
     if (existing) {
@@ -35,18 +58,40 @@ async function main() {
       );
     }
 
-    // Service user has no Person and never logs in via password — the
-    // password column is NOT NULL, so a random, never-shared placeholder
-    // fills it rather than a guessable literal.
+    let agent: Agent | null = null;
+    if (role === UserRole.AGENT) {
+      agent = await agentRepository.findOneBy({ id: agentId });
+      if (!agent) {
+        throw new Error(`Agent (id:${agentId}) not found.`);
+      }
+    }
+
+    // Service user never logs in via password — the password column is NOT
+    // NULL, so a random, never-shared placeholder fills it rather than a
+    // guessable literal. admin/coordinator keys have no Person (not scoped
+    // to a center); an agent key gets a Person so it can hold the
+    // AgentPerson membership agent-scoped write routes require.
     const placeholderPassword = crypto.randomBytes(32).toString("hex");
     const user = await userRepository.save(
       new User({
         email: `api-key+${label}@bots.need4deed.org`,
         password: await hashPassword(placeholderPassword),
-        role: UserRole.COORDINATOR,
+        role,
         isActive: true,
+        ...(agent ? { person: new Person({ firstName: label }) } : {}),
       }),
     );
+
+    if (agent) {
+      await agentPersonRepository.save(
+        new AgentPerson({
+          agentId: agent.id,
+          personId: user.personId,
+          role: AgentRoleType.OTHER,
+          status: AgentMembershipStatus.ACTIVE,
+        }),
+      );
+    }
 
     const rawKey = `n4d_${crypto.randomBytes(32).toString("hex")}`;
     await apiKeyRepository.save(
@@ -58,7 +103,7 @@ async function main() {
     );
 
     console.log(
-      `API key "${label}" created. Store it now — it will not be shown again:`,
+      `API key "${label}" created (role: ${role}${agent ? `, agent: "${agent.title}"` : ""}). Store it now — it will not be shown again:`,
     );
     console.log(rawKey);
   } finally {

--- a/src/data/scripts/create-api-key.ts
+++ b/src/data/scripts/create-api-key.ts
@@ -1,55 +1,84 @@
 import "reflect-metadata";
 import * as crypto from "crypto";
 import { AgentMembershipStatus, AgentRoleType, UserRole } from "need4deed-sdk";
+import { DataSource } from "typeorm";
 import { dataSource } from "../data-source";
 import ApiKey from "../entity/api-key.entity";
 import AgentPerson from "../entity/m2m/agent-person";
 import Agent from "../entity/opportunity/agent.entity";
 import Person from "../entity/person.entity";
 import User from "../entity/user.entity";
-import { getRepository, hashPassword } from "../utils";
+import { hashPassword, sha256Hex } from "../utils";
 
 // Mints a direct (non-login) API key for bot/automation access. No
 // self-service endpoint yet — see be#875.
 // Usage: yarn create-api-key --label <bot-label> --role <admin|coordinator|agent> [--agent-id <id>]
 
 const ALLOWED_ROLES = [UserRole.ADMIN, UserRole.COORDINATOR, UserRole.AGENT];
+const USAGE =
+  "Usage: yarn create-api-key --label <bot-label> --role <admin|coordinator|agent> [--agent-id <id>]";
 
-function parseArgs(): { label: string; role: UserRole; agentId?: number } {
-  const args = process.argv.slice(2);
+export interface CreateApiKeyOptions {
+  label: string;
+  role: UserRole;
+  agentId?: number;
+}
+
+export interface CreateApiKeyResult {
+  rawKey: string;
+  userId: number;
+  agentTitle?: string;
+}
+
+export function parseArgs(argv: string[]): CreateApiKeyOptions {
   const get = (flag: string) => {
-    const index = args.indexOf(flag);
-    return index !== -1 ? args[index + 1] : undefined;
+    const index = argv.indexOf(flag);
+    return index !== -1 ? argv[index + 1] : undefined;
   };
 
   const label = get("--label");
-  const role = get("--role") as UserRole | undefined;
+  const role = get("--role")?.toLowerCase() as UserRole | undefined;
   const agentIdRaw = get("--agent-id");
 
   if (!label || !role || !ALLOWED_ROLES.includes(role)) {
-    throw new Error(
-      "Usage: yarn create-api-key --label <bot-label> --role <admin|coordinator|agent> [--agent-id <id>]",
-    );
+    throw new Error(USAGE);
   }
 
-  if (role === UserRole.AGENT && !agentIdRaw) {
+  if (role !== UserRole.AGENT) {
+    return { label, role };
+  }
+
+  if (!agentIdRaw) {
     throw new Error(
       "--agent-id is required for --role agent (agent-scoped write routes require an AgentPerson membership).",
     );
   }
 
-  return { label, role, agentId: agentIdRaw ? Number(agentIdRaw) : undefined };
+  const agentId = Number(agentIdRaw);
+  if (!Number.isInteger(agentId) || agentId <= 0) {
+    throw new Error(
+      `--agent-id must be a positive integer, got "${agentIdRaw}".`,
+    );
+  }
+
+  return { label, role, agentId };
 }
 
-async function main() {
-  const { label, role, agentId } = parseArgs();
+// All writes run in one transaction: a service User (+ Person/AgentPerson
+// for an agent-role key) with no corresponding ApiKey row would be an
+// unrevocable, untraceable credential-less account if a crash landed
+// between the individual saves.
+export async function createApiKey(
+  ds: DataSource,
+  { label, role, agentId }: CreateApiKeyOptions,
+): Promise<CreateApiKeyResult> {
+  const rawKey = `n4d_${crypto.randomBytes(32).toString("hex")}`;
 
-  await dataSource.initialize();
-  try {
-    const userRepository = getRepository(dataSource, User);
-    const apiKeyRepository = getRepository(dataSource, ApiKey);
-    const agentRepository = getRepository(dataSource, Agent);
-    const agentPersonRepository = getRepository(dataSource, AgentPerson);
+  const { userId, agentTitle } = await ds.transaction(async (manager) => {
+    const apiKeyRepository = manager.getRepository(ApiKey);
+    const agentRepository = manager.getRepository(Agent);
+    const userRepository = manager.getRepository(User);
+    const agentPersonRepository = manager.getRepository(AgentPerson);
 
     const existing = await apiKeyRepository.findOne({ where: { label } });
     if (existing) {
@@ -93,17 +122,24 @@ async function main() {
       );
     }
 
-    const rawKey = `n4d_${crypto.randomBytes(32).toString("hex")}`;
     await apiKeyRepository.save(
-      new ApiKey({
-        label,
-        keyHash: await hashPassword(rawKey),
-        userId: user.id,
-      }),
+      new ApiKey({ label, keyHash: sha256Hex(rawKey), userId: user.id }),
     );
 
+    return { userId: user.id, agentTitle: agent?.title };
+  });
+
+  return { rawKey, userId, agentTitle };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  await dataSource.initialize();
+  try {
+    const { rawKey, agentTitle } = await createApiKey(dataSource, opts);
     console.log(
-      `API key "${label}" created (role: ${role}${agent ? `, agent: "${agent.title}"` : ""}). Store it now — it will not be shown again:`,
+      `API key "${opts.label}" created (role: ${opts.role}${agentTitle ? `, agent: "${agentTitle}"` : ""}). Store it now — it will not be shown again:`,
     );
     console.log(rawKey);
   } finally {
@@ -111,7 +147,9 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err.message || err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err.message || err);
+    process.exit(1);
+  });
+}

--- a/src/data/scripts/create-api-key.ts
+++ b/src/data/scripts/create-api-key.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import * as crypto from "crypto";
 import { AgentMembershipStatus, AgentRoleType, UserRole } from "need4deed-sdk";
 import { DataSource } from "typeorm";
+import logger from "../../logger";
 import { dataSource } from "../data-source";
 import ApiKey from "../entity/api-key.entity";
 import AgentPerson from "../entity/m2m/agent-person";
@@ -138,10 +139,10 @@ async function main() {
   await dataSource.initialize();
   try {
     const { rawKey, agentTitle } = await createApiKey(dataSource, opts);
-    console.log(
-      `API key "${opts.label}" created (role: ${opts.role}${agentTitle ? `, agent: "${agentTitle}"` : ""}). Store it now — it will not be shown again:`,
+    logger.info(
+      `API key "${opts.label}" created (role: ${opts.role}${agentTitle ? `, agent: "${agentTitle}"` : ""}).`,
     );
-    console.log(rawKey);
+    logger.info(`Store this key now — it will not be shown again: ${rawKey}`);
   } finally {
     await dataSource.destroy();
   }

--- a/src/data/scripts/revoke-api-key.ts
+++ b/src/data/scripts/revoke-api-key.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+import { DataSource } from "typeorm";
 import { dataSource } from "../data-source";
 import ApiKey from "../entity/api-key.entity";
 import { getRepository } from "../utils";
@@ -6,40 +7,60 @@ import { getRepository } from "../utils";
 // Revokes a direct (non-login) API key by label. See be#875.
 // Usage: yarn revoke-api-key --label <bot-label>
 
-function parseArgs(): { label: string } {
-  const args = process.argv.slice(2);
-  const labelIndex = args.indexOf("--label");
-  const label = labelIndex !== -1 ? args[labelIndex + 1] : undefined;
+export interface RevokeApiKeyOptions {
+  label: string;
+}
+
+export interface RevokeApiKeyResult {
+  alreadyRevoked: boolean;
+}
+
+export function parseArgs(argv: string[]): RevokeApiKeyOptions {
+  const index = argv.indexOf("--label");
+  const label = index !== -1 ? argv[index + 1] : undefined;
   if (!label) {
     throw new Error("Usage: yarn revoke-api-key --label <bot-label>");
   }
   return { label };
 }
 
+export async function revokeApiKey(
+  ds: DataSource,
+  { label }: RevokeApiKeyOptions,
+): Promise<RevokeApiKeyResult> {
+  const apiKeyRepository = getRepository(ds, ApiKey);
+  const apiKey = await apiKeyRepository.findOne({ where: { label } });
+  if (!apiKey) {
+    throw new Error(`No API key found with label "${label}".`);
+  }
+  if (apiKey.revokedAt) {
+    return { alreadyRevoked: true };
+  }
+
+  apiKey.revokedAt = new Date();
+  await apiKeyRepository.save(apiKey);
+  return { alreadyRevoked: false };
+}
+
 async function main() {
-  const { label } = parseArgs();
+  const opts = parseArgs(process.argv.slice(2));
 
   await dataSource.initialize();
   try {
-    const apiKeyRepository = getRepository(dataSource, ApiKey);
-    const apiKey = await apiKeyRepository.findOne({ where: { label } });
-    if (!apiKey) {
-      throw new Error(`No API key found with label "${label}".`);
-    }
-    if (apiKey.revokedAt) {
-      console.log(`API key "${label}" is already revoked.`);
-      return;
-    }
-
-    apiKey.revokedAt = new Date();
-    await apiKeyRepository.save(apiKey);
-    console.log(`API key "${label}" revoked.`);
+    const { alreadyRevoked } = await revokeApiKey(dataSource, opts);
+    console.log(
+      alreadyRevoked
+        ? `API key "${opts.label}" is already revoked.`
+        : `API key "${opts.label}" revoked.`,
+    );
   } finally {
     await dataSource.destroy();
   }
 }
 
-main().catch((err) => {
-  console.error(err.message || err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err.message || err);
+    process.exit(1);
+  });
+}

--- a/src/data/scripts/revoke-api-key.ts
+++ b/src/data/scripts/revoke-api-key.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import { DataSource } from "typeorm";
+import logger from "../../logger";
 import { dataSource } from "../data-source";
 import ApiKey from "../entity/api-key.entity";
 import { getRepository } from "../utils";
@@ -48,7 +49,7 @@ async function main() {
   await dataSource.initialize();
   try {
     const { alreadyRevoked } = await revokeApiKey(dataSource, opts);
-    console.log(
+    logger.info(
       alreadyRevoked
         ? `API key "${opts.label}" is already revoked.`
         : `API key "${opts.label}" revoked.`,

--- a/src/data/scripts/revoke-api-key.ts
+++ b/src/data/scripts/revoke-api-key.ts
@@ -1,0 +1,45 @@
+import "reflect-metadata";
+import { dataSource } from "../data-source";
+import ApiKey from "../entity/api-key.entity";
+import { getRepository } from "../utils";
+
+// Revokes a direct (non-login) API key by label. See be#875.
+// Usage: yarn revoke-api-key --label <bot-label>
+
+function parseArgs(): { label: string } {
+  const args = process.argv.slice(2);
+  const labelIndex = args.indexOf("--label");
+  const label = labelIndex !== -1 ? args[labelIndex + 1] : undefined;
+  if (!label) {
+    throw new Error("Usage: yarn revoke-api-key --label <bot-label>");
+  }
+  return { label };
+}
+
+async function main() {
+  const { label } = parseArgs();
+
+  await dataSource.initialize();
+  try {
+    const apiKeyRepository = getRepository(dataSource, ApiKey);
+    const apiKey = await apiKeyRepository.findOne({ where: { label } });
+    if (!apiKey) {
+      throw new Error(`No API key found with label "${label}".`);
+    }
+    if (apiKey.revokedAt) {
+      console.log(`API key "${label}" is already revoked.`);
+      return;
+    }
+
+    apiKey.revokedAt = new Date();
+    await apiKeyRepository.save(apiKey);
+    console.log(`API key "${label}" revoked.`);
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/src/data/utils/hash-token.ts
+++ b/src/data/utils/hash-token.ts
@@ -1,0 +1,9 @@
+import * as crypto from "crypto";
+
+// SHA-256, not bcrypt: this hashes high-entropy random tokens (API keys),
+// not low-entropy human passwords — no need to slow-hash, and a fast
+// deterministic digest lets it be looked up via an indexed exact match
+// instead of a linear bcrypt.compare scan over every row.
+export function sha256Hex(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}

--- a/src/data/utils/index.ts
+++ b/src/data/utils/index.ts
@@ -7,6 +7,7 @@ export * from "./get-ssl-for-data-source";
 export * from "./getLoggingForDataSource";
 export * from "./getRRULE";
 export * from "./getStartEndDates";
+export * from "./hash-token";
 export * from "./passwd";
 export * from "./remove-data";
 export * from "./update-opportunity-matching";

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -10,7 +10,7 @@ import {
   cookieOptions,
 } from "../../config/constants";
 import User from "../../data/entity/user.entity";
-import { verifyPassword } from "../../data/utils";
+import { sha256Hex } from "../../data/utils";
 import logger from "../../logger";
 import { AuthOptions } from "../types";
 
@@ -26,27 +26,27 @@ async function jwtPlugin(
     },
   });
 
-  // Direct (non-login) API access: looks up the raw key against active
-  // (non-revoked) ApiKey rows and returns the linked service user. The key
-  // set is expected to stay small (bot accounts only), so a bcrypt.compare
-  // per row is cheap — bcrypt can't be looked up by an indexed hash match.
+  // Direct (non-login) API access: an O(1) indexed lookup of the raw key's
+  // SHA-256 digest against active (non-revoked) ApiKey rows, returning the
+  // linked service user. This must stay a cheap single-row lookup (not a
+  // linear bcrypt.compare scan) since, unlike the JWT-cookie path, it runs
+  // on every request from an unauthenticated caller that merely sends the
+  // header — an expensive per-row check here would be a free CPU-exhaustion
+  // lever for anyone spraying garbage keys at any protected route.
   async function findUserByApiKey(rawKey: string): Promise<User | null> {
-    const activeKeys = await fastify.db.apiKeyRepository.find({
-      where: { revokedAt: IsNull() },
+    const apiKey = await fastify.db.apiKeyRepository.findOne({
+      where: { keyHash: sha256Hex(rawKey), revokedAt: IsNull() },
       relations: { user: true },
     });
 
-    for (const apiKey of activeKeys) {
-      if (await verifyPassword(rawKey, apiKey.keyHash)) {
-        fastify.db.apiKeyRepository
-          .update(apiKey.id, { lastUsedAt: new Date() })
-          .catch((err) =>
-            logger.error(err, "Failed to update api key lastUsedAt"),
-          );
-        return apiKey.user;
-      }
+    if (!apiKey) {
+      return null;
     }
-    return null;
+
+    fastify.db.apiKeyRepository
+      .update(apiKey.id, { lastUsedAt: new Date() })
+      .catch((err) => logger.error(err, "Failed to update api key lastUsedAt"));
+    return apiKey.user;
   }
 
   fastify.decorate("authenticate", function (opt?: AuthOptions) {
@@ -74,6 +74,12 @@ async function jwtPlugin(
         if (!user) {
           throw new UnauthenticatedError("Invalid API key.");
         }
+        // isActive is checked here but deliberately not for the JWT-cookie
+        // path below: this is a new gate introduced for API keys, not a
+        // fix applied unevenly. Changing existing cookie-session behavior
+        // (an already-issued 15-min token for a since-deactivated user
+        // currently still authenticates until it expires) is out of scope
+        // for this change.
         if (!user.isActive) {
           throw new UnauthenticatedError("Account is not active.");
         }

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -2,8 +2,15 @@ import fastifyJwt from "@fastify/jwt";
 import { FastifyInstance, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
 import { UserRole } from "need4deed-sdk";
+import { IsNull } from "typeorm";
 import { UnauthenticatedError, UnauthorizedError } from "../../config";
-import { accessCookieName, cookieOptions } from "../../config/constants";
+import {
+  accessCookieName,
+  apiKeyHeaderName,
+  cookieOptions,
+} from "../../config/constants";
+import User from "../../data/entity/user.entity";
+import { verifyPassword } from "../../data/utils";
 import logger from "../../logger";
 import { AuthOptions } from "../types";
 
@@ -19,6 +26,29 @@ async function jwtPlugin(
     },
   });
 
+  // Direct (non-login) API access: looks up the raw key against active
+  // (non-revoked) ApiKey rows and returns the linked service user. The key
+  // set is expected to stay small (bot accounts only), so a bcrypt.compare
+  // per row is cheap — bcrypt can't be looked up by an indexed hash match.
+  async function findUserByApiKey(rawKey: string): Promise<User | null> {
+    const activeKeys = await fastify.db.apiKeyRepository.find({
+      where: { revokedAt: IsNull() },
+      relations: { user: true },
+    });
+
+    for (const apiKey of activeKeys) {
+      if (await verifyPassword(rawKey, apiKey.keyHash)) {
+        fastify.db.apiKeyRepository
+          .update(apiKey.id, { lastUsedAt: new Date() })
+          .catch((err) =>
+            logger.error(err, "Failed to update api key lastUsedAt"),
+          );
+        return apiKey.user;
+      }
+    }
+    return null;
+  }
+
   fastify.decorate("authenticate", function (opt?: AuthOptions) {
     return async function (request: FastifyRequest) {
       logger.debug(
@@ -32,22 +62,39 @@ async function jwtPlugin(
         return;
       }
 
-      try {
-        await request.jwtVerify();
-      } catch {
-        throw new UnauthenticatedError("Authorization failed.");
-      }
+      const apiKeyHeader = request.headers[apiKeyHeaderName];
+      const rawApiKey = Array.isArray(apiKeyHeader)
+        ? apiKeyHeader[0]
+        : apiKeyHeader;
 
-      const userId = request.user?.id;
-      logger.debug(`jwtPlugin:authenticated: ${userId}`);
+      let user: User | null;
 
-      const userRepository = fastify.db.userRepository;
-      const user = await userRepository.findOne({
-        where: { id: userId },
-      });
+      if (rawApiKey) {
+        user = await findUserByApiKey(rawApiKey);
+        if (!user) {
+          throw new UnauthenticatedError("Invalid API key.");
+        }
+        if (!user.isActive) {
+          throw new UnauthenticatedError("Account is not active.");
+        }
+        logger.debug(`jwtPlugin:authenticated via api key: ${user.id}`);
+      } else {
+        try {
+          await request.jwtVerify();
+        } catch {
+          throw new UnauthenticatedError("Authorization failed.");
+        }
 
-      if (!user) {
-        throw new UnauthorizedError("User not found.");
+        const userId = request.user?.id;
+        logger.debug(`jwtPlugin:authenticated: ${userId}`);
+
+        user = await fastify.db.userRepository.findOne({
+          where: { id: userId },
+        });
+
+        if (!user) {
+          throw new UnauthorizedError("User not found.");
+        }
       }
 
       // Expose the already-loaded user (carries personId + DB-authoritative
@@ -57,7 +104,7 @@ async function jwtPlugin(
 
       if (user.role === UserRole.ADMIN) {
         logger.debug(
-          `Admin user ${userId} authenticated, bypassing further checks.`,
+          `Admin user ${user.id} authenticated, bypassing further checks.`,
         );
         return;
       }
@@ -65,7 +112,7 @@ async function jwtPlugin(
       const { role, allowSelf } = opt || {};
 
       logger.debug(
-        `authenticate role:${role}, allowSelf:${allowSelf}, userId:${userId}`,
+        `authenticate role:${role}, allowSelf:${allowSelf}, userId:${user.id}`,
       );
 
       if (role && role !== user.role) {
@@ -74,7 +121,7 @@ async function jwtPlugin(
 
       if (allowSelf) {
         const requestParamId = (request.params as { id?: string }).id;
-        if (String(userId) !== requestParamId) {
+        if (String(user.id) !== requestParamId) {
           throw new UnauthorizedError("Permission denied");
         }
       }

--- a/src/server/plugins/typeorm.ts
+++ b/src/server/plugins/typeorm.ts
@@ -2,6 +2,7 @@ import { FastifyPluginAsync } from "fastify";
 import fp from "fastify-plugin";
 import { initDatabase } from "../../data";
 import { dataSource } from "../../data/data-source";
+import ApiKey from "../../data/entity/api-key.entity";
 import Comment from "../../data/entity/comment.entity";
 import Communication from "../../data/entity/communication.entity";
 import Deal from "../../data/entity/deal.entity";
@@ -36,6 +37,7 @@ const typeormPlugin: FastifyPluginAsync = async (fastify) => {
 
     // Decorate the Fastify instance with repositories
     fastify.decorate("db", {
+      apiKeyRepository: dataSource.getRepository(ApiKey),
       userRepository: dataSource.getRepository(User),
       personRepository: dataSource.getRepository(Person),
       volunteerRepository: dataSource.getRepository(Volunteer),

--- a/src/server/types/fastify.d.ts
+++ b/src/server/types/fastify.d.ts
@@ -3,6 +3,7 @@ import "fastify";
 import { onRequestHookHandler } from "fastify";
 import { UserRole } from "need4deed-sdk";
 import { Repository } from "typeorm";
+import ApiKey from "../../data/entity/api-key.entity";
 import Appreciation from "../../data/entity/appreciation.entity";
 import Comment from "../../data/entity/comment.entity";
 import Communication from "../../data/entity/communication.entity";
@@ -30,6 +31,7 @@ import { AuthOptions } from "./auth";
 declare module "fastify" {
   interface FastifyInstance {
     db: {
+      apiKeyRepository: Repository<ApiKey>;
       userRepository: Repository<User>;
       personRepository: Repository<Person>;
       volunteerRepository: Repository<Volunteer>;

--- a/src/test/data/scripts/create-api-key.test.ts
+++ b/src/test/data/scripts/create-api-key.test.ts
@@ -1,0 +1,172 @@
+import { FastifyInstance } from "fastify";
+import { AgentMembershipStatus, AgentRoleType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { dataSource } from "../../../data/data-source";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import { createApiKey, parseArgs } from "../../../data/scripts/create-api-key";
+import { createServer } from "../../../server";
+
+describe("create-api-key parseArgs", () => {
+  it("requires --label and --role", () => {
+    expect(() => parseArgs([])).toThrow(/Usage/);
+    expect(() => parseArgs(["--label", "bot"])).toThrow(/Usage/);
+  });
+
+  it("rejects a role outside admin/coordinator/agent", () => {
+    expect(() => parseArgs(["--label", "bot", "--role", "volunteer"])).toThrow(
+      /Usage/,
+    );
+  });
+
+  it("accepts --role case-insensitively", () => {
+    expect(parseArgs(["--label", "bot", "--role", "Coordinator"])).toEqual({
+      label: "bot",
+      role: UserRole.COORDINATOR,
+    });
+  });
+
+  it("requires --agent-id for --role agent", () => {
+    expect(() => parseArgs(["--label", "bot", "--role", "agent"])).toThrow(
+      /--agent-id is required/,
+    );
+  });
+
+  it("rejects a non-integer --agent-id", () => {
+    expect(() =>
+      parseArgs(["--label", "bot", "--role", "agent", "--agent-id", "abc"]),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      parseArgs(["--label", "bot", "--role", "agent", "--agent-id", "0"]),
+    ).toThrow(/positive integer/);
+  });
+
+  it("parses a valid agent mint", () => {
+    expect(
+      parseArgs(["--label", "bot", "--role", "agent", "--agent-id", "7"]),
+    ).toEqual({ label: "bot", role: UserRole.AGENT, agentId: 7 });
+  });
+});
+
+describe("createApiKey", () => {
+  let fastify: FastifyInstance;
+  let agent: Agent;
+  const labelsToClean: string[] = [];
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `create-api-key test agent ${Date.now()}` }),
+    );
+  });
+
+  afterAll(async () => {
+    for (const label of labelsToClean) {
+      const key = await fastify.db.apiKeyRepository.findOne({
+        where: { label },
+      });
+      if (!key) {
+        continue;
+      }
+      const user = await fastify.db.userRepository.findOne({
+        where: { id: key.userId },
+      });
+      await fastify.db.apiKeyRepository.delete({ id: key.id });
+      if (user?.personId) {
+        await fastify.db.agentPersonRepository.delete({
+          personId: user.personId,
+        });
+      }
+      await fastify.db.userRepository.delete({ id: key.userId });
+      if (user?.personId) {
+        await fastify.db.personRepository.delete({ id: user.personId });
+      }
+    }
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.close();
+  });
+
+  it("mints an admin key with no attached Person", async () => {
+    const label = `test-admin-${Date.now()}`;
+    labelsToClean.push(label);
+
+    const { rawKey, userId } = await createApiKey(dataSource, {
+      label,
+      role: UserRole.ADMIN,
+    });
+
+    expect(rawKey).toMatch(/^n4d_[0-9a-f]{64}$/);
+
+    const user = await fastify.db.userRepository.findOneByOrFail({
+      id: userId,
+    });
+    expect(user.role).toBe(UserRole.ADMIN);
+    expect(user.personId).toBeFalsy();
+
+    const apiKey = await fastify.db.apiKeyRepository.findOneByOrFail({
+      label,
+    });
+    expect(apiKey.keyHash).not.toBe(rawKey);
+    expect(apiKey.userId).toBe(userId);
+  });
+
+  it("mints an agent key with a Person and an active AgentPerson membership", async () => {
+    const label = `test-agent-${Date.now()}`;
+    labelsToClean.push(label);
+
+    const { userId, agentTitle } = await createApiKey(dataSource, {
+      label,
+      role: UserRole.AGENT,
+      agentId: agent.id,
+    });
+
+    expect(agentTitle).toBe(agent.title);
+
+    const user = await fastify.db.userRepository.findOneByOrFail({
+      id: userId,
+    });
+    expect(user.role).toBe(UserRole.AGENT);
+    expect(user.personId).toBeTruthy();
+
+    const membership = await fastify.db.agentPersonRepository.findOneByOrFail({
+      agentId: agent.id,
+      personId: user.personId,
+    });
+    expect(membership.status).toBe(AgentMembershipStatus.ACTIVE);
+    expect(membership.role).toBe(AgentRoleType.OTHER);
+  });
+
+  it("rejects a nonexistent --agent-id and leaves no orphaned User", async () => {
+    const label = `test-bad-agent-${Date.now()}`;
+
+    await expect(
+      createApiKey(dataSource, {
+        label,
+        role: UserRole.AGENT,
+        agentId: 999999999,
+      }),
+    ).rejects.toThrow(/not found/);
+
+    const orphan = await fastify.db.userRepository.findOne({
+      where: { email: `api-key+${label}@bots.need4deed.org` },
+    });
+    expect(orphan).toBeNull();
+  });
+
+  it("rejects a duplicate label without creating a second User", async () => {
+    const label = `test-dup-${Date.now()}`;
+    labelsToClean.push(label);
+
+    await createApiKey(dataSource, { label, role: UserRole.COORDINATOR });
+
+    await expect(
+      createApiKey(dataSource, { label, role: UserRole.COORDINATOR }),
+    ).rejects.toThrow(/already exists/);
+
+    const count = await fastify.db.userRepository.count({
+      where: { email: `api-key+${label}@bots.need4deed.org` },
+    });
+    expect(count).toBe(1);
+  });
+});

--- a/src/test/data/scripts/revoke-api-key.test.ts
+++ b/src/test/data/scripts/revoke-api-key.test.ts
@@ -1,0 +1,72 @@
+import { FastifyInstance } from "fastify";
+import { UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { dataSource } from "../../../data/data-source";
+import { createApiKey } from "../../../data/scripts/create-api-key";
+import { parseArgs, revokeApiKey } from "../../../data/scripts/revoke-api-key";
+import { createServer } from "../../../server";
+
+describe("revoke-api-key parseArgs", () => {
+  it("requires --label", () => {
+    expect(() => parseArgs([])).toThrow(/Usage/);
+  });
+
+  it("parses --label", () => {
+    expect(parseArgs(["--label", "bot"])).toEqual({ label: "bot" });
+  });
+});
+
+describe("revokeApiKey", () => {
+  let fastify: FastifyInstance;
+  const labelsToClean: string[] = [];
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    for (const label of labelsToClean) {
+      const key = await fastify.db.apiKeyRepository.findOne({
+        where: { label },
+      });
+      if (!key) {
+        continue;
+      }
+      await fastify.db.apiKeyRepository.delete({ id: key.id });
+      await fastify.db.userRepository.delete({ id: key.userId });
+    }
+    await fastify.close();
+  });
+
+  it("throws for an unknown label", async () => {
+    await expect(
+      revokeApiKey(dataSource, { label: "no-such-label" }),
+    ).rejects.toThrow(/No API key found/);
+  });
+
+  it("sets revokedAt on an active key", async () => {
+    const label = `test-revoke-${Date.now()}`;
+    labelsToClean.push(label);
+    await createApiKey(dataSource, { label, role: UserRole.COORDINATOR });
+
+    const result = await revokeApiKey(dataSource, { label });
+    expect(result.alreadyRevoked).toBe(false);
+
+    const apiKey = await fastify.db.apiKeyRepository.findOneByOrFail({
+      label,
+    });
+    expect(apiKey.revokedAt).not.toBeNull();
+  });
+
+  it("reports alreadyRevoked without erroring on a second call", async () => {
+    const label = `test-revoke-twice-${Date.now()}`;
+    labelsToClean.push(label);
+    await createApiKey(dataSource, { label, role: UserRole.COORDINATOR });
+
+    await revokeApiKey(dataSource, { label });
+    const secondCall = await revokeApiKey(dataSource, { label });
+
+    expect(secondCall.alreadyRevoked).toBe(true);
+  });
+});

--- a/src/test/server/plugins/jwt.test.ts
+++ b/src/test/server/plugins/jwt.test.ts
@@ -125,6 +125,33 @@ describe("X-API-Key authentication", () => {
     expect(response.json().message).toBe("Account is not active.");
   });
 
+  it("an admin-role key bypasses the route's role check, same as an admin cookie session would", async () => {
+    const rawKey = "n4d_admin-role-key";
+    const keyHash = await hashPassword(rawKey);
+
+    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([
+      new ApiKey({
+        id: 4,
+        keyHash,
+        revokedAt: null,
+        userId: 1,
+        user: { id: 1, role: UserRole.ADMIN, isActive: true } as any,
+      }),
+    ]);
+    vi.spyOn(fastify.db.apiKeyRepository, "update").mockResolvedValue(
+      {} as any,
+    );
+    vi.spyOn(fastify.db.trustedDomainRepository, "find").mockResolvedValue([]);
+
+    const response = await fastify.inject({
+      method: "GET",
+      url: "/trusted-domain",
+      headers: { "x-api-key": rawKey },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
   it("still enforces the route's role check for a key whose user lacks it", async () => {
     const rawKey = "n4d_volunteer-role-key";
     const keyHash = await hashPassword(rawKey);

--- a/src/test/server/plugins/jwt.test.ts
+++ b/src/test/server/plugins/jwt.test.ts
@@ -1,0 +1,192 @@
+import { FastifyInstance } from "fastify";
+import { UserRole } from "need4deed-sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import ApiKey from "../../../data/entity/api-key.entity";
+import { hashPassword } from "../../../data/utils";
+import logger from "../../../logger";
+import { createServer } from "../../../server";
+
+// Exercises the X-API-Key path added to authenticate() in
+// src/server/plugins/jwt.ts, against the existing COORDINATOR-only
+// GET /trusted-domain route (be#875).
+describe("X-API-Key authentication", () => {
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const coordinatorUser = {
+    id: 42,
+    role: UserRole.COORDINATOR,
+    isActive: true,
+  };
+
+  it("authenticates a coordinator-scoped route with a valid key and records lastUsedAt", async () => {
+    const rawKey = "n4d_test-raw-key";
+    const keyHash = await hashPassword(rawKey);
+
+    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([
+      new ApiKey({
+        id: 1,
+        keyHash,
+        revokedAt: null,
+        userId: 42,
+        user: coordinatorUser as any,
+      }),
+    ]);
+    const updateSpy = vi
+      .spyOn(fastify.db.apiKeyRepository, "update")
+      .mockResolvedValue({} as any);
+    vi.spyOn(fastify.db.trustedDomainRepository, "find").mockResolvedValue([]);
+
+    const response = await fastify.inject({
+      method: "GET",
+      url: "/trusted-domain",
+      headers: { "x-api-key": rawKey },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(updateSpy).toHaveBeenCalledWith(1, { lastUsedAt: expect.any(Date) });
+  });
+
+  it("rejects an unknown key with 401 and does not fall back to cookie auth", async () => {
+    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([]);
+
+    const response = await fastify.inject({
+      method: "GET",
+      url: "/trusted-domain",
+      headers: { "x-api-key": "not-a-real-key" },
+      // A valid cookie is deliberately absent-equivalent here: presence of
+      // the header must not trigger a fallback to jwtVerify().
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json().message).toBe("Invalid API key.");
+  });
+
+  it("rejects a revoked key (excluded by the repository's revokedAt filter)", async () => {
+    // authenticate() only ever sees non-revoked rows (find() is called with
+    // where: { revokedAt: IsNull() }), so a revoked key looks identical to
+    // an unknown one from the mock's perspective.
+    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([]);
+
+    const response = await fastify.inject({
+      method: "GET",
+      url: "/trusted-domain",
+      headers: { "x-api-key": "n4d_revoked-key" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json().message).toBe("Invalid API key.");
+  });
+
+  it("rejects a valid key whose service user has been deactivated", async () => {
+    const rawKey = "n4d_inactive-user-key";
+    const keyHash = await hashPassword(rawKey);
+
+    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([
+      new ApiKey({
+        id: 2,
+        keyHash,
+        revokedAt: null,
+        userId: 42,
+        user: { ...coordinatorUser, isActive: false } as any,
+      }),
+    ]);
+    vi.spyOn(fastify.db.apiKeyRepository, "update").mockResolvedValue(
+      {} as any,
+    );
+
+    const response = await fastify.inject({
+      method: "GET",
+      url: "/trusted-domain",
+      headers: { "x-api-key": rawKey },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json().message).toBe("Account is not active.");
+  });
+
+  it("still enforces the route's role check for a key whose user lacks it", async () => {
+    const rawKey = "n4d_volunteer-role-key";
+    const keyHash = await hashPassword(rawKey);
+
+    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([
+      new ApiKey({
+        id: 3,
+        keyHash,
+        revokedAt: null,
+        userId: 7,
+        user: { id: 7, role: UserRole.VOLUNTEER, isActive: true } as any,
+      }),
+    ]);
+    vi.spyOn(fastify.db.apiKeyRepository, "update").mockResolvedValue(
+      {} as any,
+    );
+
+    const response = await fastify.inject({
+      method: "GET",
+      url: "/trusted-domain",
+      headers: { "x-api-key": rawKey },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it("never logs the raw API key value", async () => {
+    const rawKey = "n4d_should-never-appear-in-logs";
+    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([]);
+    const debugSpy = vi.spyOn(logger, "debug");
+    const errorSpy = vi.spyOn(logger, "error");
+
+    await fastify.inject({
+      method: "GET",
+      url: "/trusted-domain",
+      headers: { "x-api-key": rawKey },
+    });
+
+    for (const call of [...debugSpy.mock.calls, ...errorSpy.mock.calls]) {
+      expect(JSON.stringify(call)).not.toContain(rawKey);
+    }
+  });
+
+  it("leaves the existing JWT-cookie flow unaffected when no header is sent", async () => {
+    vi.spyOn(fastify.db.userRepository, "findOne").mockResolvedValue(
+      coordinatorUser as any,
+    );
+    vi.spyOn(fastify.db.trustedDomainRepository, "find").mockResolvedValue([]);
+    const apiKeyFindSpy = vi.spyOn(fastify.db.apiKeyRepository, "find");
+
+    const accessToken = fastify.jwt.sign({
+      id: 42,
+      email: "coordinator@example.com",
+    });
+
+    const response = await fastify.inject({
+      method: "GET",
+      url: "/trusted-domain",
+      cookies: { access: accessToken },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(apiKeyFindSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/server/plugins/jwt.test.ts
+++ b/src/test/server/plugins/jwt.test.ts
@@ -10,7 +10,7 @@ import {
   vi,
 } from "vitest";
 import ApiKey from "../../../data/entity/api-key.entity";
-import { hashPassword } from "../../../data/utils";
+import { sha256Hex } from "../../../data/utils";
 import logger from "../../../logger";
 import { createServer } from "../../../server";
 
@@ -41,17 +41,19 @@ describe("X-API-Key authentication", () => {
 
   it("authenticates a coordinator-scoped route with a valid key and records lastUsedAt", async () => {
     const rawKey = "n4d_test-raw-key";
-    const keyHash = await hashPassword(rawKey);
+    const keyHash = sha256Hex(rawKey);
 
-    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([
-      new ApiKey({
-        id: 1,
-        keyHash,
-        revokedAt: null,
-        userId: 42,
-        user: coordinatorUser as any,
-      }),
-    ]);
+    const findOneSpy = vi
+      .spyOn(fastify.db.apiKeyRepository, "findOne")
+      .mockResolvedValue(
+        new ApiKey({
+          id: 1,
+          keyHash,
+          revokedAt: null,
+          userId: 42,
+          user: coordinatorUser as any,
+        }),
+      );
     const updateSpy = vi
       .spyOn(fastify.db.apiKeyRepository, "update")
       .mockResolvedValue({} as any);
@@ -64,11 +66,16 @@ describe("X-API-Key authentication", () => {
     });
 
     expect(response.statusCode).toBe(200);
+    // The lookup must be a single indexed findOne by hash, not a scan over
+    // every active key — this is what makes an invalid-key request cheap.
+    expect(findOneSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ keyHash }) }),
+    );
     expect(updateSpy).toHaveBeenCalledWith(1, { lastUsedAt: expect.any(Date) });
   });
 
   it("rejects an unknown key with 401 and does not fall back to cookie auth", async () => {
-    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([]);
+    vi.spyOn(fastify.db.apiKeyRepository, "findOne").mockResolvedValue(null);
 
     const response = await fastify.inject({
       method: "GET",
@@ -83,10 +90,10 @@ describe("X-API-Key authentication", () => {
   });
 
   it("rejects a revoked key (excluded by the repository's revokedAt filter)", async () => {
-    // authenticate() only ever sees non-revoked rows (find() is called with
-    // where: { revokedAt: IsNull() }), so a revoked key looks identical to
-    // an unknown one from the mock's perspective.
-    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([]);
+    // authenticate() only ever matches non-revoked rows (findOne() is
+    // called with where: { keyHash, revokedAt: IsNull() }), so a revoked
+    // key looks identical to an unknown one from the mock's perspective.
+    vi.spyOn(fastify.db.apiKeyRepository, "findOne").mockResolvedValue(null);
 
     const response = await fastify.inject({
       method: "GET",
@@ -100,9 +107,9 @@ describe("X-API-Key authentication", () => {
 
   it("rejects a valid key whose service user has been deactivated", async () => {
     const rawKey = "n4d_inactive-user-key";
-    const keyHash = await hashPassword(rawKey);
+    const keyHash = sha256Hex(rawKey);
 
-    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([
+    vi.spyOn(fastify.db.apiKeyRepository, "findOne").mockResolvedValue(
       new ApiKey({
         id: 2,
         keyHash,
@@ -110,7 +117,7 @@ describe("X-API-Key authentication", () => {
         userId: 42,
         user: { ...coordinatorUser, isActive: false } as any,
       }),
-    ]);
+    );
     vi.spyOn(fastify.db.apiKeyRepository, "update").mockResolvedValue(
       {} as any,
     );
@@ -127,9 +134,9 @@ describe("X-API-Key authentication", () => {
 
   it("an admin-role key bypasses the route's role check, same as an admin cookie session would", async () => {
     const rawKey = "n4d_admin-role-key";
-    const keyHash = await hashPassword(rawKey);
+    const keyHash = sha256Hex(rawKey);
 
-    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([
+    vi.spyOn(fastify.db.apiKeyRepository, "findOne").mockResolvedValue(
       new ApiKey({
         id: 4,
         keyHash,
@@ -137,7 +144,7 @@ describe("X-API-Key authentication", () => {
         userId: 1,
         user: { id: 1, role: UserRole.ADMIN, isActive: true } as any,
       }),
-    ]);
+    );
     vi.spyOn(fastify.db.apiKeyRepository, "update").mockResolvedValue(
       {} as any,
     );
@@ -154,9 +161,9 @@ describe("X-API-Key authentication", () => {
 
   it("still enforces the route's role check for a key whose user lacks it", async () => {
     const rawKey = "n4d_volunteer-role-key";
-    const keyHash = await hashPassword(rawKey);
+    const keyHash = sha256Hex(rawKey);
 
-    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([
+    vi.spyOn(fastify.db.apiKeyRepository, "findOne").mockResolvedValue(
       new ApiKey({
         id: 3,
         keyHash,
@@ -164,7 +171,7 @@ describe("X-API-Key authentication", () => {
         userId: 7,
         user: { id: 7, role: UserRole.VOLUNTEER, isActive: true } as any,
       }),
-    ]);
+    );
     vi.spyOn(fastify.db.apiKeyRepository, "update").mockResolvedValue(
       {} as any,
     );
@@ -180,7 +187,7 @@ describe("X-API-Key authentication", () => {
 
   it("never logs the raw API key value", async () => {
     const rawKey = "n4d_should-never-appear-in-logs";
-    vi.spyOn(fastify.db.apiKeyRepository, "find").mockResolvedValue([]);
+    vi.spyOn(fastify.db.apiKeyRepository, "findOne").mockResolvedValue(null);
     const debugSpy = vi.spyOn(logger, "debug");
     const errorSpy = vi.spyOn(logger, "error");
 
@@ -200,7 +207,7 @@ describe("X-API-Key authentication", () => {
       coordinatorUser as any,
     );
     vi.spyOn(fastify.db.trustedDomainRepository, "find").mockResolvedValue([]);
-    const apiKeyFindSpy = vi.spyOn(fastify.db.apiKeyRepository, "find");
+    const apiKeyFindOneSpy = vi.spyOn(fastify.db.apiKeyRepository, "findOne");
 
     const accessToken = fastify.jwt.sign({
       id: 42,
@@ -214,6 +221,6 @@ describe("X-API-Key authentication", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(apiKeyFindSpy).not.toHaveBeenCalled();
+    expect(apiKeyFindOneSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #875

## Summary

- New `ApiKey` entity/table (`label`, `key_hash`, `user_id` FK, `revoked_at`, `last_used_at`, `created_at`) — self-contained migration, generated from the entity.
- `authenticate()` in `src/server/plugins/jwt.ts` accepts an `X-API-Key` header as an alternative to the JWT cookie: an indexed exact-match lookup on a SHA-256 digest of the key against active (non-revoked) rows, loads the linked service `User`, and falls through into the existing role/`allowSelf` checks unchanged. An invalid/revoked key fails closed (401) — it does not fall back to cookie auth. `lastUsedAt` is updated best-effort on each successful auth.
- Each key is minted with one of `admin`, `coordinator`, or `agent` as its role — the key gets exactly that role's permissions, same as any other user, so every existing `fastify.authenticate({ role: ... })` route works unchanged:
  - `admin`/`coordinator` keys: no attached `Person` (the `personId` relation was already nullable) — not scoped to a center.
  - `agent` keys: role alone isn't enough here — agent-scoped write routes (edit agent, manage contacts, create/edit opportunity) additionally require an active `AgentPerson` membership at a specific center, resolved via `personId`. So `--role agent` requires `--agent-id` and also creates a `Person` + active `AgentPerson` membership at that center, atomically with the `User` and `ApiKey` rows (one DB transaction — a crash mid-mint can't leave an orphaned service account). Verified manually: an agent-role key can PATCH its own agent (204) but gets 403 on a different agent's PATCH.
- No new REST endpoints in this phase — `yarn create-api-key --label <name> --role <admin|coordinator|agent> [--agent-id <id>]` / `yarn revoke-api-key --label <name>` CLI scripts mint/revoke keys (mint prints the raw key once, never persisted in plaintext).
- No SDK contract change: no new endpoint, request/response shape, or error code is exposed.

## Changes since first review

- **Hashing:** switched from bcrypt to SHA-256 for the stored key hash. API keys are high-entropy random tokens, not human passwords, so they don't need slow/salted hashing — and bcrypt was forcing a linear `bcrypt.compare` scan over every active key on every request carrying an `X-API-Key` header (including garbage ones from unauthenticated callers), which is an unthrottled CPU-exhaustion vector on routes with no rate limiting. Now an indexed `findOne` by hash — O(1) regardless of key count.
- **Atomicity:** `create-api-key`'s `User`/`AgentPerson`/`ApiKey` writes now run inside one `dataSource.transaction(...)` instead of three independent `.save()` calls.
- **Test coverage:** added `src/test/data/scripts/{create-api-key,revoke-api-key}.test.ts` — role allowlist, `--agent-id` requirement/validation, duplicate-label guard, agent-not-found leaves no orphaned `User`, revoke idempotency — previously only manually smoke-tested.
- **CLI validation:** `--role` is now case-insensitive; `--agent-id` is validated as a positive integer instead of silently becoming `NaN`.
- Added a comment in `jwt.ts` explaining why the `isActive` check applies only to the API-key path, not the existing JWT-cookie path (intentionally out of scope to change existing session behavior).

## Test plan

- [x] `yarn typecheck`, `yarn lint` (only pre-existing, unrelated warnings/errors — none in touched files)
- [x] `yarn test:run` — 645/645 passing across 77 files, including 8 tests in `jwt.test.ts` and 15 new tests across the two script test files
- [x] Manual smoke test against the local docker dev server for all three roles, including the new SHA-256 path: minted admin/coordinator/agent keys via `yarn create-api-key`, confirmed an agent key can read (`GET /agent/:id`) and write its own center (`PATCH`, 204) but not another center's (`PATCH`, 403); confirmed an admin key bypasses a coordinator-only route; confirmed invalid/revoked keys are rejected (401) via `yarn revoke-api-key`; confirmed case-insensitive `--role` and rejection of a non-numeric `--agent-id`
- [x] Migration replay verified: reverted and regenerated against the updated entity (adds the unique index on `key_hash`), reapplied cleanly
