### PR TITLE
feat: coordinator-created NGO/agent profiles with no linked User (fe#911)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.143",
+    "need4deed-sdk": "0.0.145",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/config/error/base.ts
+++ b/src/config/error/base.ts
@@ -1,11 +1,22 @@
 export class BaseError extends Error {
   public readonly statusCode: number;
   public readonly isOperational: boolean;
+  // Extra fields merged into the error response body alongside `error` +
+  // `message` (see the global error handler in src/server/index.ts) — for
+  // subclasses that need to carry structured data (e.g. a conflicting
+  // resource's id) beyond a plain message.
+  public readonly details?: Record<string, unknown>;
 
-  constructor(message: string, statusCode: number, isOperational = true) {
+  constructor(
+    message: string,
+    statusCode: number,
+    isOperational = true,
+    details?: Record<string, unknown>,
+  ) {
     super(message);
     this.statusCode = statusCode;
     this.isOperational = isOperational;
+    this.details = details;
     Error.captureStackTrace(this, this.constructor);
   }
 }

--- a/src/data/entity/opportunity/agent.entity.ts
+++ b/src/data/entity/opportunity/agent.entity.ts
@@ -152,4 +152,12 @@ export default class Agent {
   @IsOptional()
   @IsString()
   nid?: string;
+
+  // Coordinator/admin-created agent (fe#911) with no linked Person yet.
+  // joinAgent refuses to link anyone to it — claiming it is deferred to a
+  // future, explicitly-reviewed flow (not implemented yet). Distinct from
+  // "zero AgentPerson rows", which pre-existing legacy agents (created via
+  // POST /opportunity/legacy with no rac_email) can also have.
+  @Column({ default: false })
+  unclaimed: boolean;
 }

--- a/src/data/migrations/1787257727533-add-unclaimed-to-agent.ts
+++ b/src/data/migrations/1787257727533-add-unclaimed-to-agent.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUnclaimedToAgent1787257727533 implements MigrationInterface {
+  name = "AddUnclaimedToAgent1787257727533";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent" ADD "unclaimed" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agent" DROP COLUMN "unclaimed"`);
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -136,6 +136,7 @@ export async function createServer(): Promise<FastifyInstance> {
       return reply.status(error.statusCode).send({
         error: error.constructor.name,
         message: error.message,
+        ...error.details,
       });
     }
 

--- a/src/server/routes/agent/agent-communication.routes.ts
+++ b/src/server/routes/agent/agent-communication.routes.ts
@@ -1,9 +1,11 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { ApiCommunicationPost, UserRole } from "need4deed-sdk";
+import { NotFoundError } from "../../../config";
 import Communication from "../../../data/entity/communication.entity";
 import { dtoCommunication } from "../../../services";
 import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyDataCount } from "../../types";
+import { assertAgentVisible } from "../../utils";
 import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 
 export default function agentCommunicationRoutes(
@@ -26,6 +28,12 @@ export default function agentCommunicationRoutes(
     },
     async (request, reply) => {
       const { id } = request.params;
+
+      const agent = await fastify.db.agentRepository.findOneBy({ id });
+      if (!agent) {
+        throw new NotFoundError(`Agent (id:${id}) not found.`);
+      }
+      assertAgentVisible(agent, request.authUser?.role);
 
       const communicationRepository = fastify.db.communicationRepository;
       const [communications, count] =

--- a/src/server/routes/agent/agent-opportunity.routes.ts
+++ b/src/server/routes/agent/agent-opportunity.routes.ts
@@ -4,6 +4,7 @@ import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import { dtoAgentOpportunity } from "../../../services";
 import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyData } from "../../types";
+import { assertAgentVisible } from "../../utils";
 import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 
 export default async function agentOpportunityRoutes(
@@ -40,6 +41,7 @@ export default async function agentOpportunityRoutes(
       if (!agent) {
         throw new NotFoundError(`Agent (id:${id}) not found.`);
       }
+      assertAgentVisible(agent, request.authUser?.role);
 
       // DTO (dtoAgentOpportunity) runs in the preSerialization hook after PII
       // masking of the nested volunteer persons.

--- a/src/server/routes/agent/agent-volunteer.routes.ts
+++ b/src/server/routes/agent/agent-volunteer.routes.ts
@@ -1,8 +1,10 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { NotFoundError } from "../../../config";
 import OpportunityVolunteer from "../../../data/entity/m2m/opportunity-volunteer";
 import { opportunityOpportunityVolunteerDTO } from "../../../services";
 import { idParamSchema, responseSchema } from "../../schema";
 import { ParamsId, ReplyData } from "../../types";
+import { assertAgentVisible } from "../../utils";
 import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 
 export default function agentVolunteerRoutes(
@@ -26,6 +28,12 @@ export default function agentVolunteerRoutes(
     },
     async (request, reply) => {
       const { id } = request.params;
+
+      const agent = await fastify.db.agentRepository.findOneBy({ id });
+      if (!agent) {
+        throw new NotFoundError(`Agent (id:${id}) not found.`);
+      }
+      assertAgentVisible(agent, request.authUser?.role);
 
       const opportunityVolunteerRepository =
         fastify.db.opportunityVolunteerRepository;

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -49,11 +49,7 @@ import {
   updateAgentLanguages,
   updateAgentServices,
 } from "../../utils";
-import {
-  AgentAddressConflictError,
-  classifyRegisterAgentConflict,
-  createAgent,
-} from "../../utils/data/write-agent-registration";
+import { createAgent } from "../../utils/data/write-agent-registration";
 import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 import agentCommunicationRoutes from "./agent-communication.routes";
 import agentOpportunityRoutes from "./agent-opportunity.routes";
@@ -154,6 +150,17 @@ export default async function agentRoutes(
       const [skip, take] = getSkipTake({ page, limit });
       const where = await getAgentWhere(filter);
 
+      // A coordinator-created agent (fe#911) stays `unclaimed` until a real
+      // registration claims it — keep it out of the list for anyone but
+      // coordinator/admin. Filtered in the query itself (not in-memory after
+      // the page is fetched) so `count` and the returned page stay consistent.
+      const role = request.authUser?.role;
+      const isPrivileged =
+        role === UserRole.COORDINATOR || role === UserRole.ADMIN;
+      if (!isPrivileged) {
+        where.unclaimed = false;
+      }
+
       logger.debug(
         `GET /agent: filters:${JSON.stringify(filter)}, skip:${skip}, take:${take}`,
       );
@@ -185,23 +192,10 @@ export default async function agentRoutes(
         await agentRepository.save(updates);
       }
 
-      // A coordinator-created agent (fe#911) has no AgentPerson at all until a
-      // real registration claims it — keep it out of the list for anyone but
-      // coordinator/admin. `count` intentionally still reflects the unfiltered
-      // total (this page's data is filtered, not the query itself).
-      const role = request.authUser?.role;
-      const isPrivileged =
-        role === UserRole.COORDINATOR || role === UserRole.ADMIN;
-      const visibleAgents = isPrivileged
-        ? agentsDistrict
-        : agentsDistrict.filter(
-            (agent) => (agent.agentPerson?.length ?? 0) > 0,
-          );
-
       // DTO (dtoAgentGetList) runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Agents page:${page || 1} fetched successfully`,
-        data: visibleAgents,
+        data: agentsDistrict,
         count,
       });
     },
@@ -225,35 +219,11 @@ export default async function agentRoutes(
       },
     },
     async (request, reply) => {
-      try {
-        const result = await createAgent(request.body);
-        return reply.status(201).send({
-          message: "Agent created successfully.",
-          data: result,
-        });
-      } catch (err) {
-        if (err instanceof AgentAddressConflictError) {
-          return reply.status(409).send({
-            message: "An agent at this address already exists.",
-            conflict: "address",
-            agentId: err.agentId,
-          });
-        }
-        if (classifyRegisterAgentConflict(err) === "title") {
-          const existing = await fastify.db.agentRepository.findOne({
-            where: { title: request.body.title },
-          });
-          return reply.status(409).send({
-            message: "An agent with this title already exists.",
-            conflict: "title",
-            ...(existing ? { agentId: existing.id } : {}),
-          });
-        }
-        logger.error(
-          `POST /agent: create failed: ${err instanceof Error ? err.message : err}`,
-        );
-        return reply.status(500).send({ message: "Failed to create agent." });
-      }
+      const result = await createAgent(request.body);
+      return reply.status(201).send({
+        message: "Agent created successfully.",
+        data: result,
+      });
     },
   );
 
@@ -282,6 +252,17 @@ export default async function agentRoutes(
       ];
       const agent = await agentRepository.findOne({ where: { id }, relations });
       if (!agent) {
+        throw new NotFoundError(`Agent (id:${id}) not found.`);
+      }
+
+      // Mirrors the GET /agent list filter: a coordinator-created agent
+      // (fe#911) stays invisible to non-coordinator/admin callers until a
+      // real registration claims it. 404 rather than 403 so its existence
+      // isn't leaked to a caller guessing ids.
+      const role = request.authUser?.role;
+      const isPrivileged =
+        role === UserRole.COORDINATOR || role === UserRole.ADMIN;
+      if (agent.unclaimed && !isPrivileged) {
         throw new NotFoundError(`Agent (id:${id}) not found.`);
       }
 

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -40,6 +40,7 @@ import {
 import {
   addAgentTypeServiceTranslations,
   addComments2Entity,
+  assertAgentVisible,
   createAddress,
   getAgentWhere,
   getDistrictToAgentHandler,
@@ -255,16 +256,7 @@ export default async function agentRoutes(
         throw new NotFoundError(`Agent (id:${id}) not found.`);
       }
 
-      // Mirrors the GET /agent list filter: a coordinator-created agent
-      // (fe#911) stays invisible to non-coordinator/admin callers until a
-      // real registration claims it. 404 rather than 403 so its existence
-      // isn't leaked to a caller guessing ids.
-      const role = request.authUser?.role;
-      const isPrivileged =
-        role === UserRole.COORDINATOR || role === UserRole.ADMIN;
-      if (agent.unclaimed && !isPrivileged) {
-        throw new NotFoundError(`Agent (id:${id}) not found.`);
-      }
+      assertAgentVisible(agent, request.authUser?.role);
 
       const { addDistrictToAgent, updates } = getDistrictToAgentHandler();
       const agentDistrict = await addDistrictToAgent(agent);

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyPluginOptions, FastifyRequest } from "fastify";
 import {
   AgentMembershipStatus,
+  ApiAgentCreateResponse,
   ApiAgentPatch,
   ApiAgentRegisterNew,
   SortOrder,
@@ -206,7 +207,10 @@ export default async function agentRoutes(
   // (fe#911), for an NGO the coordinator already has details for before it has
   // self-registered. Distinct from POST /agent/register, which always links
   // the authenticated caller's own person.
-  fastify.post<{ Body: ApiAgentRegisterNew }>(
+  fastify.post<{
+    Body: ApiAgentRegisterNew;
+    Reply: ReplyData<ApiAgentCreateResponse>;
+  }>(
     "/",
     {
       onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),

--- a/src/server/routes/agent/agent.routes.ts
+++ b/src/server/routes/agent/agent.routes.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyPluginOptions, FastifyRequest } from "fastify";
 import {
   AgentMembershipStatus,
   ApiAgentPatch,
+  ApiAgentRegisterNew,
   SortOrder,
   UserRole,
 } from "need4deed-sdk";
@@ -21,7 +22,11 @@ import {
 } from "../../../services";
 import {
   agentListQuerySchema,
+  createAgentBodySchema,
+  createAgentResponseSchema,
   idParamSchema,
+  registerAgentConflictSchema,
+  responseErrors,
   responseSchema,
 } from "../../schema";
 import {
@@ -44,6 +49,11 @@ import {
   updateAgentLanguages,
   updateAgentServices,
 } from "../../utils";
+import {
+  AgentAddressConflictError,
+  classifyRegisterAgentConflict,
+  createAgent,
+} from "../../utils/data/write-agent-registration";
 import { makePiiSerialization } from "../../utils/pii/pre-serialization";
 import agentCommunicationRoutes from "./agent-communication.routes";
 import agentOpportunityRoutes from "./agent-opportunity.routes";
@@ -175,12 +185,75 @@ export default async function agentRoutes(
         await agentRepository.save(updates);
       }
 
+      // A coordinator-created agent (fe#911) has no AgentPerson at all until a
+      // real registration claims it — keep it out of the list for anyone but
+      // coordinator/admin. `count` intentionally still reflects the unfiltered
+      // total (this page's data is filtered, not the query itself).
+      const role = request.authUser?.role;
+      const isPrivileged =
+        role === UserRole.COORDINATOR || role === UserRole.ADMIN;
+      const visibleAgents = isPrivileged
+        ? agentsDistrict
+        : agentsDistrict.filter(
+            (agent) => (agent.agentPerson?.length ?? 0) > 0,
+          );
+
       // DTO (dtoAgentGetList) runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
         message: `Agents page:${page || 1} fetched successfully`,
-        data: agentsDistrict,
+        data: visibleAgents,
         count,
       });
+    },
+  );
+
+  // POST / — coordinator/admin creates a bare Agent with no linked Person/User
+  // (fe#911), for an NGO the coordinator already has details for before it has
+  // self-registered. Distinct from POST /agent/register, which always links
+  // the authenticated caller's own person.
+  fastify.post<{ Body: ApiAgentRegisterNew }>(
+    "/",
+    {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
+      schema: {
+        body: createAgentBodySchema,
+        response: {
+          201: createAgentResponseSchema,
+          ...responseErrors,
+          409: registerAgentConflictSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const result = await createAgent(request.body);
+        return reply.status(201).send({
+          message: "Agent created successfully.",
+          data: result,
+        });
+      } catch (err) {
+        if (err instanceof AgentAddressConflictError) {
+          return reply.status(409).send({
+            message: "An agent at this address already exists.",
+            conflict: "address",
+            agentId: err.agentId,
+          });
+        }
+        if (classifyRegisterAgentConflict(err) === "title") {
+          const existing = await fastify.db.agentRepository.findOne({
+            where: { title: request.body.title },
+          });
+          return reply.status(409).send({
+            message: "An agent with this title already exists.",
+            conflict: "title",
+            ...(existing ? { agentId: existing.id } : {}),
+          });
+        }
+        logger.error(
+          `POST /agent: create failed: ${err instanceof Error ? err.message : err}`,
+        );
+        return reply.status(500).send({ message: "Failed to create agent." });
+      }
     },
   );
 

--- a/src/server/routes/agent/contact.routes.ts
+++ b/src/server/routes/agent/contact.routes.ts
@@ -15,7 +15,11 @@ import {
   idParamSchema,
 } from "../../schema";
 import { ParamsId } from "../../types";
-import { createAgentContact, updateAgentContact } from "../../utils";
+import {
+  assertAgentVisible,
+  createAgentContact,
+  updateAgentContact,
+} from "../../utils";
 
 // Mirrors the role allowlist on PATCH /opportunity/:id: only these three
 // roles may reach the membership check, regardless of whether a stray
@@ -92,6 +96,7 @@ export default function agentContactRoutes(
       if (!agent) {
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
       }
+      assertAgentVisible(agent, request.authUser?.role);
 
       await assertCanManageContacts(fastify, request, agentId);
 
@@ -129,6 +134,7 @@ export default function agentContactRoutes(
       if (!agent) {
         throw new NotFoundError(`Agent (id:${agentId}) not found.`);
       }
+      assertAgentVisible(agent, request.authUser?.role);
 
       await assertCanManageContacts(fastify, request, agentId);
 

--- a/src/server/routes/agent/register.routes.ts
+++ b/src/server/routes/agent/register.routes.ts
@@ -100,9 +100,18 @@ export default async function agentRegisterRoutes(
       const candidates = await fastify.db.agentRepository
         .createQueryBuilder("agent")
         .leftJoinAndSelect("agent.address", "address")
+        .leftJoinAndSelect("agent.agentPerson", "agentPerson")
         .getMany();
 
-      const data = searchAgentCandidates(candidates, street).map((a) => ({
+      // A coordinator-created agent (fe#911) has no AgentPerson yet — it isn't
+      // claimable through self-registration's JOIN (which auto-approves on an
+      // email-domain match with zero coordinator review); exclude it here so
+      // it can only be linked through a future, explicitly-reviewed flow.
+      const claimable = candidates.filter(
+        (a) => (a.agentPerson?.length ?? 0) > 0,
+      );
+
+      const data = searchAgentCandidates(claimable, street).map((a) => ({
         id: a.id,
         title: a.title,
       }));

--- a/src/server/routes/agent/register.routes.ts
+++ b/src/server/routes/agent/register.routes.ts
@@ -170,6 +170,12 @@ export default async function agentRegisterRoutes(
 
         return reply.status(201).send({ message, data: result });
       } catch (err) {
+        // Not this route's to translate — let Fastify's error handler map it
+        // to 403 (e.g. joinAgent rejecting a coordinator-created/unclaimed
+        // agent, fe#911).
+        if (err instanceof UnauthorizedError) {
+          throw err;
+        }
         if (err instanceof AgentAddressConflictError) {
           return reply.status(409).send({
             message: "An agent at this address already exists.",

--- a/src/server/routes/agent/register.routes.ts
+++ b/src/server/routes/agent/register.routes.ts
@@ -22,8 +22,6 @@ import {
   responseErrors,
 } from "../../schema";
 import {
-  AgentAddressConflictError,
-  classifyRegisterAgentConflict,
   createAgentForPerson,
   joinAgent,
   resolveJoinStatus,
@@ -100,16 +98,17 @@ export default async function agentRegisterRoutes(
       const candidates = await fastify.db.agentRepository
         .createQueryBuilder("agent")
         .leftJoinAndSelect("agent.address", "address")
-        .leftJoinAndSelect("agent.agentPerson", "agentPerson")
         .getMany();
 
-      // A coordinator-created agent (fe#911) has no AgentPerson yet — it isn't
+      // A coordinator-created agent (fe#911) is `unclaimed` — it isn't
       // claimable through self-registration's JOIN (which auto-approves on an
       // email-domain match with zero coordinator review); exclude it here so
       // it can only be linked through a future, explicitly-reviewed flow.
-      const claimable = candidates.filter(
-        (a) => (a.agentPerson?.length ?? 0) > 0,
-      );
+      // Gating on this flag rather than "zero AgentPerson rows" matters: a
+      // legacy agent (created via POST /opportunity/legacy with no
+      // rac_email) can also have zero AgentPerson rows and must stay
+      // findable through this picker.
+      const claimable = candidates.filter((a) => !a.unclaimed);
 
       const data = searchAgentCandidates(claimable, street).map((a) => ({
         id: a.id,
@@ -153,53 +152,25 @@ export default async function agentRegisterRoutes(
 
       const body = request.body;
 
-      try {
-        const result =
-          "agentId" in body
-            ? await joinAgent(
-                personId,
-                body.agentId,
-                await resolveJoinStatus(body.agentId, user!.email),
-              )
-            : await createAgentForPerson(personId, body.agent);
+      // joinAgent/createAgentForPerson throw typed BaseError subclasses
+      // (UnauthorizedError, NotFoundError, AgentAddressConflictError,
+      // AgentTitleConflictError) — let them propagate to the global error
+      // handler rather than translating them here.
+      const result =
+        "agentId" in body
+          ? await joinAgent(
+              personId,
+              body.agentId,
+              await resolveJoinStatus(body.agentId, user!.email),
+            )
+          : await createAgentForPerson(personId, body.agent);
 
-        const message =
-          result.membershipStatus === AgentMembershipStatus.PENDING
-            ? "Join request submitted — an administrator will review it."
-            : "Agent registration complete.";
+      const message =
+        result.membershipStatus === AgentMembershipStatus.PENDING
+          ? "Join request submitted — an administrator will review it."
+          : "Agent registration complete.";
 
-        return reply.status(201).send({ message, data: result });
-      } catch (err) {
-        // Not this route's to translate — let Fastify's error handler map it
-        // to 403 (e.g. joinAgent rejecting a coordinator-created/unclaimed
-        // agent, fe#911).
-        if (err instanceof UnauthorizedError) {
-          throw err;
-        }
-        if (err instanceof AgentAddressConflictError) {
-          return reply.status(409).send({
-            message: "An agent at this address already exists.",
-            conflict: "address",
-            agentId: err.agentId,
-          });
-        }
-        if (classifyRegisterAgentConflict(err) === "title") {
-          const title = "agent" in body ? body.agent.title : undefined;
-          const existing = title
-            ? await fastify.db.agentRepository.findOne({ where: { title } })
-            : null;
-          return reply.status(409).send({
-            message: "An agent with this title already exists.",
-            conflict: "title",
-            ...(existing ? { agentId: existing.id } : {}),
-          });
-        }
-        // Don't echo the request body — may contain personal data.
-        logger.error(
-          `register-agent: write failed: ${err instanceof Error ? err.message : err}`,
-        );
-        return reply.status(500).send({ message: "Failed to register agent." });
-      }
+      return reply.status(201).send({ message, data: result });
     },
   );
 }

--- a/src/server/schema/agent-register.schema.ts
+++ b/src/server/schema/agent-register.schema.ts
@@ -49,7 +49,7 @@ export const registerSearchResponseSchema = {
   },
 };
 
-const registerAgentNewSchema = {
+export const registerAgentNewSchema = {
   type: "object",
   required: ["title"],
   additionalProperties: false,
@@ -120,5 +120,25 @@ export const registerAgentConflictSchema = {
     message: { type: "string" },
     conflict: { type: "string", enum: ["title", "address"] },
     agentId: { type: "integer" },
+  },
+};
+
+// POST /agent (coordinator/admin-only, fe#911) — same create fields as
+// registration's CREATE branch (registerAgentNewSchema), but the body isn't
+// wrapped in { agent: ... } since this endpoint only ever creates, never joins.
+export const createAgentBodySchema = registerAgentNewSchema;
+
+export const createAgentResponseSchema = {
+  type: "object",
+  required: ["message", "data"],
+  properties: {
+    message: { type: "string" },
+    data: {
+      type: "object",
+      required: ["agentId"],
+      properties: {
+        agentId: { type: "integer" },
+      },
+    },
   },
 };

--- a/src/server/schema/agent-register.schema.ts
+++ b/src/server/schema/agent-register.schema.ts
@@ -49,7 +49,11 @@ export const registerSearchResponseSchema = {
   },
 };
 
-export const registerAgentNewSchema = {
+// Fields shared by both create flows: self-registration's CREATE branch
+// (which also collects `phone`, written onto the registrant's own Person)
+// and the coordinator/admin bare-create below (which has no Person to
+// attach a phone to).
+const agentCreateBaseSchema = {
   type: "object",
   required: ["title"],
   additionalProperties: false,
@@ -62,7 +66,6 @@ export const registerAgentNewSchema = {
       type: "array",
       items: { type: "integer" },
     },
-    phone: { type: "string" },
     addressStreet: { type: "string" },
     addressPostcode: { type: "string" },
     districtId: { type: "integer" },
@@ -70,6 +73,14 @@ export const registerAgentNewSchema = {
       type: "array",
       items: { type: "integer" },
     },
+  },
+};
+
+export const registerAgentNewSchema = {
+  ...agentCreateBaseSchema,
+  properties: {
+    ...agentCreateBaseSchema.properties,
+    phone: { type: "string" },
   },
 };
 
@@ -124,9 +135,10 @@ export const registerAgentConflictSchema = {
 };
 
 // POST /agent (coordinator/admin-only, fe#911) — same create fields as
-// registration's CREATE branch (registerAgentNewSchema), but the body isn't
-// wrapped in { agent: ... } since this endpoint only ever creates, never joins.
-export const createAgentBodySchema = registerAgentNewSchema;
+// registration's CREATE branch, minus `phone` (a bare agent has no linked
+// Person to attach it to — see createBareAgent). The body isn't wrapped in
+// { agent: ... } since this endpoint only ever creates, never joins.
+export const createAgentBodySchema = agentCreateBaseSchema;
 
 export const createAgentResponseSchema = {
   type: "object",

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -1341,6 +1341,9 @@
         },
         "volunteerSearch": {
           "$ref": "AgentVolunteerSearchType#"
+        },
+        "unclaimed": {
+          "type": "boolean"
         }
       }
     },
@@ -1356,7 +1359,8 @@
         "numActiveVolunteers",
         "numOpportunities",
         "email",
-        "volunteerSearch"
+        "volunteerSearch",
+        "unclaimed"
       ]
     },
     "AgentProps": {
@@ -1484,6 +1488,7 @@
         "numActiveVolunteers",
         "email",
         "volunteerSearch",
+        "unclaimed",
         "createdAt",
         "statusEngagement",
         "agentDetails",

--- a/src/server/utils/data/assert-agent-visible.ts
+++ b/src/server/utils/data/assert-agent-visible.ts
@@ -1,0 +1,19 @@
+import { UserRole } from "need4deed-sdk";
+import { NotFoundError } from "../../../config";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+
+// A coordinator-created agent (fe#911) stays `unclaimed` until a real
+// registration claims it, and must stay invisible to non-coordinator/admin
+// callers across every /agent/:id-scoped route, not just GET /agent/:id —
+// otherwise a sibling route that skips this check leaks its existence via a
+// response distinguishable from a genuinely nonexistent id. 404 rather than
+// 403 so existence isn't leaked to a caller guessing ids.
+export function assertAgentVisible(
+  agent: Agent,
+  role: UserRole | undefined,
+): void {
+  const isPrivileged = role === UserRole.COORDINATOR || role === UserRole.ADMIN;
+  if (agent.unclaimed && !isPrivileged) {
+    throw new NotFoundError(`Agent (id:${agent.id}) not found.`);
+  }
+}

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -3,6 +3,7 @@ export * from "./add-category-to-deal";
 export * from "./add-comments-entity";
 export * from "./add-district-to-agent";
 export * from "./add-district-to-opp";
+export * from "./assert-agent-visible";
 export * from "./create-agent-contact";
 export * from "./for-routes";
 export * from "./get-agent-by-postcode";

--- a/src/server/utils/data/write-agent-registration.ts
+++ b/src/server/utils/data/write-agent-registration.ts
@@ -3,6 +3,7 @@ import {
   AgentRoleType,
   ApiAgentRegisterNew,
 } from "need4deed-sdk";
+import { EntityManager } from "typeorm";
 import { dataSource } from "../../../data/data-source";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
@@ -30,6 +31,77 @@ export class AgentAddressConflictError extends Error {
   }
 }
 
+// Dedup: if the street+postcode already resolve to an existing agent (same
+// picker POST /opportunity/legacy uses), don't mint a duplicate — surface it
+// so the caller can offer JOIN (self-registration) or just point at the
+// existing agent (coordinator create) instead.
+async function assertNoAddressConflict(
+  addressStreet?: string,
+  addressPostcode?: string,
+): Promise<void> {
+  if (!addressStreet || !addressPostcode) {
+    return;
+  }
+  const agents = await dataSource.getRepository(Agent).find({
+    relations: ["address.postcode", "agentPostcode.postcode"],
+  });
+  const match = getAgentByAddress(agents, addressStreet, addressPostcode);
+  if (match) {
+    throw new AgentAddressConflictError(match.id);
+  }
+}
+
+// The Agent + Address + AgentService + AgentLanguage rows shared by both the
+// self-registration CREATE path and the coordinator-created (personless)
+// path — everything except the AgentPerson membership itself, which only the
+// former needs.
+async function createBareAgent(
+  input: ApiAgentRegisterNew,
+  manager: EntityManager,
+): Promise<Agent> {
+  const address =
+    input.addressStreet && input.addressPostcode
+      ? await createAddress(
+          { street: input.addressStreet },
+          { value: input.addressPostcode },
+          manager,
+        )
+      : null;
+
+  const agent = await manager.getRepository(Agent).save(
+    new Agent({
+      title: input.title,
+      agentTypeId: input.typeId ?? undefined,
+      info: input.info ?? undefined,
+      website: input.website ?? undefined,
+      districtId: input.districtId ?? undefined,
+      addressId: address?.id,
+    }),
+  );
+
+  if (input.serviceIds?.length) {
+    await manager
+      .getRepository(AgentService)
+      .save(
+        input.serviceIds.map(
+          (serviceId) => ({ agentId: agent.id, serviceId }) as AgentService,
+        ),
+      );
+  }
+
+  if (input.languages?.length) {
+    await manager
+      .getRepository(AgentLanguage)
+      .save(
+        input.languages.map(
+          (languageId) => ({ agentId: agent.id, languageId }) as AgentLanguage,
+        ),
+      );
+  }
+
+  return agent;
+}
+
 /**
  * CREATE path: a verified user creates a brand-new agent and becomes its first
  * VOLUNTEER_COORDINATOR. The creator owns the record, so the membership is
@@ -48,55 +120,12 @@ export async function createAgentForPerson(
   personId: number,
   input: AgentRegisterInput,
 ): Promise<RegisterAgentResult> {
-  // Dedup: if the street+postcode already resolve to an existing agent (same
-  // picker POST /opportunity/legacy uses), don't mint a duplicate — surface it
-  // so the client can offer JOIN instead.
-  if (input.addressStreet && input.addressPostcode) {
-    const agents = await dataSource.getRepository(Agent).find({
-      relations: ["address.postcode", "agentPostcode.postcode"],
-    });
-    const match = getAgentByAddress(
-      agents,
-      input.addressStreet,
-      input.addressPostcode,
-    );
-    if (match) {
-      throw new AgentAddressConflictError(match.id);
-    }
-  }
+  await assertNoAddressConflict(input.addressStreet, input.addressPostcode);
 
   let result!: RegisterAgentResult;
 
   await dataSource.manager.transaction(async (manager) => {
-    const address =
-      input.addressStreet && input.addressPostcode
-        ? await createAddress(
-            { street: input.addressStreet },
-            { value: input.addressPostcode },
-            manager,
-          )
-        : null;
-
-    const agent = await manager.getRepository(Agent).save(
-      new Agent({
-        title: input.title,
-        agentTypeId: input.typeId ?? undefined,
-        info: input.info ?? undefined,
-        website: input.website ?? undefined,
-        districtId: input.districtId ?? undefined,
-        addressId: address?.id,
-      }),
-    );
-
-    if (input.serviceIds?.length) {
-      await manager
-        .getRepository(AgentService)
-        .save(
-          input.serviceIds.map(
-            (serviceId) => ({ agentId: agent.id, serviceId }) as AgentService,
-          ),
-        );
-    }
+    const agent = await createBareAgent(input, manager);
 
     await manager.getRepository(AgentPerson).save(
       new AgentPerson({
@@ -106,17 +135,6 @@ export async function createAgentForPerson(
         status: AgentMembershipStatus.ACTIVE,
       }),
     );
-
-    if (input.languages?.length) {
-      await manager
-        .getRepository(AgentLanguage)
-        .save(
-          input.languages.map(
-            (languageId) =>
-              ({ agentId: agent.id, languageId }) as AgentLanguage,
-          ),
-        );
-    }
 
     if (input.phone) {
       await manager
@@ -131,6 +149,28 @@ export async function createAgentForPerson(
   });
 
   return result;
+}
+
+/**
+ * COORDINATOR/ADMIN create path (fe#911, be side): an Agent with no linked
+ * Person/User at all — for adding an NGO the coordinator already has details
+ * for, before it has self-registered. Shares createBareAgent with
+ * createAgentForPerson; the only difference is there's no AgentPerson
+ * membership (and thus no phone-on-Person write) to add.
+ */
+export async function createAgent(
+  input: ApiAgentRegisterNew,
+): Promise<{ agentId: number }> {
+  await assertNoAddressConflict(input.addressStreet, input.addressPostcode);
+
+  let agentId!: number;
+
+  await dataSource.manager.transaction(async (manager) => {
+    const agent = await createBareAgent(input, manager);
+    agentId = agent.id;
+  });
+
+  return { agentId };
 }
 
 /**

--- a/src/server/utils/data/write-agent-registration.ts
+++ b/src/server/utils/data/write-agent-registration.ts
@@ -4,7 +4,7 @@ import {
   ApiAgentRegisterNew,
 } from "need4deed-sdk";
 import { EntityManager } from "typeorm";
-import { BaseError, UnauthorizedError } from "../../../config";
+import { BaseError, NotFoundError, UnauthorizedError } from "../../../config";
 import { dataSource } from "../../../data/data-source";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
@@ -144,29 +144,39 @@ export async function createAgentForPerson(
 
   let result!: RegisterAgentResult;
 
-  await dataSource.manager.transaction(async (manager) => {
-    const agent = await createBareAgent(input, manager);
+  try {
+    await dataSource.manager.transaction(async (manager) => {
+      const agent = await createBareAgent(input, manager);
 
-    await manager.getRepository(AgentPerson).save(
-      new AgentPerson({
+      await manager.getRepository(AgentPerson).save(
+        new AgentPerson({
+          agentId: agent.id,
+          personId,
+          role: AgentRoleType.VOLUNTEER_COORDINATOR,
+          status: AgentMembershipStatus.ACTIVE,
+        }),
+      );
+
+      if (input.phone) {
+        await manager
+          .getRepository(Person)
+          .update({ id: personId }, { phone: input.phone });
+      }
+
+      result = {
         agentId: agent.id,
-        personId,
-        role: AgentRoleType.VOLUNTEER_COORDINATOR,
-        status: AgentMembershipStatus.ACTIVE,
-      }),
-    );
-
-    if (input.phone) {
-      await manager
-        .getRepository(Person)
-        .update({ id: personId }, { phone: input.phone });
+        membershipStatus: AgentMembershipStatus.ACTIVE,
+      };
+    });
+  } catch (err) {
+    if (classifyRegisterAgentConflict(err) === "title") {
+      const existing = await dataSource
+        .getRepository(Agent)
+        .findOne({ where: { title: input.title } });
+      throw new AgentTitleConflictError(existing?.id);
     }
-
-    result = {
-      agentId: agent.id,
-      membershipStatus: AgentMembershipStatus.ACTIVE,
-    };
-  });
+    throw err;
+  }
 
   return result;
 }
@@ -268,7 +278,10 @@ export async function joinAgent(
   // legacy agents (created via POST /opportunity/legacy with no rac_email)
   // can also have zero AgentPerson rows and must remain joinable.
   const agent = await agentRepo.findOne({ where: { id: agentId } });
-  if (!agent || agent.unclaimed) {
+  if (!agent) {
+    throw new NotFoundError(`Agent (id:${agentId}) not found.`);
+  }
+  if (agent.unclaimed) {
     throw new UnauthorizedError(
       "This agent has not been claimed yet and cannot be joined directly.",
     );

--- a/src/server/utils/data/write-agent-registration.ts
+++ b/src/server/utils/data/write-agent-registration.ts
@@ -4,6 +4,7 @@ import {
   ApiAgentRegisterNew,
 } from "need4deed-sdk";
 import { EntityManager } from "typeorm";
+import { UnauthorizedError } from "../../../config";
 import { dataSource } from "../../../data/data-source";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
@@ -226,6 +227,19 @@ export async function joinAgent(
   status: AgentMembershipStatus,
 ): Promise<RegisterAgentResult> {
   const repo = dataSource.getRepository(AgentPerson);
+
+  // A coordinator-created agent (fe#911) has zero AgentPerson rows until a
+  // real registration claims it — that claim must go through a future,
+  // explicitly-reviewed flow, not this auto-approve-on-domain-match JOIN.
+  // Excluding it from the /search picker isn't enough on its own: this route
+  // takes agentId directly from the client, so anyone who already has (or
+  // guesses) the id could otherwise join straight past that picker.
+  const anyMembership = await repo.findOne({ where: { agentId } });
+  if (!anyMembership) {
+    throw new UnauthorizedError(
+      "This agent has not been claimed yet and cannot be joined directly.",
+    );
+  }
 
   const existing = await repo.findOne({
     where: { agentId, personId, role: AgentRoleType.VOLUNTEER_COORDINATOR },

--- a/src/server/utils/data/write-agent-registration.ts
+++ b/src/server/utils/data/write-agent-registration.ts
@@ -4,7 +4,7 @@ import {
   ApiAgentRegisterNew,
 } from "need4deed-sdk";
 import { EntityManager } from "typeorm";
-import { UnauthorizedError } from "../../../config";
+import { BaseError, UnauthorizedError } from "../../../config";
 import { dataSource } from "../../../data/data-source";
 import AgentLanguage from "../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../data/entity/m2m/agent-person";
@@ -25,10 +25,27 @@ export interface RegisterAgentResult {
  * existing agent (via the same getAgentByAddress picker POST /opportunity/legacy
  * uses). The route maps it to a 409 + agentId so the client can offer JOIN.
  */
-export class AgentAddressConflictError extends Error {
+export class AgentAddressConflictError extends BaseError {
   constructor(public readonly agentId: number) {
-    super("An agent at this address already exists.");
-    this.name = "AgentAddressConflictError";
+    super("An agent at this address already exists.", 409, true, {
+      conflict: "address",
+      agentId,
+    });
+  }
+}
+
+/**
+ * Raised by createAgent (coordinator/admin bare-create, fe#911) on a
+ * unique-title violation. Mirrors AgentAddressConflictError's response shape
+ * so the route can let it propagate to the global error handler instead of
+ * hand-building the 409 body itself.
+ */
+export class AgentTitleConflictError extends BaseError {
+  constructor(public readonly agentId?: number) {
+    super("An agent with this title already exists.", 409, true, {
+      conflict: "title",
+      ...(agentId !== undefined ? { agentId } : {}),
+    });
   }
 }
 
@@ -59,6 +76,7 @@ async function assertNoAddressConflict(
 async function createBareAgent(
   input: ApiAgentRegisterNew,
   manager: EntityManager,
+  unclaimed = false,
 ): Promise<Agent> {
   const address =
     input.addressStreet && input.addressPostcode
@@ -77,6 +95,7 @@ async function createBareAgent(
       website: input.website ?? undefined,
       districtId: input.districtId ?? undefined,
       addressId: address?.id,
+      unclaimed,
     }),
   );
 
@@ -166,10 +185,20 @@ export async function createAgent(
 
   let agentId!: number;
 
-  await dataSource.manager.transaction(async (manager) => {
-    const agent = await createBareAgent(input, manager);
-    agentId = agent.id;
-  });
+  try {
+    await dataSource.manager.transaction(async (manager) => {
+      const agent = await createBareAgent(input, manager, true);
+      agentId = agent.id;
+    });
+  } catch (err) {
+    if (classifyRegisterAgentConflict(err) === "title") {
+      const existing = await dataSource
+        .getRepository(Agent)
+        .findOne({ where: { title: input.title } });
+      throw new AgentTitleConflictError(existing?.id);
+    }
+    throw err;
+  }
 
   return { agentId };
 }
@@ -227,15 +256,19 @@ export async function joinAgent(
   status: AgentMembershipStatus,
 ): Promise<RegisterAgentResult> {
   const repo = dataSource.getRepository(AgentPerson);
+  const agentRepo = dataSource.getRepository(Agent);
 
-  // A coordinator-created agent (fe#911) has zero AgentPerson rows until a
-  // real registration claims it — that claim must go through a future,
+  // A coordinator-created agent (fe#911) is marked `unclaimed` until a real
+  // registration claims it — that claim must go through a future,
   // explicitly-reviewed flow, not this auto-approve-on-domain-match JOIN.
   // Excluding it from the /search picker isn't enough on its own: this route
   // takes agentId directly from the client, so anyone who already has (or
-  // guesses) the id could otherwise join straight past that picker.
-  const anyMembership = await repo.findOne({ where: { agentId } });
-  if (!anyMembership) {
+  // guesses) the id could otherwise join straight past that picker. Gating on
+  // this flag rather than "zero AgentPerson rows" matters: pre-existing
+  // legacy agents (created via POST /opportunity/legacy with no rac_email)
+  // can also have zero AgentPerson rows and must remain joinable.
+  const agent = await agentRepo.findOne({ where: { id: agentId } });
+  if (!agent || agent.unclaimed) {
     throw new UnauthorizedError(
       "This agent has not been claimed yet and cannot be joined directly.",
     );

--- a/src/services/dto/dto-agent.ts
+++ b/src/services/dto/dto-agent.ts
@@ -56,6 +56,7 @@ export function dtoAgentGetList(agent: Agent): ApiAgentGetList {
     email:
       agent.representative?.person?.email || agent.organization?.email || "",
     district: { id: agent.districtId, title: { de: agent?.district?.title } },
+    unclaimed: agent.unclaimed,
   };
 }
 

--- a/src/test/server/routes/agent-unclaimed-visibility.routes.test.ts
+++ b/src/test/server/routes/agent-unclaimed-visibility.routes.test.ts
@@ -1,0 +1,146 @@
+import { FastifyInstance } from "fastify";
+import { AgentRoleType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+// Regression coverage for the fe#911 visibility guarantee ("a
+// coordinator-created agent stays invisible to non-coordinator/admin callers
+// until claimed") across every /agent/:id-scoped sibling route, not just
+// GET /agent/:id and GET /agent — a route that skips this check would leak
+// an unclaimed agent's existence via a response distinguishable from a
+// genuinely nonexistent id.
+describe("unclaimed-agent visibility across /agent/:id sibling routes", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  let coordinatorCookie: string;
+  let agentCookie: string;
+  let unclaimedAgentId: number;
+  const createdPersonIds: number[] = [];
+
+  async function login(email: string): Promise<string> {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email, password: PASSWORD },
+    });
+    return res.cookies.find((c) => c.name === accessCookieName)!.value;
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const coordinatorEmail = `coordinator-${suffix}@test.need4deed.org`;
+    await fastify.db.userRepository.save(
+      new User({
+        email: coordinatorEmail,
+        password: await hashPassword(PASSWORD),
+        role: UserRole.COORDINATOR,
+        isActive: true,
+      }),
+    );
+    coordinatorCookie = await login(coordinatorEmail);
+
+    const agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: `Agent-${suffix}` }),
+    );
+    createdPersonIds.push(agentPerson.id);
+    const agentEmail = `agentrole-${suffix}@test.need4deed.org`;
+    await fastify.db.userRepository.save(
+      new User({
+        email: agentEmail,
+        password: await hashPassword(PASSWORD),
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
+    agentCookie = await login(agentEmail);
+
+    const createRes = await fastify.inject({
+      method: "POST",
+      url: "/agent",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { title: `Unclaimed Agent ${suffix}` },
+    });
+    unclaimedAgentId = createRes.json().data.agentId;
+  });
+
+  afterAll(async () => {
+    await fastify.db.agentRepository.delete({ id: unclaimedAgentId });
+    for (const personId of createdPersonIds) {
+      await fastify.db.userRepository.delete({ personId });
+      await fastify.db.personRepository.delete({ id: personId });
+    }
+    await fastify.db.userRepository.delete({
+      email: `coordinator-${suffix}@test.need4deed.org`,
+    });
+    await fastify.close();
+  });
+
+  it("GET /agent/:id/opportunity-linked 404s for a non-privileged caller, 200s for a coordinator", async () => {
+    const asAgent = await fastify.inject({
+      method: "GET",
+      url: `/agent/${unclaimedAgentId}/opportunity-linked`,
+      cookies: { [accessCookieName]: agentCookie },
+    });
+    expect(asAgent.statusCode).toBe(404);
+
+    const asCoordinator = await fastify.inject({
+      method: "GET",
+      url: `/agent/${unclaimedAgentId}/opportunity-linked`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(asCoordinator.statusCode).toBe(200);
+  });
+
+  it("GET /agent/:id/communication 404s for a non-privileged caller, 200s for a coordinator", async () => {
+    const asAgent = await fastify.inject({
+      method: "GET",
+      url: `/agent/${unclaimedAgentId}/communication`,
+      cookies: { [accessCookieName]: agentCookie },
+    });
+    expect(asAgent.statusCode).toBe(404);
+
+    const asCoordinator = await fastify.inject({
+      method: "GET",
+      url: `/agent/${unclaimedAgentId}/communication`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(asCoordinator.statusCode).toBe(200);
+  });
+
+  it("POST /agent/:id/contact 404s for a non-privileged caller instead of leaking existence via 403", async () => {
+    const payload = {
+      firstName: "Test",
+      lastName: "Contact",
+      role: AgentRoleType.SOCIAL_WORKER,
+    };
+
+    const asAgent = await fastify.inject({
+      method: "POST",
+      url: `/agent/${unclaimedAgentId}/contact`,
+      cookies: { [accessCookieName]: agentCookie },
+      payload,
+    });
+    expect(asAgent.statusCode).toBe(404);
+
+    const asCoordinator = await fastify.inject({
+      method: "POST",
+      url: `/agent/${unclaimedAgentId}/contact`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload,
+    });
+    expect(asCoordinator.statusCode).toBe(201);
+
+    const created = asCoordinator.json().data;
+    await fastify.db.agentPersonRepository.delete({ id: created.id });
+    await fastify.db.personRepository.delete({ id: created.person.id });
+  });
+});

--- a/src/test/server/routes/agent-volunteer.routes.test.ts
+++ b/src/test/server/routes/agent-volunteer.routes.test.ts
@@ -45,6 +45,9 @@ describe("GET /agent/:id/volunteer-linked", () => {
   let opportunityVolunteer: OpportunityVolunteer;
   let coordinatorPerson: Person;
   let coordinatorCookie: string;
+  let agentRolePerson: Person;
+  let agentRoleCookie: string;
+  let unclaimedAgent: Agent;
 
   beforeAll(async () => {
     fastify = await createServer();
@@ -122,6 +125,33 @@ describe("GET /agent/:id/volunteer-linked", () => {
       },
     });
     coordinatorCookie = getCookie(loginRes.cookies, accessCookieName);
+
+    agentRolePerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "AgentRole" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `agentrole-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentRolePerson.id,
+      }),
+    );
+    const agentRoleLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `agentrole-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    agentRoleCookie = getCookie(agentRoleLoginRes.cookies, accessCookieName);
+
+    // fe#911: a coordinator-created agent with no linked Person/User yet.
+    unclaimedAgent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Unclaimed Agent ${suffix}`, unclaimed: true }),
+    );
   });
 
   afterAll(async () => {
@@ -134,8 +164,11 @@ describe("GET /agent/:id/volunteer-linked", () => {
     await fastify.db.dealRepository.delete({ id: deal.id });
     await fastify.db.agentRepository.delete({ id: agent.id });
     await fastify.db.agentRepository.delete({ id: emptyAgent.id });
+    await fastify.db.agentRepository.delete({ id: unclaimedAgent.id });
     await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
     await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.userRepository.delete({ personId: agentRolePerson.id });
+    await fastify.db.personRepository.delete({ id: agentRolePerson.id });
     await fastify.close();
   });
 
@@ -177,5 +210,24 @@ describe("GET /agent/:id/volunteer-linked", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().data).toEqual([]);
+  });
+
+  // fe#911: an unclaimed agent must stay invisible to non-coordinator/admin
+  // callers here too, not just on GET /agent/:id — otherwise this route
+  // leaks its existence via a 200 distinguishable from a nonexistent id.
+  it("404s for an unclaimed agent when the caller isn't coordinator/admin, but not for a coordinator", async () => {
+    const asAgentRole = await fastify.inject({
+      method: "GET",
+      url: `/agent/${unclaimedAgent.id}/volunteer-linked`,
+      cookies: { [accessCookieName]: agentRoleCookie },
+    });
+    expect(asAgentRole.statusCode).toBe(404);
+
+    const asCoordinator = await fastify.inject({
+      method: "GET",
+      url: `/agent/${unclaimedAgent.id}/volunteer-linked`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(asCoordinator.statusCode).toBe(200);
   });
 });

--- a/src/test/server/routes/agent.routes.test.ts
+++ b/src/test/server/routes/agent.routes.test.ts
@@ -601,6 +601,55 @@ describe("POST /agent — coordinator-created agent (fe#911)", () => {
     expect(
       asCoordinator.json().data.some((a: { id: number }) => a.id === agentId),
     ).toBe(true);
+
+    // Regression check: `count` must reflect the same filtered set as
+    // `data`, not the unfiltered total — the unclaimed agent just created
+    // is excluded from the where clause itself, not filtered in-memory
+    // after skip/take.
+    expect(asAgent.json().count).toBe(asAgent.json().data.length);
+  });
+
+  it("hides an unclaimed agent from GET /agent/:id for a non-privileged caller, but not a coordinator", async () => {
+    const createRes = await fastify.inject({
+      method: "POST",
+      url: "/agent",
+      cookies: { access: coordinatorCookie },
+      payload: { title: `Bare Agent For Get ${suffix}` },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const agentId = createRes.json().data.agentId;
+    createdAgentIds.push(agentId);
+
+    const asAgent = await fastify.inject({
+      method: "GET",
+      url: `/agent/${agentId}`,
+      cookies: { access: agentCookie },
+    });
+    expect(asAgent.statusCode).toBe(404);
+
+    const asCoordinator = await fastify.inject({
+      method: "GET",
+      url: `/agent/${agentId}`,
+      cookies: { access: coordinatorCookie },
+    });
+    expect(asCoordinator.statusCode).toBe(200);
+    expect(asCoordinator.json().data.id).toBe(agentId);
+  });
+
+  // createAgentBodySchema no longer declares `phone` (a bare agent has no
+  // linked Person to attach it to) — AJV's project-wide `removeAdditional`
+  // setting means it's now stripped before the handler ever sees it,
+  // rather than being accepted and then silently dropped deep in
+  // createBareAgent as it was before.
+  it("strips an unsupported phone field rather than silently accepting it", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/agent",
+      cookies: { access: coordinatorCookie },
+      payload: { title: `Bare Agent With Phone ${suffix}`, phone: "+491234" },
+    });
+    expect(res.statusCode).toBe(201);
+    createdAgentIds.push(res.json().data.agentId);
   });
 
   it("409s on a duplicate title", async () => {

--- a/src/test/server/routes/agent.routes.test.ts
+++ b/src/test/server/routes/agent.routes.test.ts
@@ -485,3 +485,136 @@ describe("PATCH /agent/:id organization details", () => {
     });
   });
 });
+
+// fe#911: a coordinator can create a bare Agent with no linked Person/User,
+// and it must stay invisible to non-coordinator/admin callers until a real
+// registration claims it.
+describe("POST /agent — coordinator-created agent (fe#911)", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const createdAgentIds: number[] = [];
+  const createdPersonIds: number[] = [];
+  let coordinatorCookie: string;
+  let agentCookie: string;
+
+  async function login(email: string): Promise<string> {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email, password: "test_password" },
+    });
+    return res.cookies.find((c) => c.name === "access")!.value;
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const coordinatorEmail = `coordinator-${suffix}@test.need4deed.org`;
+    await fastify.db.userRepository.save(
+      new User({
+        email: coordinatorEmail,
+        password: await hashPassword("test_password"),
+        role: UserRole.COORDINATOR,
+        isActive: true,
+      }),
+    );
+    coordinatorCookie = await login(coordinatorEmail);
+
+    const agentPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: `Agent-${suffix}` }),
+    );
+    createdPersonIds.push(agentPerson.id);
+    const agentEmail = `agentrole-${suffix}@test.need4deed.org`;
+    await fastify.db.userRepository.save(
+      new User({
+        email: agentEmail,
+        password: await hashPassword("test_password"),
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: agentPerson.id,
+      }),
+    );
+    agentCookie = await login(agentEmail);
+  });
+
+  afterAll(async () => {
+    for (const id of createdAgentIds) {
+      await fastify.db.agentRepository.delete({ id });
+    }
+    for (const personId of createdPersonIds) {
+      await fastify.db.userRepository.delete({ personId });
+      await fastify.db.personRepository.delete({ id: personId });
+    }
+    await fastify.db.userRepository.delete({
+      email: `coordinator-${suffix}@test.need4deed.org`,
+    });
+    await fastify.close();
+  });
+
+  it("rejects a non-coordinator/admin caller", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/agent",
+      cookies: { access: agentCookie },
+      payload: { title: `Should Not Create ${suffix}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("creates a bare agent with no AgentPerson, hidden from non-privileged GET /agent", async () => {
+    const createRes = await fastify.inject({
+      method: "POST",
+      url: "/agent",
+      cookies: { access: coordinatorCookie },
+      payload: { title: `Bare Agent ${suffix}` },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const agentId = createRes.json().data.agentId;
+    createdAgentIds.push(agentId);
+
+    const memberships = await fastify.db.agentPersonRepository.find({
+      where: { agentId },
+    });
+    expect(memberships).toHaveLength(0);
+
+    const asAgent = await fastify.inject({
+      method: "GET",
+      url: "/agent?limit=1000",
+      cookies: { access: agentCookie },
+    });
+    expect(
+      asAgent.json().data.some((a: { id: number }) => a.id === agentId),
+    ).toBe(false);
+
+    const asCoordinator = await fastify.inject({
+      method: "GET",
+      url: "/agent?limit=1000",
+      cookies: { access: coordinatorCookie },
+    });
+    expect(
+      asCoordinator.json().data.some((a: { id: number }) => a.id === agentId),
+    ).toBe(true);
+  });
+
+  it("409s on a duplicate title", async () => {
+    const title = `Duplicate Agent ${suffix}`;
+    const first = await fastify.inject({
+      method: "POST",
+      url: "/agent",
+      cookies: { access: coordinatorCookie },
+      payload: { title },
+    });
+    expect(first.statusCode).toBe(201);
+    createdAgentIds.push(first.json().data.agentId);
+
+    const second = await fastify.inject({
+      method: "POST",
+      url: "/agent",
+      cookies: { access: coordinatorCookie },
+      payload: { title },
+    });
+    expect(second.statusCode).toBe(409);
+    expect(second.json()).toMatchObject({ conflict: "title" });
+  });
+});

--- a/src/test/server/routes/agent.routes.test.ts
+++ b/src/test/server/routes/agent.routes.test.ts
@@ -598,9 +598,14 @@ describe("POST /agent — coordinator-created agent (fe#911)", () => {
       url: "/agent?limit=120&sortOrder=new-old",
       cookies: { access: coordinatorCookie },
     });
-    expect(
-      asCoordinator.json().data.some((a: { id: number }) => a.id === agentId),
-    ).toBe(true);
+    const coordinatorEntry = asCoordinator
+      .json()
+      .data.find((a: { id: number }) => a.id === agentId);
+    expect(coordinatorEntry).toBeDefined();
+    // Regression check: sdk-types.json's ApiAgentGetList schema must declare
+    // `unclaimed`, or fast-json-stringify silently strips it from the wire
+    // response even though dtoAgentGetList sets it (same bug class as be#575).
+    expect(coordinatorEntry.unclaimed).toBe(true);
 
     // Regression check: `count` must reflect the same filtered set as
     // `data`, not the unfiltered total — the unclaimed agent just created
@@ -634,6 +639,7 @@ describe("POST /agent — coordinator-created agent (fe#911)", () => {
     });
     expect(asCoordinator.statusCode).toBe(200);
     expect(asCoordinator.json().data.id).toBe(agentId);
+    expect(asCoordinator.json().data.unclaimed).toBe(true);
   });
 
   // createAgentBodySchema no longer declares `phone` (a bare agent has no

--- a/src/test/server/routes/agent.routes.test.ts
+++ b/src/test/server/routes/agent.routes.test.ts
@@ -580,7 +580,10 @@ describe("POST /agent — coordinator-created agent (fe#911)", () => {
 
     const asAgent = await fastify.inject({
       method: "GET",
-      url: "/agent?limit=1000",
+      // limit is capped at 120 by agentListQuerySchema; sortOrder=new-old
+      // (DESC by id) puts the just-created agent reliably on page 1 no matter
+      // how many other agents already exist in the DB.
+      url: "/agent?limit=120&sortOrder=new-old",
       cookies: { access: agentCookie },
     });
     expect(
@@ -589,7 +592,10 @@ describe("POST /agent — coordinator-created agent (fe#911)", () => {
 
     const asCoordinator = await fastify.inject({
       method: "GET",
-      url: "/agent?limit=1000",
+      // limit is capped at 120 by agentListQuerySchema; sortOrder=new-old
+      // (DESC by id) puts the just-created agent reliably on page 1 no matter
+      // how many other agents already exist in the DB.
+      url: "/agent?limit=120&sortOrder=new-old",
       cookies: { access: coordinatorCookie },
     });
     expect(

--- a/src/test/server/utils/data/write-agent-registration.test.ts
+++ b/src/test/server/utils/data/write-agent-registration.test.ts
@@ -316,8 +316,26 @@ describe("resolveJoinStatus", () => {
 });
 
 describe("joinAgent", () => {
-  it("creates a new membership link with the given status when none exists", async () => {
+  // fe#911: a coordinator-created agent has zero AgentPerson rows until a
+  // real registration claims it. Excluding it from the /search picker isn't
+  // enough on its own — this is the endpoint that actually grants access, and
+  // it takes agentId directly from the client — so it must refuse to link
+  // anyone to an agent nobody has ever joined yet.
+  it("rejects joining an agent with no existing memberships at all", async () => {
     agentPersonRepoFindOne.mockResolvedValueOnce(null);
+
+    await expect(
+      joinAgent(11, 33, AgentMembershipStatus.PENDING),
+    ).rejects.toThrow(
+      "This agent has not been claimed yet and cannot be joined directly.",
+    );
+    expect(agentPersonRepoSave).not.toHaveBeenCalled();
+  });
+
+  it("creates a new membership link with the given status when the agent already has a member", async () => {
+    agentPersonRepoFindOne
+      .mockResolvedValueOnce({ id: 1, role: AgentRoleType.SOCIAL_WORKER })
+      .mockResolvedValueOnce(null);
 
     const result = await joinAgent(11, 33, AgentMembershipStatus.PENDING);
 
@@ -335,10 +353,12 @@ describe("joinAgent", () => {
   });
 
   it("is idempotent: returns the existing membership status without saving again", async () => {
-    agentPersonRepoFindOne.mockResolvedValueOnce({
-      id: 7,
-      status: AgentMembershipStatus.ACTIVE,
-    });
+    agentPersonRepoFindOne
+      .mockResolvedValueOnce({ id: 1, role: AgentRoleType.SOCIAL_WORKER })
+      .mockResolvedValueOnce({
+        id: 7,
+        status: AgentMembershipStatus.ACTIVE,
+      });
 
     const result = await joinAgent(11, 33, AgentMembershipStatus.PENDING);
 

--- a/src/test/server/utils/data/write-agent-registration.test.ts
+++ b/src/test/server/utils/data/write-agent-registration.test.ts
@@ -7,6 +7,7 @@ import Agent from "../../../../data/entity/opportunity/agent.entity";
 import Person from "../../../../data/entity/person.entity";
 import {
   AgentAddressConflictError,
+  AgentTitleConflictError,
   classifyRegisterAgentConflict,
   createAgent,
   createAgentForPerson,
@@ -26,6 +27,15 @@ vi.mock("../../../../server/utils/data/is-trusted-domain", () => ({
 }));
 
 const txnManager: any = { getRepository: vi.fn() };
+
+// Agent.find (address-dedup lookup) and Agent.findOne (joinAgent's
+// exists/unclaimed check, createAgent's title-conflict lookup) — kept
+// distinct from the AgentPerson repo mocks below since routing now depends
+// on which entity's repository is requested (unlike before fe#911's
+// `unclaimed` flag, joinAgent only ever touched AgentPerson).
+const agentRepoFind = vi.fn();
+const agentRepoFindOne = vi.fn();
+
 const agentPersonRepoFindOne = vi.fn();
 const agentPersonRepoFind = vi.fn();
 const agentPersonRepoSave = vi.fn();
@@ -33,11 +43,14 @@ const agentPersonRepoSave = vi.fn();
 vi.mock("../../../../data/data-source", () => ({
   dataSource: {
     manager: { transaction: async (cb: any) => cb(txnManager) },
-    getRepository: () => ({
-      findOne: agentPersonRepoFindOne,
-      find: agentPersonRepoFind,
-      save: agentPersonRepoSave,
-    }),
+    getRepository: (entity: any) =>
+      entity?.name === "Agent"
+        ? { find: agentRepoFind, findOne: agentRepoFindOne }
+        : {
+            findOne: agentPersonRepoFindOne,
+            find: agentPersonRepoFind,
+            save: agentPersonRepoSave,
+          },
   },
 }));
 
@@ -69,7 +82,7 @@ beforeEach(() => {
 
   // Default: the address-dedup lookup (dataSource.getRepository(Agent).find)
   // finds no existing agent, so createAgentForPerson proceeds to create.
-  agentPersonRepoFind.mockResolvedValue([]);
+  agentRepoFind.mockResolvedValue([]);
 
   // Default: domain not on the trusted allowlist (member-match decides).
   isEmailDomainTrustedMock.mockResolvedValue(false);
@@ -126,7 +139,7 @@ describe("createAgentForPerson", () => {
   it("throws AgentAddressConflictError (no create) when street+postcode match an existing agent", async () => {
     // The dedup lookup finds an agent at the same address (getAgentByAddress
     // strict match on normalized street + postcode).
-    agentPersonRepoFind.mockResolvedValueOnce([
+    agentRepoFind.mockResolvedValueOnce([
       {
         id: 77,
         address: {
@@ -210,17 +223,31 @@ describe("createAgentForPerson", () => {
 // AgentPerson membership (and the phone-on-Person write, which has no person
 // to target here).
 describe("createAgent", () => {
-  it("persists the Agent alone — no AgentPerson, no phone write", async () => {
+  it("persists the Agent alone — no AgentPerson, no phone write — marked unclaimed", async () => {
     const result = await createAgent({ title: "Bare Agent HERO" });
 
     expect(agentSave).toHaveBeenCalledTimes(1);
     expect(agentSave.mock.calls[0][0]).toMatchObject({
       title: "Bare Agent HERO",
       addressId: undefined,
+      unclaimed: true,
     });
     expect(agentPersonSave).not.toHaveBeenCalled();
     expect(personUpdate).not.toHaveBeenCalled();
     expect(result).toEqual({ agentId: 33 });
+  });
+
+  it("throws AgentTitleConflictError with the existing agent's id on a unique-title violation", async () => {
+    agentSave.mockRejectedValueOnce({
+      code: "23505",
+      detail: "Key (title)=(Bare Agent HERO) already exists.",
+    });
+    agentRepoFindOne.mockResolvedValueOnce({ id: 55 });
+
+    const err = await createAgent({ title: "Bare Agent HERO" }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AgentTitleConflictError);
+    expect(err.agentId).toBe(55);
   });
 
   it("creates Address and propagates addressId when street+postcode given", async () => {
@@ -236,7 +263,7 @@ describe("createAgent", () => {
   });
 
   it("throws AgentAddressConflictError (no create) when street+postcode match an existing agent", async () => {
-    agentPersonRepoFind.mockResolvedValueOnce([
+    agentRepoFind.mockResolvedValueOnce([
       {
         id: 77,
         address: {
@@ -316,13 +343,8 @@ describe("resolveJoinStatus", () => {
 });
 
 describe("joinAgent", () => {
-  // fe#911: a coordinator-created agent has zero AgentPerson rows until a
-  // real registration claims it. Excluding it from the /search picker isn't
-  // enough on its own — this is the endpoint that actually grants access, and
-  // it takes agentId directly from the client — so it must refuse to link
-  // anyone to an agent nobody has ever joined yet.
-  it("rejects joining an agent with no existing memberships at all", async () => {
-    agentPersonRepoFindOne.mockResolvedValueOnce(null);
+  it("rejects joining an agent that doesn't exist", async () => {
+    agentRepoFindOne.mockResolvedValueOnce(null);
 
     await expect(
       joinAgent(11, 33, AgentMembershipStatus.PENDING),
@@ -332,10 +354,28 @@ describe("joinAgent", () => {
     expect(agentPersonRepoSave).not.toHaveBeenCalled();
   });
 
-  it("creates a new membership link with the given status when the agent already has a member", async () => {
-    agentPersonRepoFindOne
-      .mockResolvedValueOnce({ id: 1, role: AgentRoleType.SOCIAL_WORKER })
-      .mockResolvedValueOnce(null);
+  // fe#911: a coordinator-created agent is marked `unclaimed` until a real
+  // registration claims it. Excluding it from the /search picker isn't
+  // enough on its own — this is the endpoint that actually grants access, and
+  // it takes agentId directly from the client — so it must refuse to link
+  // anyone to an agent nobody has ever joined yet.
+  it("rejects joining an unclaimed (coordinator-created) agent", async () => {
+    agentRepoFindOne.mockResolvedValueOnce({ id: 33, unclaimed: true });
+
+    await expect(
+      joinAgent(11, 33, AgentMembershipStatus.PENDING),
+    ).rejects.toThrow(
+      "This agent has not been claimed yet and cannot be joined directly.",
+    );
+    expect(agentPersonRepoSave).not.toHaveBeenCalled();
+  });
+
+  // A legacy agent (e.g. created via POST /opportunity/legacy with no
+  // rac_email) can also have zero AgentPerson rows, but it is not
+  // `unclaimed` — it must stay joinable, unlike a coordinator-created agent.
+  it("allows joining a non-unclaimed agent even with zero existing memberships", async () => {
+    agentRepoFindOne.mockResolvedValueOnce({ id: 33, unclaimed: false });
+    agentPersonRepoFindOne.mockResolvedValueOnce(null);
 
     const result = await joinAgent(11, 33, AgentMembershipStatus.PENDING);
 
@@ -353,12 +393,11 @@ describe("joinAgent", () => {
   });
 
   it("is idempotent: returns the existing membership status without saving again", async () => {
-    agentPersonRepoFindOne
-      .mockResolvedValueOnce({ id: 1, role: AgentRoleType.SOCIAL_WORKER })
-      .mockResolvedValueOnce({
-        id: 7,
-        status: AgentMembershipStatus.ACTIVE,
-      });
+    agentRepoFindOne.mockResolvedValueOnce({ id: 33, unclaimed: false });
+    agentPersonRepoFindOne.mockResolvedValueOnce({
+      id: 7,
+      status: AgentMembershipStatus.ACTIVE,
+    });
 
     const result = await joinAgent(11, 33, AgentMembershipStatus.PENDING);
 

--- a/src/test/server/utils/data/write-agent-registration.test.ts
+++ b/src/test/server/utils/data/write-agent-registration.test.ts
@@ -1,5 +1,6 @@
 import { AgentMembershipStatus, AgentRoleType } from "need4deed-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotFoundError } from "../../../../config";
 import AgentLanguage from "../../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../../data/entity/m2m/agent-person";
 import AgentService from "../../../../data/entity/m2m/agent-service";
@@ -216,6 +217,21 @@ describe("createAgentForPerson", () => {
 
     expect(personUpdate).not.toHaveBeenCalled();
   });
+
+  it("throws AgentTitleConflictError with the existing agent's id on a unique-title violation", async () => {
+    agentSave.mockRejectedValueOnce({
+      code: "23505",
+      detail: "Key (title)=(Centre HERO) already exists.",
+    });
+    agentRepoFindOne.mockResolvedValueOnce({ id: 55 });
+
+    const err = await createAgentForPerson(11, { title: "Centre HERO" }).catch(
+      (e) => e,
+    );
+
+    expect(err).toBeInstanceOf(AgentTitleConflictError);
+    expect(err.agentId).toBe(55);
+  });
 });
 
 // fe#911: coordinator/admin creates a bare Agent with no linked Person — same
@@ -343,14 +359,14 @@ describe("resolveJoinStatus", () => {
 });
 
 describe("joinAgent", () => {
-  it("rejects joining an agent that doesn't exist", async () => {
+  it("404s (not 403) when the agent doesn't exist at all", async () => {
     agentRepoFindOne.mockResolvedValueOnce(null);
 
-    await expect(
-      joinAgent(11, 33, AgentMembershipStatus.PENDING),
-    ).rejects.toThrow(
-      "This agent has not been claimed yet and cannot be joined directly.",
+    const err = await joinAgent(11, 33, AgentMembershipStatus.PENDING).catch(
+      (e) => e,
     );
+
+    expect(err).toBeInstanceOf(NotFoundError);
     expect(agentPersonRepoSave).not.toHaveBeenCalled();
   });
 

--- a/src/test/server/utils/data/write-agent-registration.test.ts
+++ b/src/test/server/utils/data/write-agent-registration.test.ts
@@ -2,11 +2,13 @@ import { AgentMembershipStatus, AgentRoleType } from "need4deed-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AgentLanguage from "../../../../data/entity/m2m/agent-language";
 import AgentPerson from "../../../../data/entity/m2m/agent-person";
+import AgentService from "../../../../data/entity/m2m/agent-service";
 import Agent from "../../../../data/entity/opportunity/agent.entity";
 import Person from "../../../../data/entity/person.entity";
 import {
   AgentAddressConflictError,
   classifyRegisterAgentConflict,
+  createAgent,
   createAgentForPerson,
   joinAgent,
   resolveJoinStatus,
@@ -42,6 +44,7 @@ vi.mock("../../../../data/data-source", () => ({
 const agentSave = vi.fn();
 const agentPersonSave = vi.fn();
 const agentLanguageSave = vi.fn();
+const agentServiceSave = vi.fn();
 const personUpdate = vi.fn();
 
 beforeEach(() => {
@@ -55,6 +58,8 @@ beforeEach(() => {
         return { save: agentPersonSave };
       case AgentLanguage:
         return { save: agentLanguageSave };
+      case AgentService:
+        return { save: agentServiceSave };
       case Person:
         return { update: personUpdate };
       default:
@@ -72,6 +77,7 @@ beforeEach(() => {
   agentSave.mockImplementation(async (a: any) => ({ ...a, id: 33 }));
   agentPersonSave.mockImplementation(async (ap: any) => ({ ...ap, id: 44 }));
   agentLanguageSave.mockImplementation(async (rows: any[]) => rows);
+  agentServiceSave.mockImplementation(async (rows: any[]) => rows);
 });
 
 describe("createAgentForPerson", () => {
@@ -181,15 +187,88 @@ describe("createAgentForPerson", () => {
   it("updates person.phone inside the transaction when phone is provided", async () => {
     personUpdate.mockResolvedValue({});
 
-    await createAgentForPerson(11, { title: "Centre HERO", phone: "+49123456789" });
+    await createAgentForPerson(11, {
+      title: "Centre HERO",
+      phone: "+49123456789",
+    });
 
-    expect(personUpdate).toHaveBeenCalledWith({ id: 11 }, { phone: "+49123456789" });
+    expect(personUpdate).toHaveBeenCalledWith(
+      { id: 11 },
+      { phone: "+49123456789" },
+    );
   });
 
   it("skips person.phone update when phone is not provided", async () => {
     await createAgentForPerson(11, { title: "Centre HERO" });
 
     expect(personUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// fe#911: coordinator/admin creates a bare Agent with no linked Person — same
+// Agent/Address/Service/Language writes as createAgentForPerson, minus the
+// AgentPerson membership (and the phone-on-Person write, which has no person
+// to target here).
+describe("createAgent", () => {
+  it("persists the Agent alone — no AgentPerson, no phone write", async () => {
+    const result = await createAgent({ title: "Bare Agent HERO" });
+
+    expect(agentSave).toHaveBeenCalledTimes(1);
+    expect(agentSave.mock.calls[0][0]).toMatchObject({
+      title: "Bare Agent HERO",
+      addressId: undefined,
+    });
+    expect(agentPersonSave).not.toHaveBeenCalled();
+    expect(personUpdate).not.toHaveBeenCalled();
+    expect(result).toEqual({ agentId: 33 });
+  });
+
+  it("creates Address and propagates addressId when street+postcode given", async () => {
+    createAddressMock.mockResolvedValueOnce({ id: 99 });
+
+    await createAgent({
+      title: "Bare Agent HERO",
+      addressStreet: "Bitterfelder Str 11",
+      addressPostcode: "12681",
+    });
+
+    expect(agentSave.mock.calls[0][0].addressId).toBe(99);
+  });
+
+  it("throws AgentAddressConflictError (no create) when street+postcode match an existing agent", async () => {
+    agentPersonRepoFind.mockResolvedValueOnce([
+      {
+        id: 77,
+        address: {
+          street: "Bitterfelder Str 11",
+          postcode: { value: "12681" },
+        },
+      },
+    ]);
+
+    const err = await createAgent({
+      title: "Bare Agent HERO",
+      addressStreet: "Bitterfelder Str 11",
+      addressPostcode: "12681",
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AgentAddressConflictError);
+    expect(err.agentId).toBe(77);
+    expect(agentSave).not.toHaveBeenCalled();
+  });
+
+  it("inserts AgentLanguage and AgentService rows when given", async () => {
+    await createAgent({
+      title: "Bare Agent HERO",
+      languages: [5, 7],
+      serviceIds: [1, 2],
+    });
+
+    expect(agentLanguageSave).toHaveBeenCalledTimes(1);
+    expect(agentLanguageSave.mock.calls[0][0]).toEqual([
+      { agentId: 33, languageId: 5 },
+      { agentId: 33, languageId: 7 },
+    ]);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.143:
-  version "0.0.143"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.143.tgz#d7d43922ef645bc64acff9d43671beb715c205dc"
-  integrity sha512-KoyL7ivHBgdb22HOC/Qxlt4hwar+6ZTqOLVbyluI5NSJ2RCxPtXAnEiBPCv0n1g+yNNHpULWRFuTjxkYPYuX8A==
+need4deed-sdk@0.0.145:
+  version "0.0.145"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.145.tgz#79c2e4ffefbe2bed5520dd356e644f7b572862fe"
+  integrity sha512-xLfKK9W9AvpwAoq95c/ifBTBGGU9ndALyGLpiUAp7DNLnWjyQjLghhVVFTwyKygKSxY04p6h/hvY0G7amsJSKg==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## What
Backend support for https://github.com/need4deed-org/fe/issues/911 — lets a coordinator/admin create a bare NGO/agent profile with no linked Person/User, for an org they already have details for before it has self-registered.

## Changes
- `POST /agent` (new, coordinator/admin-only via `fastify.authenticate({ role: UserRole.COORDINATOR })`, same as `DELETE /agent/:id`) — creates an `Agent` with no `AgentPerson`/`User` at all.
- `write-agent-registration.ts`: extracted `createBareAgent` (Agent + Address + AgentService + AgentLanguage) shared by the existing `createAgentForPerson` (self-registration) and the new `createAgent` (personless). Same title/address conflict handling (409) as `/agent/register`, reusing `AgentAddressConflictError` / `classifyRegisterAgentConflict`.
- Visibility, per the issue's explicit requirement ("not surfaced anywhere an NGO user could see or claim it"):
  - `GET /agent` (list): agents with zero `AgentPerson` rows are filtered out of the response for non-coordinator/admin callers (`count` still reflects the unfiltered total — filtering the query itself for this one case felt like more risk than it's worth; noting this as a known minor imprecision).
  - `GET /agent/register/search` (self-registration picker): excludes them unconditionally for everyone, since that flow can auto-approve a JOIN on an email-domain match with zero coordinator review — an unclaimed agent must not be linkable through it.
- Out of scope (flagging rather than silently dropping): `GET /agent/:id` by direct/guessed ID, and the opportunity/volunteer sub-routes, aren't restricted — surfacing an unclaimed agent to someone who already has its exact numeric ID felt like a different, smaller risk than list/search discovery. Happy to extend if that's wanted.

## Depends on
need4deed-sdk#198 (`ApiAgentCreateResponse`) — opened, not yet merged (blocked on required review, left open per discussion, no other reviewer available in this session). This PR doesn't actually need that type to compile — the route infers its response shape from `createAgent`'s return value — so it typechecks fine against the currently-published SDK version. Flagging so the SDK PR isn't forgotten.

## Test plan
- [x] `yarn tsc --noEmit`, `eslint`, `prettier` clean.
- [x] `createAgent` unit tests (mocked, no DB) — Agent+Address+Service+Language persisted, no `AgentPerson`/phone write, address/title conflicts. All pass.
- [x] `POST /agent — coordinator-created agent (fe#911)` route test: rejects non-coordinator, creates with zero memberships, hidden from an AGENT-role `GET /agent` but visible to a COORDINATOR's, 409 on duplicate title.
- [ ] Could not run against a real DB locally (no Postgres in this sandbox) — same `ECONNREFUSED 127.0.0.1:5432` affecting every DB-backed suite in this repo currently, not specific to this change.