### PR TITLE
feat: GET /opportunity/:id/registrations + CSV export

### DIFF
--- a/src/server/routes/opportunity/opportunity-event-registration.routes.ts
+++ b/src/server/routes/opportunity/opportunity-event-registration.routes.ts
@@ -1,0 +1,152 @@
+import { FastifyInstance, FastifyPluginOptions, FastifyRequest } from "fastify";
+import { AgentMembershipStatus, UserRole } from "need4deed-sdk";
+import { NotFoundError, UnauthorizedError } from "../../../config";
+import { dtoOpportunityEventRegistration } from "../../../services";
+import {
+  idParamSchema,
+  opportunityEventRegistrationListResponseSchema,
+} from "../../schema";
+
+// Only these roles may view an event's registrations at all. An AGENT is
+// further scoped below to opportunities belonging to their own agent — the
+// registrant's name/email/phone is PII, and be/CLAUDE.md only calls out
+// COORDINATOR as PII-safe, so AGENT access is deliberately ownership-scoped
+// rather than blanket (see be#879 discussion).
+function assertHasRegistrationsRole(request: FastifyRequest): void {
+  const role = request.authUser?.role;
+  if (
+    role !== UserRole.COORDINATOR &&
+    role !== UserRole.AGENT &&
+    role !== UserRole.ADMIN
+  ) {
+    throw new UnauthorizedError();
+  }
+}
+
+async function assertCanViewRegistrations(
+  fastify: FastifyInstance,
+  request: FastifyRequest,
+  agentId?: number,
+): Promise<void> {
+  const role = request.authUser?.role;
+  if (role === UserRole.COORDINATOR || role === UserRole.ADMIN) {
+    return;
+  }
+
+  const personId = request.authUser?.personId;
+  const membership =
+    personId && agentId
+      ? await fastify.db.agentPersonRepository.findOneBy({
+          agentId,
+          personId,
+          status: AgentMembershipStatus.ACTIVE,
+        })
+      : null;
+  if (!membership) {
+    throw new UnauthorizedError(
+      "Agents can only view registrations for their own agent's opportunities.",
+    );
+  }
+}
+
+function toCsv(rows: string[][]): string {
+  const escape = (value: string) =>
+    /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  return rows.map((row) => row.map(escape).join(",")).join("\n");
+}
+
+export default function opportunityEventRegistrationRoutes(
+  fastify: FastifyInstance,
+  _options: FastifyPluginOptions,
+) {
+  fastify.get<{ Params: { id: number } }>(
+    "/",
+    {
+      schema: {
+        params: idParamSchema,
+        response: opportunityEventRegistrationListResponseSchema,
+      },
+    },
+    async (request, reply) => {
+      assertHasRegistrationsRole(request);
+      const opportunityId = request.params.id;
+
+      const opportunity = await fastify.db.opportunityRepository.findOne({
+        where: { id: opportunityId },
+      });
+      if (!opportunity) {
+        throw new NotFoundError(`Opportunity (id:${opportunityId}) not found.`);
+      }
+      await assertCanViewRegistrations(fastify, request, opportunity.agentId);
+
+      const registrations =
+        await fastify.db.opportunityEventRegistrationRepository.find({
+          where: { opportunityId },
+          order: { createdAt: "DESC" },
+        });
+
+      const totalPeople = registrations.reduce(
+        (sum, r) => sum + r.numberOfPeople,
+        0,
+      );
+
+      return reply.status(200).send({
+        message: `Registrations for opportunity id:${opportunityId}.`,
+        data: registrations.map(dtoOpportunityEventRegistration),
+        count: registrations.length,
+        totalPeople,
+      });
+    },
+  );
+
+  fastify.get<{ Params: { id: number } }>(
+    "/export",
+    { schema: { params: idParamSchema } },
+    async (request, reply) => {
+      assertHasRegistrationsRole(request);
+      const opportunityId = request.params.id;
+
+      const opportunity = await fastify.db.opportunityRepository.findOne({
+        where: { id: opportunityId },
+      });
+      if (!opportunity) {
+        throw new NotFoundError(`Opportunity (id:${opportunityId}) not found.`);
+      }
+      await assertCanViewRegistrations(fastify, request, opportunity.agentId);
+
+      const registrations =
+        await fastify.db.opportunityEventRegistrationRepository.find({
+          where: { opportunityId },
+          order: { createdAt: "DESC" },
+        });
+
+      const rows = [
+        [
+          "Name",
+          "Email",
+          "Phone",
+          "People",
+          "Language",
+          "Message",
+          "Registered at",
+        ],
+        ...registrations.map((r) => [
+          r.fullName,
+          r.email,
+          r.phone ?? "",
+          String(r.numberOfPeople),
+          r.languagePreference ?? "",
+          r.message ?? "",
+          r.createdAt.toISOString(),
+        ]),
+      ];
+
+      reply.header("Content-Type", "text/csv");
+      reply.header(
+        "Content-Disposition",
+        `attachment; filename="registrations-${opportunityId}.csv"`,
+      );
+      return reply.send(toCsv(rows));
+    },
+  );
+}

--- a/src/server/routes/opportunity/opportunity-event-registration.routes.ts
+++ b/src/server/routes/opportunity/opportunity-event-registration.routes.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyPluginOptions, FastifyRequest } from "fastify";
 import { AgentMembershipStatus, UserRole } from "need4deed-sdk";
 import { NotFoundError, UnauthorizedError } from "../../../config";
+import OpportunityEventRegistration from "../../../data/entity/opportunity-event-registration.entity";
 import { dtoOpportunityEventRegistration } from "../../../services";
 import {
   idParamSchema,
@@ -35,7 +36,7 @@ async function assertCanViewRegistrations(
 
   const personId = request.authUser?.personId;
   const membership =
-    personId && agentId
+    personId !== undefined && agentId !== undefined
       ? await fastify.db.agentPersonRepository.findOneBy({
           agentId,
           personId,
@@ -49,10 +50,42 @@ async function assertCanViewRegistrations(
   }
 }
 
+// Shared by both handlers below so the role gate, 404, and ownership check
+// can't drift apart between the JSON list and the CSV export.
+async function getAuthorizedRegistrations(
+  fastify: FastifyInstance,
+  request: FastifyRequest,
+  opportunityId: number,
+): Promise<OpportunityEventRegistration[]> {
+  assertHasRegistrationsRole(request);
+
+  const opportunity = await fastify.db.opportunityRepository.findOne({
+    where: { id: opportunityId },
+  });
+  if (!opportunity) {
+    throw new NotFoundError(`Opportunity (id:${opportunityId}) not found.`);
+  }
+  await assertCanViewRegistrations(fastify, request, opportunity.agentId);
+
+  return fastify.db.opportunityEventRegistrationRepository.find({
+    where: { opportunityId },
+    order: { createdAt: "DESC" },
+  });
+}
+
+function csvCell(value: string): string {
+  // Neutralize formula injection (OWASP CSV injection): fullName/message
+  // come from the public, unauthenticated POST /event-registration form, and
+  // a leading =, +, -, or @ is interpreted as a live formula by Excel/Sheets
+  // once a coordinator/agent opens this export.
+  const guarded = /^[=+\-@]/.test(value) ? `'${value}` : value;
+  return /["\r\n,]/.test(guarded)
+    ? `"${guarded.replace(/"/g, '""')}"`
+    : guarded;
+}
+
 function toCsv(rows: string[][]): string {
-  const escape = (value: string) =>
-    /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
-  return rows.map((row) => row.map(escape).join(",")).join("\n");
+  return rows.map((row) => row.map(csvCell).join(",")).join("\n");
 }
 
 export default function opportunityEventRegistrationRoutes(
@@ -68,22 +101,12 @@ export default function opportunityEventRegistrationRoutes(
       },
     },
     async (request, reply) => {
-      assertHasRegistrationsRole(request);
       const opportunityId = request.params.id;
-
-      const opportunity = await fastify.db.opportunityRepository.findOne({
-        where: { id: opportunityId },
-      });
-      if (!opportunity) {
-        throw new NotFoundError(`Opportunity (id:${opportunityId}) not found.`);
-      }
-      await assertCanViewRegistrations(fastify, request, opportunity.agentId);
-
-      const registrations =
-        await fastify.db.opportunityEventRegistrationRepository.find({
-          where: { opportunityId },
-          order: { createdAt: "DESC" },
-        });
+      const registrations = await getAuthorizedRegistrations(
+        fastify,
+        request,
+        opportunityId,
+      );
 
       const totalPeople = registrations.reduce(
         (sum, r) => sum + r.numberOfPeople,
@@ -103,22 +126,12 @@ export default function opportunityEventRegistrationRoutes(
     "/export",
     { schema: { params: idParamSchema } },
     async (request, reply) => {
-      assertHasRegistrationsRole(request);
       const opportunityId = request.params.id;
-
-      const opportunity = await fastify.db.opportunityRepository.findOne({
-        where: { id: opportunityId },
-      });
-      if (!opportunity) {
-        throw new NotFoundError(`Opportunity (id:${opportunityId}) not found.`);
-      }
-      await assertCanViewRegistrations(fastify, request, opportunity.agentId);
-
-      const registrations =
-        await fastify.db.opportunityEventRegistrationRepository.find({
-          where: { opportunityId },
-          order: { createdAt: "DESC" },
-        });
+      const registrations = await getAuthorizedRegistrations(
+        fastify,
+        request,
+        opportunityId,
+      );
 
       const rows = [
         [
@@ -130,15 +143,17 @@ export default function opportunityEventRegistrationRoutes(
           "Message",
           "Registered at",
         ],
-        ...registrations.map((r) => [
-          r.fullName,
-          r.email,
-          r.phone ?? "",
-          String(r.numberOfPeople),
-          r.languagePreference ?? "",
-          r.message ?? "",
-          r.createdAt.toISOString(),
-        ]),
+        ...registrations
+          .map(dtoOpportunityEventRegistration)
+          .map((r) => [
+            r.fullName,
+            r.email,
+            r.phone ?? "",
+            String(r.numberOfPeople),
+            r.languagePreference ?? "",
+            r.message ?? "",
+            r.createdAt.toISOString(),
+          ]),
       ];
 
       reply.header("Content-Type", "text/csv");

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -84,6 +84,7 @@ import {
   maskForCaller,
 } from "../../utils/pii/pre-serialization";
 import opportunityLegacyRoutes from "./legacy.routes";
+import opportunityEventRegistrationRoutes from "./opportunity-event-registration.routes";
 import opportunityOpportunityVolunteerRoutes from "./opportunity-volunteer.routes";
 
 async function sendNewOpportunityEmail(
@@ -141,6 +142,10 @@ export default async function opportunityRoutes(
 
   await fastify.register(opportunityOpportunityVolunteerRoutes, {
     prefix: `:id${RoutePrefix.VOLUNTEER_LINKED}`,
+  });
+
+  await fastify.register(opportunityEventRegistrationRoutes, {
+    prefix: `:id${RoutePrefix.REGISTRATIONS}`,
   });
 
   fastify.get<{ Params: ParamsId; Replay: ReplyData<ApiOpportunityGet> }>(

--- a/src/server/schema/opportunity-event-registration.schema.ts
+++ b/src/server/schema/opportunity-event-registration.schema.ts
@@ -1,4 +1,5 @@
 import { responseSchema } from "./response-schema";
+import { responseErrors } from "./responseErrors";
 
 // Body for POST /event-registration (SDK ApiOpportunityEventRegistrationPost).
 export const opportunityEventRegistrationBodySchema = {
@@ -19,3 +20,35 @@ export const opportunityEventRegistrationBodySchema = {
 export const opportunityEventRegistrationResponseSchema = responseSchema({
   statusCode: 201,
 });
+
+// Item shape for GET /opportunity/:id/registrations (SDK
+// ApiOpportunityEventRegistrationGet). Inline, not $ref'd — not yet part of
+// the generated sdk-types.json bundle.
+const opportunityEventRegistrationItemSchema = {
+  type: "object",
+  properties: {
+    id: { type: "integer" },
+    fullName: { type: "string" },
+    email: { type: "string" },
+    phone: { type: ["string", "null"] },
+    numberOfPeople: { type: "integer" },
+    languagePreference: { type: ["string", "null"] },
+    message: { type: ["string", "null"] },
+    createdAt: { type: "string" },
+  },
+};
+
+export const opportunityEventRegistrationListResponseSchema = {
+  200: {
+    type: "object",
+    required: ["message", "data", "count", "totalPeople"],
+    properties: {
+      message: { type: "string" },
+      data: { type: "array", items: opportunityEventRegistrationItemSchema },
+      count: { type: "integer" },
+      totalPeople: { type: "integer" },
+    },
+    additionalProperties: false,
+  },
+  ...responseErrors,
+};

--- a/src/server/types/enums.ts
+++ b/src/server/types/enums.ts
@@ -20,6 +20,7 @@ export const RoutePrefix = {
   ORGANIZATION: "/organization",
   OPTION: "/option",
   PERSON: "/person",
+  REGISTRATIONS: "/registrations",
   POST: "/post",
   REFRESH: "/refresh",
   REQUEST_RESET: "/request-reset",

--- a/src/services/dto/dto-opportunity-event-registration.ts
+++ b/src/services/dto/dto-opportunity-event-registration.ts
@@ -1,0 +1,17 @@
+import { ApiOpportunityEventRegistrationGet } from "need4deed-sdk";
+import OpportunityEventRegistration from "../../data/entity/opportunity-event-registration.entity";
+
+export function dtoOpportunityEventRegistration(
+  registration: OpportunityEventRegistration,
+): ApiOpportunityEventRegistrationGet {
+  return {
+    id: registration.id,
+    fullName: registration.fullName,
+    email: registration.email,
+    phone: registration.phone ?? null,
+    numberOfPeople: registration.numberOfPeople,
+    languagePreference: registration.languagePreference ?? null,
+    message: registration.message ?? null,
+    createdAt: registration.createdAt,
+  };
+}

--- a/src/services/dto/index.ts
+++ b/src/services/dto/index.ts
@@ -4,6 +4,7 @@ export * from "./dto-agent";
 export * from "./dto-comment";
 export * from "./dto-communication";
 export * from "./dto-opportunity";
+export * from "./dto-opportunity-event-registration";
 export * from "./dto-opportunity-volunteer";
 export * from "./dto-organization";
 export * from "./dto-person";

--- a/src/test/server/routes/opportunity-event-registration-get.routes.test.ts
+++ b/src/test/server/routes/opportunity-event-registration-get.routes.test.ts
@@ -1,0 +1,249 @@
+import { FastifyInstance } from "fastify";
+import {
+  OpportunityStatusType,
+  OpportunityType,
+  UserRole,
+} from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import { dataSource } from "../../../data/data-source";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import OpportunityEventRegistration from "../../../data/entity/opportunity-event-registration.entity";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { getRepository, hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("GET /opportunity/:id/registrations", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  let ownAgent: Agent;
+  let otherAgent: Agent;
+  let ownOpportunity: Opportunity;
+  let agentPerson: Person;
+  let coordinatorPerson: Person;
+  let agentCookie: string;
+  let coordinatorCookie: string;
+  let volunteerCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    ownAgent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (own) ${suffix}` }),
+    );
+    otherAgent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (other) ${suffix}` }),
+    );
+
+    ownOpportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test event-registration-get opportunity ${suffix}`,
+        type: OpportunityType.EVENTS,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: ownAgent.id,
+      } as Partial<Opportunity>),
+    );
+
+    // Saved sequentially (not batched) so each row gets a distinct createdAt
+    // — a batched multi-row INSERT shares one now() value, making the
+    // createdAt DESC ordering assertions below non-deterministic.
+    await getRepository(dataSource, OpportunityEventRegistration).save(
+      new OpportunityEventRegistration({
+        opportunityId: ownOpportunity.id,
+        fullName: "Ali K.",
+        email: "ali@example.com",
+        numberOfPeople: 2,
+      }),
+    );
+    await getRepository(dataSource, OpportunityEventRegistration).save(
+      new OpportunityEventRegistration({
+        opportunityId: ownOpportunity.id,
+        fullName: "Bilal T.",
+        email: "bilal@example.com",
+        numberOfPeople: 3,
+      }),
+    );
+
+    agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Agent" }),
+    );
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    const volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+
+    const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `agent-getreg-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-getreg-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `volunteer-getreg-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.VOLUNTEER,
+        isActive: true,
+        personId: volunteerPerson.id,
+      }),
+    );
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({ agentId: ownAgent.id, personId: agentPerson.id }),
+    );
+
+    const login = async (email: string): Promise<string> => {
+      const res = await fastify.inject({
+        method: "POST",
+        url: "/auth/login",
+        payload: { email, password: PASSWORD },
+      });
+      return getCookie(res.cookies, accessCookieName);
+    };
+
+    agentCookie = await login(`agent-getreg-${suffix}@test.need4deed.org`);
+    coordinatorCookie = await login(
+      `coordinator-getreg-${suffix}@test.need4deed.org`,
+    );
+    volunteerCookie = await login(
+      `volunteer-getreg-${suffix}@test.need4deed.org`,
+    );
+  });
+
+  afterAll(async () => {
+    await getRepository(dataSource, OpportunityEventRegistration).delete({
+      opportunityId: ownOpportunity.id,
+    });
+    await fastify.db.opportunityRepository.delete({ id: ownOpportunity.id });
+    await fastify.db.agentPersonRepository.delete({
+      agentId: ownAgent.id,
+      personId: agentPerson.id,
+    });
+    await fastify.db.agentRepository.delete({ id: ownAgent.id });
+    await fastify.db.agentRepository.delete({ id: otherAgent.id });
+    await fastify.db.userRepository.delete({ personId: agentPerson.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: agentPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.close();
+  });
+
+  it("lets a coordinator list registrations with count and totalPeople", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/opportunity/${ownOpportunity.id}/registrations`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.count).toBe(2);
+    expect(body.totalPeople).toBe(5);
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].fullName).toBe("Bilal T.");
+  });
+
+  it("lets an agent list registrations for their own agent's opportunity", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/opportunity/${ownOpportunity.id}/registrations`,
+      cookies: { [accessCookieName]: agentCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().count).toBe(2);
+  });
+
+  it("403s a volunteer/user role outright", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/opportunity/${ownOpportunity.id}/registrations`,
+      cookies: { [accessCookieName]: volunteerCookie },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("403s an agent from another agent's opportunity", async () => {
+    const otherOpportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test other-agent opportunity ${suffix}`,
+        type: OpportunityType.EVENTS,
+        agentId: otherAgent.id,
+      } as Partial<Opportunity>),
+    );
+
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/opportunity/${otherOpportunity.id}/registrations`,
+      cookies: { [accessCookieName]: agentCookie },
+    });
+
+    expect(res.statusCode).toBe(403);
+
+    await fastify.db.opportunityRepository.delete({ id: otherOpportunity.id });
+  });
+
+  it("404s for a nonexistent opportunity", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity/999999999/registrations",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("exports a CSV with the expected headers and columns", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/opportunity/${ownOpportunity.id}/registrations/export`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/csv");
+    expect(res.headers["content-disposition"]).toBe(
+      `attachment; filename="registrations-${ownOpportunity.id}.csv"`,
+    );
+
+    const lines = res.body.trim().split("\n");
+    expect(lines[0]).toBe(
+      "Name,Email,Phone,People,Language,Message,Registered at",
+    );
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain("Bilal T.");
+  });
+});

--- a/src/test/server/routes/opportunity-event-registration-get.routes.test.ts
+++ b/src/test/server/routes/opportunity-event-registration-get.routes.test.ts
@@ -246,4 +246,33 @@ describe("GET /opportunity/:id/registrations", () => {
     expect(lines).toHaveLength(3);
     expect(lines[1]).toContain("Bilal T.");
   });
+
+  it("neutralizes CSV formula injection in exported fields", async () => {
+    const injected = await getRepository(
+      dataSource,
+      OpportunityEventRegistration,
+    ).save(
+      new OpportunityEventRegistration({
+        opportunityId: ownOpportunity.id,
+        fullName: '=HYPERLINK("http://evil","x")',
+        email: "injected@example.com",
+        numberOfPeople: 1,
+      }),
+    );
+
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/opportunity/${ownOpportunity.id}/registrations/export`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain(
+      '"\'=HYPERLINK(""http://evil"",""x"")",injected@example.com',
+    );
+
+    await getRepository(dataSource, OpportunityEventRegistration).delete({
+      id: injected.id,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `GET /opportunity/:id/registrations` — list, `count`, `totalPeople` (sum of `numberOfPeople`), ordered by `createdAt DESC`
- Adds `GET /opportunity/:id/registrations/export` — CSV download (Name, Email, Phone, People, Language, Message, Registered at)
- New DTO `dtoOpportunityEventRegistration`

**Auth deviation from the issue text** (flagged and confirmed with the repo owner before implementing): the issue specifies "COORDINATOR, NGO, ADMIN", but there is no `NGO` role in the published `UserRole` enum — the closest domain match is `AGENT` (accommodation centers). Since `be/CLAUDE.md` calls out only `COORDINATOR` as PII-safe and this endpoint returns registrants' name/email/phone, `AGENT` access is ownership-scoped rather than blanket: an `AGENT` can only view/export registrations for opportunities belonging to an agent they're an active member of (mirrors `agent/contact.routes.ts`'s membership check). `COORDINATOR`/`ADMIN` see everything.

CSV is hand-rolled (no existing CSV writer in the repo; not worth a new dependency for 7 fixed columns).

Sub-issue of #682, depends on #877/#878 (merged) and need4deed-org/sdk#195 (published).

Closes #879

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` — no new errors
- [x] `yarn test:run` — 659 tests passing (6 new: coordinator success w/ count+totalPeople+ordering, agent own-opportunity success, volunteer role 403, cross-agent 403, nonexistent-opportunity 404, CSV headers/columns)