### PR TITLE
feat: return all active agent memberships from GET /me (be#809)

### DIFF
--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -1,6 +1,7 @@
 import { validate } from "class-validator";
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
+  ApiAgentMembershipSummary,
   ApiUserGet,
   ApiUserPost,
   Lang,
@@ -29,6 +30,7 @@ import {
 } from "../schema/user.schema";
 import { QuerystringUserList, ReplyDataCount, RoutePrefix } from "../types";
 import { getSkipTake, getUserWhere, isEmailDomainTrusted } from "../utils";
+import { getActiveAgentMemberships } from "../utils/data/get-agent-memberships";
 import { getAgentPersonRepresentative } from "../utils/data/get-agent-person-representative";
 
 export default async function userRoutes(
@@ -61,7 +63,7 @@ export default async function userRoutes(
         order: { id: direction },
       });
 
-      const data = users.map(serializeUserToMeDTO);
+      const data = users.map((user) => serializeUserToMeDTO(user));
 
       return reply.status(200).send({
         message: `List of users page:${page || 1}`,
@@ -162,13 +164,22 @@ export default async function userRoutes(
         }
 
         let agentId: number | undefined;
+        let agentMemberships: ApiAgentMembershipSummary[] | undefined;
         if (user.role === UserRole.AGENT && user.personId) {
           // Prefer VOLUNTEER_COORDINATOR role; fall back to any active membership.
           const membership = await getAgentPersonRepresentative(user.personId);
           agentId = membership?.agentId;
+
+          // All active memberships, not just the "representative" one — a
+          // person can belong to more than one agent (be#809).
+          const memberships = await getActiveAgentMemberships(user.personId);
+          agentMemberships = memberships.map((m) => ({
+            agentId: m.agentId,
+            agentTitle: m.agent?.title ?? "",
+          }));
         }
 
-        const payload = serializeUserToMeDTO(user, agentId);
+        const payload = serializeUserToMeDTO(user, agentId, agentMemberships);
         return reply
           .status(200)
           .send({ message: "Logged in User", data: payload });

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -487,6 +487,22 @@
         },
         "agentId": {
           "type": "integer"
+        },
+        "agentMemberships": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "agentId": {
+                "type": "number"
+              },
+              "agentTitle": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "required": ["agentId", "agentTitle"]
+          }
         }
       },
       "additionalProperties": false,

--- a/src/server/utils/data/get-agent-memberships.ts
+++ b/src/server/utils/data/get-agent-memberships.ts
@@ -1,0 +1,18 @@
+import { AgentMembershipStatus } from "need4deed-sdk";
+import { dataSource } from "../../../data/data-source";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import { getRepository } from "../../../data/utils";
+
+// All of a person's active agent memberships, not just one — a person can
+// belong to more than one Agent (be#809), unlike
+// getAgentPersonRepresentative's single "primary" pick.
+export async function getActiveAgentMemberships(
+  personId: number,
+): Promise<AgentPerson[]> {
+  const agentPersonRepository = getRepository(dataSource, AgentPerson);
+  return agentPersonRepository.find({
+    where: { personId, status: AgentMembershipStatus.ACTIVE },
+    relations: ["agent"],
+    order: { id: "ASC" },
+  });
+}

--- a/src/services/dto/dto-user.ts
+++ b/src/services/dto/dto-user.ts
@@ -1,7 +1,11 @@
-import { ApiUserGet } from "need4deed-sdk";
+import { ApiAgentMembershipSummary, ApiUserGet } from "need4deed-sdk";
 import User from "../../data/entity/user.entity";
 
-export function serializeUserToMeDTO(user: User, agentId?: number): ApiUserGet {
+export function serializeUserToMeDTO(
+  user: User,
+  agentId?: number,
+  agentMemberships?: ApiAgentMembershipSummary[],
+): ApiUserGet {
   return {
     id: user.id,
     // personId is nullable (person-less users); emit undefined so the
@@ -16,5 +20,6 @@ export function serializeUserToMeDTO(user: User, agentId?: number): ApiUserGet {
     isoCode: user.language || "en",
     timezone: user.timezone || "CET",
     agentId,
+    agentMemberships,
   };
 }

--- a/src/test/server/routes/user.routes.test.ts
+++ b/src/test/server/routes/user.routes.test.ts
@@ -1,7 +1,12 @@
 import { FastifyInstance } from "fastify";
-import { UserRole } from "need4deed-sdk";
+import { AgentMembershipStatus, AgentRoleType, UserRole } from "need4deed-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Person from "../../../data/entity/person.entity";
 import TrustedDomain from "../../../data/entity/trusted-domain.entity";
+import User from "../../../data/entity/user.entity";
+import { hashPassword } from "../../../data/utils";
 import { createServer } from "../../../server";
 
 // Regression coverage for two things landed together:
@@ -66,5 +71,92 @@ describe("POST /user — AGENT email-domain gate", () => {
 
     expect(res.statusCode).toBe(201);
     createdUserIds.push(res.json().id);
+  });
+});
+
+// be#809: a person can hold more than one active AgentPerson membership (the
+// unique index is on the (agentId, personId, role) triple, not personId
+// alone) — /me previously only ever surfaced one via agentId.
+describe("GET /user/me — agentMemberships (be#809)", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  let person: Person;
+  let agentOne: Agent;
+  let agentTwo: Agent;
+  let user: User;
+  let accessToken: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    person = await fastify.db.personRepository.save(
+      new Person({ firstName: "Multi", lastName: `Agent-${suffix}` }),
+    );
+    agentOne = await fastify.db.agentRepository.save(
+      new Agent({ title: `RAC One ${suffix}` }),
+    );
+    agentTwo = await fastify.db.agentRepository.save(
+      new Agent({ title: `RAC Two ${suffix}` }),
+    );
+    await fastify.db.agentPersonRepository.save([
+      new AgentPerson({
+        agentId: agentOne.id,
+        personId: person.id,
+        role: AgentRoleType.VOLUNTEER_COORDINATOR,
+        status: AgentMembershipStatus.ACTIVE,
+      }),
+      new AgentPerson({
+        agentId: agentTwo.id,
+        personId: person.id,
+        role: AgentRoleType.SOCIAL_WORKER,
+        status: AgentMembershipStatus.ACTIVE,
+      }),
+    ]);
+    user = await fastify.db.userRepository.save(
+      new User({
+        email: `multi-agent-${suffix}@test.need4deed.org`,
+        password: await hashPassword("test_password"),
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: person.id,
+      }),
+    );
+    accessToken = fastify.jwt.sign({
+      id: user.id,
+      email: user.email,
+      type: "access",
+    });
+  });
+
+  afterAll(async () => {
+    await fastify.db.userRepository.delete({ id: user.id });
+    await fastify.db.agentPersonRepository.delete({ personId: person.id });
+    await fastify.db.agentRepository.delete({ id: agentOne.id });
+    await fastify.db.agentRepository.delete({ id: agentTwo.id });
+    await fastify.db.personRepository.delete({ id: person.id });
+    await fastify.close();
+  });
+
+  it("returns every active agent membership, not just one", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/user/me",
+      cookies: { access: accessToken },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+
+    // The single "primary" field stays populated for existing consumers.
+    expect(typeof data.agentId).toBe("number");
+
+    expect(data.agentMemberships).toEqual(
+      expect.arrayContaining([
+        { agentId: agentOne.id, agentTitle: agentOne.title },
+        { agentId: agentTwo.id, agentTitle: agentTwo.title },
+      ]),
+    );
+    expect(data.agentMemberships).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## What
Closes https://github.com/need4deed-org/be/issues/809

`GET /me` only ever returned a single `agentId`, even though the data model already supports a person belonging to more than one Agent (`AgentPerson`'s unique index is on `(agentId, personId, role)`, not `personId` alone). A volunteer coordinator working at two RACs on one account could only ever see one of them.

## Changes
- `getActiveAgentMemberships` (new, `src/server/utils/data/get-agent-memberships.ts`): all of a person's active `AgentPerson` rows, with the `agent` relation loaded.
- `/me` route: populates the new `agentMemberships: { agentId, agentTitle }[]` field alongside the existing single `agentId` (kept as-is for backward compatibility with existing single-agent consumers).
- `serializeUserToMeDTO` takes the new optional param.
- `sdk-types.json`: added `agentMemberships` to `ApiUserMe` (the SDK contract itself — `ApiAgentMembershipSummary` — already landed in need4deed-sdk#190 / published as 0.0.142, which `be` is already pinned to; `yarn install` was just out of sync locally).

## Test plan
- [x] `yarn tsc --noEmit`, `eslint`, `prettier` all clean.
- [x] Added `GET /user/me — agentMemberships (be#809)` covering a person with two active memberships at different agents — asserts `agentId` still resolves (backward compat) and `agentMemberships` contains both.
- [ ] Could not run the suite locally (no Postgres in this sandbox) — every DB-backed suite fails identically with `ECONNREFUSED 127.0.0.1:5432`, including this repo's pre-existing tests, not specific to this change.

Paired `fe` issue for the profile-switching UI this unblocks is out of scope here, per the linked issue.