### PR TITLE
feat: filter opportunities by skill

### DIFF
--- a/src/server/utils/data/get-opportunity-where.ts
+++ b/src/server/utils/data/get-opportunity-where.ts
@@ -24,36 +24,36 @@ export function getOpportunityWhere(
           title: ILike(`%${filter.search}%`),
         }
       : {}),
-    ...(filter?.language
+    // language, district, activity and skill all constrain the same `deal` relation, so they must share a
+    // single `deal` key.
+    // if we use two spreads with the same key, the second replaces the first, and the earlier
+    // constraint is silently dropped.
+    ...(filter?.language ||
+    filter?.district ||
+    filter?.activity ||
+    filter?.skill
       ? {
           deal: {
-            dealLanguage: {
-              language: {
-                id: normalizeStringArrayInput(filter.language),
+            ...(filter?.language && {
+              dealLanguage: {
+                language: { id: normalizeStringArrayInput(filter.language) },
               },
-            },
-          },
-        }
-      : {}),
-    ...(filter?.district
-      ? {
-          deal: {
-            dealDistrict: {
-              district: {
-                id: normalizeStringArrayInput(filter.district),
+            }),
+            ...(filter?.district && {
+              dealDistrict: {
+                district: { id: normalizeStringArrayInput(filter.district) },
               },
-            },
-          },
-        }
-      : {}),
-    ...(filter?.activity
-      ? {
-          deal: {
-            dealActivity: {
-              activity: {
-                id: normalizeStringArrayInput(filter.activity),
+            }),
+            ...(filter?.activity && {
+              dealActivity: {
+                activity: { id: normalizeStringArrayInput(filter.activity) },
               },
-            },
+            }),
+            ...(filter?.skill && {
+              dealSkill: {
+                skill: { id: normalizeStringArrayInput(filter.skill) },
+              },
+            }),
           },
         }
       : {}),

--- a/src/server/utils/data/get-opportunity-where.ts
+++ b/src/server/utils/data/get-opportunity-where.ts
@@ -101,12 +101,46 @@ function getTypeWhere(
     : {};
 }
 
+// language, district, activity and skill all constrain the same `deal`
+// relation, so they must accumulate onto one shared `deal` key rather than
+// each writing their own top-level spread — two spreads with the same key
+// have the second replace the first, silently dropping the earlier
+// constraint. Mirrors get-volunteer-where.ts's identical dealFilter.
+function getDealWhere(
+  filter: QuerystringOpportunityFiltering["filter"],
+): Record<string, unknown> {
+  const dealFilter: Record<string, unknown> = {};
+  if (filter?.language) {
+    dealFilter.dealLanguage = {
+      language: { id: normalizeStringArrayInput(filter.language) },
+    };
+  }
+  if (filter?.district) {
+    dealFilter.dealDistrict = {
+      district: { id: normalizeStringArrayInput(filter.district) },
+    };
+  }
+  if (filter?.activity) {
+    dealFilter.dealActivity = {
+      activity: { id: normalizeStringArrayInput(filter.activity) },
+    };
+  }
+  if (filter?.skill) {
+    dealFilter.dealSkill = {
+      skill: { id: normalizeStringArrayInput(filter.skill) },
+    };
+  }
+  return dealFilter;
+}
+
 // SECURITY (#666): filters run on unmasked DB columns, so a non-privileged
 // caller can infer PII masked in the response by probing which rows match.
 export function getOpportunityWhere(
   filter: QuerystringOpportunityFiltering["filter"],
   appointment?: OpportunityAppointmentFilter,
 ): FindOptionsWhere<Opportunity> {
+  const dealFilter = getDealWhere(filter);
+
   return {
     ...getTypeWhere(filter, appointment?.excludeAccompanying),
     ...getAppointmentDateWhere(appointment),
@@ -120,38 +154,6 @@ export function getOpportunityWhere(
           title: ILike(`%${filter.search}%`),
         }
       : {}),
-    // language, district, activity and skill all constrain the same `deal` relation, so they must share a
-    // single `deal` key.
-    // if we use two spreads with the same key, the second replaces the first, and the earlier
-    // constraint is silently dropped.
-    ...(filter?.language ||
-    filter?.district ||
-    filter?.activity ||
-    filter?.skill
-      ? {
-          deal: {
-            ...(filter?.language && {
-              dealLanguage: {
-                language: { id: normalizeStringArrayInput(filter.language) },
-              },
-            }),
-            ...(filter?.district && {
-              dealDistrict: {
-                district: { id: normalizeStringArrayInput(filter.district) },
-              },
-            }),
-            ...(filter?.activity && {
-              dealActivity: {
-                activity: { id: normalizeStringArrayInput(filter.activity) },
-              },
-            }),
-            ...(filter?.skill && {
-              dealSkill: {
-                skill: { id: normalizeStringArrayInput(filter.skill) },
-              },
-            }),
-          },
-        }
-      : {}),
+    ...(Object.keys(dealFilter).length ? { deal: dealFilter } : {}),
   } as FindOptionsWhere<Opportunity>;
 }

--- a/src/test/server/utils/data/get-opportunity-where.test.ts
+++ b/src/test/server/utils/data/get-opportunity-where.test.ts
@@ -183,4 +183,31 @@ describe("getOpportunityWhere", () => {
       dealLanguage: { language: { id: "3" } },
     });
   });
+
+  // be#888's own repro: activity alone matched 1 row; activity plus a
+  // non-matching language still matched that same 1, because the language
+  // spread silently overwrote the activity spread on the shared `deal` key.
+  // Asserting both constraints survive together is the unit-level proof that
+  // no longer happens.
+  it("keeps both activity and language when combined, matching be#888's repro", () => {
+    const activityOnly = getOpportunityWhere({
+      type: "",
+      status: "",
+      activity: "3",
+    });
+    expect(activityOnly.deal).toEqual({
+      dealActivity: { activity: { id: "3" } },
+    });
+
+    const activityPlusLanguage = getOpportunityWhere({
+      type: "",
+      status: "",
+      activity: "3",
+      language: "9",
+    });
+    expect(activityPlusLanguage.deal).toEqual({
+      dealActivity: { activity: { id: "3" } },
+      dealLanguage: { language: { id: "9" } },
+    });
+  });
 });

--- a/src/test/server/utils/data/get-opportunity-where.test.ts
+++ b/src/test/server/utils/data/get-opportunity-where.test.ts
@@ -1,0 +1,52 @@
+import { In } from "typeorm";
+import { describe, expect, it } from "vitest";
+import { QuerystringOpportunityFiltering } from "../../../../server/types";
+import { getOpportunityWhere } from "../../../../server/utils";
+
+describe("getOpportunityWhere", () => {
+  it("returns an empty object when no filters are provided", () => {
+    expect(getOpportunityWhere(undefined)).toEqual({});
+  });
+
+  it("keeps every deal constraint when several are combined", () => {
+    const where = getOpportunityWhere({
+      type: "",
+      status: "",
+      language: "1",
+      district: "2",
+      activity: "3",
+      skill: "4",
+    });
+
+    expect(where.deal).toEqual({
+      dealLanguage: { language: { id: "1" } },
+      dealDistrict: { district: { id: "2" } },
+      dealActivity: { activity: { id: "3" } },
+      dealSkill: { skill: { id: "4" } },
+    });
+  });
+
+  // Multiple selections arrive as an array at runtime (?language=3&language=4)
+  // and become In([...]), which TypeORM ORs. The querystring type declares
+  // every filter as `string`, hence the cast, see the
+  // `// TODO: what about arrays?` above QuerystringOpportunityFiltering.
+  it("ORs multiple values within a single filter", () => {
+    const where = getOpportunityWhere({
+      type: "",
+      status: "",
+      language: ["3", "4"],
+    } as unknown as QuerystringOpportunityFiltering["filter"]);
+
+    expect(where.deal).toEqual({
+      dealLanguage: { language: { id: In(["3", "4"]) } },
+    });
+  });
+
+  it("applies only the language constraint when nothing else is selected", () => {
+    const where = getOpportunityWhere({ type: "", status: "", language: "3" });
+
+    expect(where.deal).toEqual({
+      dealLanguage: { language: { id: "3" } },
+    });
+  });
+});


### PR DESCRIPTION
## Description
 - `filter[skill]` was already accepted by the querystring schema and the handler type, but `getOpportunityWhere` never read it, so the param was silently ignored and the filter did nothing
- Adds the `dealSkill` branch so skill actually constrains the query. This is the BE half of fe#905
 - Adding it surfaced an existing bug: language, district, and activity each wrote the same `deal` key from separate spreads, so the object spread replaced the previous constraint and only the last one reached the query. Combining an activity with a non-matching language returned the activity count instead of 0. Measured locally:
 activity alone 1, activity plus non-matching language still 1
- Fixed by giving all four constraints one shared `deal` object as optional properties, so they accumulate instead of overwriting. Skill drops in as one more property  rather than a fourth competing spread
- Unblocks fe [936](https://github.com/need4deed-org/fe/pull/936),  which needs a skill branch added to this same function. It now slots in as one more property instead of a fourth competing spread.


## Related Issues
Closes #888 

## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

