### PR TITLE
feat: POST /event-registration public endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.141",
+    "need4deed-sdk": "0.0.142",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,6 +23,7 @@ import communicationRoutes from "./routes/communication.routes";
 import healthRoutes from "./routes/health";
 import activityLogCollectionRoutes from "./routes/m2m/activity-log.routes";
 import m2mOpportunityVolunteerRoutes from "./routes/m2m/opportunity-volunteer.routes";
+import opportunityEventRegistrationRoutes from "./routes/opportunity-event-registration.routes";
 import opportunityRoutes from "./routes/opportunity/opportunity.routes";
 import optionRoutes from "./routes/option";
 import organizationRoutes from "./routes/organization.routes";
@@ -238,6 +239,9 @@ export async function createServer(): Promise<FastifyInstance> {
   });
   await fastifyInstance.register(trustedDomainRoutes, {
     prefix: RoutePrefix.TRUSTED_DOMAIN,
+  });
+  await fastifyInstance.register(opportunityEventRegistrationRoutes, {
+    prefix: RoutePrefix.EVENT_REGISTRATION,
   });
 
   await fastifyInstance.ready();

--- a/src/server/routes/opportunity-event-registration.routes.ts
+++ b/src/server/routes/opportunity-event-registration.routes.ts
@@ -1,3 +1,4 @@
+import { validate } from "class-validator";
 import {
   FastifyContextConfig,
   FastifyInstance,
@@ -5,6 +6,7 @@ import {
 } from "fastify";
 import {
   ApiOpportunityEventRegistrationPost,
+  OpportunityStatusType,
   OpportunityType,
 } from "need4deed-sdk";
 import { BadRequestError, NotFoundError } from "../../config";
@@ -14,6 +16,14 @@ import {
   opportunityEventRegistrationResponseSchema,
 } from "../schema";
 import { ReplyMessage } from "../types/endpoint-handlers";
+
+// Statuses under which an opportunity is still publicly open — same set the
+// public opportunity listing filters to (opportunity/legacy.routes.ts).
+const OPEN_OPPORTUNITY_STATUSES: OpportunityStatusType[] = [
+  OpportunityStatusType.NEW,
+  OpportunityStatusType.ACTIVE,
+  OpportunityStatusType.SEARCHING,
+];
 
 export default async function opportunityEventRegistrationRoutes(
   fastify: FastifyInstance,
@@ -47,9 +57,23 @@ export default async function opportunityEventRegistrationRoutes(
       if (new Date(opportunity.onetimer.date).getTime() < Date.now()) {
         throw new BadRequestError("Event date has already passed.");
       }
+      if (!OPEN_OPPORTUNITY_STATUSES.includes(opportunity.status)) {
+        throw new BadRequestError("Opportunity is no longer open.");
+      }
+
+      const newRegistration = new OpportunityEventRegistration({
+        opportunityId,
+        ...registration,
+      });
+      const errors = await validate(newRegistration);
+      if (errors.length > 0) {
+        throw new BadRequestError(
+          errors.flatMap((e) => Object.values(e.constraints || {})).join(", "),
+        );
+      }
 
       await fastify.db.opportunityEventRegistrationRepository.save(
-        new OpportunityEventRegistration({ opportunityId, ...registration }),
+        newRegistration,
       );
 
       return reply

--- a/src/server/routes/opportunity-event-registration.routes.ts
+++ b/src/server/routes/opportunity-event-registration.routes.ts
@@ -1,0 +1,60 @@
+import {
+  FastifyContextConfig,
+  FastifyInstance,
+  FastifyPluginOptions,
+} from "fastify";
+import {
+  ApiOpportunityEventRegistrationPost,
+  OpportunityType,
+} from "need4deed-sdk";
+import { BadRequestError, NotFoundError } from "../../config";
+import OpportunityEventRegistration from "../../data/entity/opportunity-event-registration.entity";
+import {
+  opportunityEventRegistrationBodySchema,
+  opportunityEventRegistrationResponseSchema,
+} from "../schema";
+import { ReplyMessage } from "../types/endpoint-handlers";
+
+export default async function opportunityEventRegistrationRoutes(
+  fastify: FastifyInstance,
+  _options: FastifyPluginOptions,
+) {
+  fastify.post<{ Body: ApiOpportunityEventRegistrationPost }>(
+    "/",
+    {
+      config: { public: true } as FastifyContextConfig,
+      schema: {
+        body: opportunityEventRegistrationBodySchema,
+        response: opportunityEventRegistrationResponseSchema,
+      },
+    },
+    async (request, reply) => {
+      const { opportunityId, ...registration } = request.body;
+
+      const opportunity = await fastify.db.opportunityRepository.findOne({
+        where: { id: opportunityId },
+        relations: ["onetimer"],
+      });
+      if (!opportunity) {
+        throw new NotFoundError(`Opportunity (id:${opportunityId}) not found.`);
+      }
+      if (
+        !opportunity.onetimer ||
+        opportunity.type === OpportunityType.ACCOMPANYING
+      ) {
+        throw new BadRequestError("Opportunity is not a dated event.");
+      }
+      if (new Date(opportunity.onetimer.date).getTime() < Date.now()) {
+        throw new BadRequestError("Event date has already passed.");
+      }
+
+      await fastify.db.opportunityEventRegistrationRepository.save(
+        new OpportunityEventRegistration({ opportunityId, ...registration }),
+      );
+
+      return reply
+        .status(201)
+        .send({ message: "Registration submitted." } as ReplyMessage);
+    },
+  );
+}

--- a/src/server/schema/index.ts
+++ b/src/server/schema/index.ts
@@ -5,6 +5,7 @@ export * from "./param";
 export * from "./person.schema";
 export * from "./querystring";
 export * from "./opportunity-create.schema";
+export * from "./opportunity-event-registration.schema";
 export * from "./response-schema";
 export * from "./responseErrors";
 export * from "./trusted-domain.schema";

--- a/src/server/schema/opportunity-event-registration.schema.ts
+++ b/src/server/schema/opportunity-event-registration.schema.ts
@@ -10,7 +10,7 @@ export const opportunityEventRegistrationBodySchema = {
     fullName: { type: "string", minLength: 1 },
     email: { type: "string", minLength: 1, format: "email" },
     phone: { type: ["string", "null"] },
-    numberOfPeople: { type: "integer", minimum: 1 },
+    numberOfPeople: { type: "integer", minimum: 1, maximum: 1000 },
     languagePreference: { type: ["string", "null"] },
     message: { type: ["string", "null"], maxLength: 500 },
   },

--- a/src/server/schema/opportunity-event-registration.schema.ts
+++ b/src/server/schema/opportunity-event-registration.schema.ts
@@ -1,0 +1,21 @@
+import { responseSchema } from "./response-schema";
+
+// Body for POST /event-registration (SDK ApiOpportunityEventRegistrationPost).
+export const opportunityEventRegistrationBodySchema = {
+  type: "object",
+  required: ["opportunityId", "fullName", "email"],
+  additionalProperties: false,
+  properties: {
+    opportunityId: { type: "integer" },
+    fullName: { type: "string", minLength: 1 },
+    email: { type: "string", minLength: 1 },
+    phone: { type: ["string", "null"] },
+    numberOfPeople: { type: "integer", minimum: 1, default: 1 },
+    languagePreference: { type: ["string", "null"] },
+    message: { type: ["string", "null"], maxLength: 500 },
+  },
+};
+
+export const opportunityEventRegistrationResponseSchema = responseSchema({
+  statusCode: 201,
+});

--- a/src/server/schema/opportunity-event-registration.schema.ts
+++ b/src/server/schema/opportunity-event-registration.schema.ts
@@ -3,14 +3,14 @@ import { responseSchema } from "./response-schema";
 // Body for POST /event-registration (SDK ApiOpportunityEventRegistrationPost).
 export const opportunityEventRegistrationBodySchema = {
   type: "object",
-  required: ["opportunityId", "fullName", "email"],
+  required: ["opportunityId", "fullName", "email", "numberOfPeople"],
   additionalProperties: false,
   properties: {
     opportunityId: { type: "integer" },
     fullName: { type: "string", minLength: 1 },
-    email: { type: "string", minLength: 1 },
+    email: { type: "string", minLength: 1, format: "email" },
     phone: { type: ["string", "null"] },
-    numberOfPeople: { type: "integer", minimum: 1, default: 1 },
+    numberOfPeople: { type: "integer", minimum: 1 },
     languagePreference: { type: ["string", "null"] },
     message: { type: ["string", "null"], maxLength: 500 },
   },

--- a/src/server/types/enums.ts
+++ b/src/server/types/enums.ts
@@ -7,6 +7,7 @@ export const RoutePrefix = {
   COMMUNICATION: "/communication",
   CONTACT: "/contact",
   DOC: "/doc",
+  EVENT_REGISTRATION: "/event-registration",
   HEALTH_CHECK: "/health-check",
   LEGACY: "/legacy",
   LOGIN: "/login",

--- a/src/test/server/routes/opportunity-event-registration.routes.test.ts
+++ b/src/test/server/routes/opportunity-event-registration.routes.test.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from "fastify";
-import { OpportunityType } from "need4deed-sdk";
+import { OpportunityStatusType, OpportunityType } from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { dataSource } from "../../../data/data-source";
 import OpportunityEventRegistration from "../../../data/entity/opportunity-event-registration.entity";
@@ -19,6 +19,7 @@ describe("POST /event-registration", () => {
   let pastEventOpportunityId: number;
   let accompanyingOpportunityId: number;
   let noOnetimerOpportunityId: number;
+  let inactiveEventOpportunityId: number;
 
   beforeAll(async () => {
     fastify = await createServer();
@@ -29,6 +30,7 @@ describe("POST /event-registration", () => {
     async function makeOpportunity(
       type: OpportunityType,
       date: Date | null,
+      status?: OpportunityStatusType,
     ): Promise<number> {
       let onetimerId: number | undefined;
       if (date) {
@@ -41,6 +43,7 @@ describe("POST /event-registration", () => {
           title: `Test event-registration opportunity ${suffix}`,
           type,
           onetimerId,
+          ...(status ? { status } : {}),
         } as Partial<Opportunity>),
       );
       opportunityIds.push(opportunity.id);
@@ -62,6 +65,11 @@ describe("POST /event-registration", () => {
     noOnetimerOpportunityId = await makeOpportunity(
       OpportunityType.REGULAR,
       null,
+    );
+    inactiveEventOpportunityId = await makeOpportunity(
+      OpportunityType.EVENTS,
+      new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      OpportunityStatusType.INACTIVE,
     );
   });
 
@@ -158,6 +166,36 @@ describe("POST /event-registration", () => {
         opportunityId: pastEventOpportunityId,
         fullName: "Ali K.",
         email: "ali@example.com",
+        numberOfPeople: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when the opportunity is no longer open (e.g. inactive)", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event-registration/",
+      payload: {
+        opportunityId: inactiveEventOpportunityId,
+        fullName: "Ali K.",
+        email: "ali@example.com",
+        numberOfPeople: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 for a malformed email", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event-registration/",
+      payload: {
+        opportunityId: futureEventOpportunityId,
+        fullName: "Ali K.",
+        email: "not-an-email",
         numberOfPeople: 1,
       },
     });

--- a/src/test/server/routes/opportunity-event-registration.routes.test.ts
+++ b/src/test/server/routes/opportunity-event-registration.routes.test.ts
@@ -1,0 +1,167 @@
+import { FastifyInstance } from "fastify";
+import { OpportunityType } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { dataSource } from "../../../data/data-source";
+import OpportunityEventRegistration from "../../../data/entity/opportunity-event-registration.entity";
+import Onetimer from "../../../data/entity/opportunity/onetimer.entity";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import { getRepository } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+describe("POST /event-registration", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  const opportunityIds: number[] = [];
+  const onetimerIds: number[] = [];
+
+  let futureEventOpportunityId: number;
+  let pastEventOpportunityId: number;
+  let accompanyingOpportunityId: number;
+  let noOnetimerOpportunityId: number;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const onetimerRepository = getRepository(dataSource, Onetimer);
+
+    async function makeOpportunity(
+      type: OpportunityType,
+      date: Date | null,
+    ): Promise<number> {
+      let onetimerId: number | undefined;
+      if (date) {
+        const onetimer = await onetimerRepository.save(new Onetimer({ date }));
+        onetimerIds.push(onetimer.id);
+        onetimerId = onetimer.id;
+      }
+      const opportunity = await fastify.db.opportunityRepository.save(
+        new Opportunity({
+          title: `Test event-registration opportunity ${suffix}`,
+          type,
+          onetimerId,
+        } as Partial<Opportunity>),
+      );
+      opportunityIds.push(opportunity.id);
+      return opportunity.id;
+    }
+
+    futureEventOpportunityId = await makeOpportunity(
+      OpportunityType.EVENTS,
+      new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    );
+    pastEventOpportunityId = await makeOpportunity(
+      OpportunityType.EVENTS,
+      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    );
+    accompanyingOpportunityId = await makeOpportunity(
+      OpportunityType.ACCOMPANYING,
+      new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    );
+    noOnetimerOpportunityId = await makeOpportunity(
+      OpportunityType.REGULAR,
+      null,
+    );
+  });
+
+  afterAll(async () => {
+    await getRepository(dataSource, OpportunityEventRegistration).delete({
+      opportunityId: futureEventOpportunityId,
+    });
+    for (const id of opportunityIds) {
+      await fastify.db.opportunityRepository.delete({ id });
+    }
+    for (const id of onetimerIds) {
+      await fastify.db.onetimerRepository.delete({ id });
+    }
+    await fastify.close();
+  });
+
+  it("registers an attendee for a future, dated, non-accompanying opportunity", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event-registration/",
+      payload: {
+        opportunityId: futureEventOpportunityId,
+        fullName: "Ali K.",
+        email: "ali@example.com",
+        phone: "+49123456",
+        numberOfPeople: 2,
+        languagePreference: "Arabic",
+        message: "Looking forward to it",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({ message: "Registration submitted." });
+
+    const saved = await getRepository(
+      dataSource,
+      OpportunityEventRegistration,
+    ).findOneOrFail({ where: { opportunityId: futureEventOpportunityId } });
+    expect(saved.fullName).toBe("Ali K.");
+    expect(saved.email).toBe("ali@example.com");
+    expect(saved.numberOfPeople).toBe(2);
+  });
+
+  it("returns 404 when the opportunity does not exist", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event-registration/",
+      payload: {
+        opportunityId: -1,
+        fullName: "Ali K.",
+        email: "ali@example.com",
+        numberOfPeople: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 400 for an accompanying-type opportunity", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event-registration/",
+      payload: {
+        opportunityId: accompanyingOpportunityId,
+        fullName: "Ali K.",
+        email: "ali@example.com",
+        numberOfPeople: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 for an opportunity with no date", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event-registration/",
+      payload: {
+        opportunityId: noOnetimerOpportunityId,
+        fullName: "Ali K.",
+        email: "ali@example.com",
+        numberOfPeople: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when the event date has already passed", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event-registration/",
+      payload: {
+        opportunityId: pastEventOpportunityId,
+        fullName: "Ali K.",
+        email: "ali@example.com",
+        numberOfPeople: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/src/test/server/routes/opportunity-event-registration.routes.test.ts
+++ b/src/test/server/routes/opportunity-event-registration.routes.test.ts
@@ -202,4 +202,19 @@ describe("POST /event-registration", () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it("returns 400 for an unreasonably large numberOfPeople", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event-registration/",
+      payload: {
+        opportunityId: futureEventOpportunityId,
+        fullName: "Ali K.",
+        email: "ali@example.com",
+        numberOfPeople: 3_000_000_000,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.141:
-  version "0.0.141"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.141.tgz#f8f62efc5f48e99f03e935a0e7dba3970d7ba7bd"
-  integrity sha512-zGjp4hiArKMfWumv/dhQqulMOf4FL9DxKTkorEzI/bHOE7BV2zoQqUa3zlt6RRI5CX1I8065PatiAB98ImCtkg==
+need4deed-sdk@0.0.142:
+  version "0.0.142"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.142.tgz#f5e2a24d63149f0d8a98c8aee1319eb59016c9b0"
+  integrity sha512-BiSwsXu5mwc/lB/+0hZaYZADEP5hbSnuzxRQCAdi9vE4CBh/DHtEMq2tXwZu8mUEqMQvd65q8O/VUnA5yO+Q1g==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
- Adds `POST /event-registration` — public, no auth
- Validates: opportunity exists (404), is a dated non-accompanying opportunity via its `onetimer` relation and `type !== ACCOMPANYING` (400), and the event date hasn't passed (400)
- Persists an `OpportunityEventRegistration` row, responds `201 { message: "Registration submitted." }`
- Upgrades `need4deed-sdk` to 0.0.142 for `ApiOpportunityEventRegistrationPost`

Sub-issue of #682, depends on #877 (merged) and need4deed-org/sdk#195 (published).

Closes #878

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — no new errors
- [x] `yarn test:run` — 650 tests passing (5 new: success, 404 not found, 400 accompanying-type, 400 no date, 400 past date)