### PR TITLE
feat: expose appointmentDate/appointmentTime on GET /opportunity list

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.142",
+    "need4deed-sdk": "0.0.143",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -1006,6 +1006,12 @@
         "agentId": {
           "type": ["integer", "null"]
         },
+        "appointmentDate": {
+          "type": ["string", "null"]
+        },
+        "appointmentTime": {
+          "type": ["string", "null"]
+        },
         "volunteerNames": {
           "type": "array",
           "items": {
@@ -1029,7 +1035,9 @@
         "location",
         "accompanyingDetails",
         "agentTitle",
-        "agentId"
+        "agentId",
+        "appointmentDate",
+        "appointmentTime"
       ]
     },
     "ApiOpportunityGet": {

--- a/src/services/dto/dto-accompanying.ts
+++ b/src/services/dto/dto-accompanying.ts
@@ -2,7 +2,7 @@ import { ApiOpportunityAccompanyingDetails, OptionById } from "need4deed-sdk";
 import District from "../../data/entity/location/district.entity";
 import DealLanguage from "../../data/entity/m2m/deal-language";
 import Accompanying from "../../data/entity/opportunity/accompanying.entity";
-import { formatDate, formatTime } from "../utils";
+import { formatAppointmentDateTime } from "../utils";
 
 export function dtoOpportunityAccompanying(
   accompanying: Accompanying,
@@ -10,15 +10,13 @@ export function dtoOpportunityAccompanying(
   dealLanguage: DealLanguage[] = [],
   district?: District | null,
 ): ApiOpportunityAccompanyingDetails {
+  const { appointmentDate, appointmentTime } =
+    formatAppointmentDateTime(onetimerDate);
+
   return accompanying
     ? {
         appointmentAddress: accompanying.address,
-        ...(onetimerDate
-          ? {
-              appointmentDate: formatDate(onetimerDate),
-              appointmentTime: formatTime(onetimerDate),
-            }
-          : {}),
+        ...(appointmentDate ? { appointmentDate, appointmentTime } : {}),
         refugeeNumber: accompanying.phone,
         refugeeName: accompanying.name,
         appointmentLanguage: accompanying.languageToTranslate,

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -86,6 +86,12 @@ export function dtoOpportunityGetList(
     ),
     agentTitle: opportunity.agent?.title ?? "",
     agentId: opportunity.agentId,
+    appointmentDate: opportunity.onetimer
+      ? formatDate(opportunity.onetimer.date)
+      : null,
+    appointmentTime: opportunity.onetimer
+      ? formatTime(opportunity.onetimer.date)
+      : null,
     // Names of the volunteers MATCHED to the opportunity (status opp-matched
     // only — not pending/active/past links). PII masking runs before this DTO,
     // so masked names pass through. Needs the

--- a/src/services/dto/dto-opportunity.ts
+++ b/src/services/dto/dto-opportunity.ts
@@ -10,7 +10,12 @@ import Comment from "../../data/entity/comment.entity";
 import District from "../../data/entity/location/district.entity";
 import Opportunity from "../../data/entity/opportunity/opportunity.entity";
 import logger from "../../logger";
-import { formatDate, formatTime, tryCatchFn } from "../utils";
+import {
+  formatAppointmentDateTime,
+  formatDate,
+  formatTime,
+  tryCatchFn,
+} from "../utils";
 import { dtoOpportunityAccompanying } from "./dto-accompanying";
 import { dtoOpportunityAgent } from "./dto-agent";
 import { commentSerializer } from "./dto-comment";
@@ -57,6 +62,10 @@ export function getOpportunityContact(
 export function dtoOpportunityGetList(
   opportunity: Opportunity,
 ): ApiOpportunityGetList {
+  const { appointmentDate, appointmentTime } = formatAppointmentDateTime(
+    opportunity.onetimer?.date,
+  );
+
   return {
     id: opportunity.id,
     title: opportunity.title,
@@ -86,12 +95,8 @@ export function dtoOpportunityGetList(
     ),
     agentTitle: opportunity.agent?.title ?? "",
     agentId: opportunity.agentId,
-    appointmentDate: opportunity.onetimer
-      ? formatDate(opportunity.onetimer.date)
-      : null,
-    appointmentTime: opportunity.onetimer
-      ? formatTime(opportunity.onetimer.date)
-      : null,
+    appointmentDate,
+    appointmentTime,
     // Names of the volunteers MATCHED to the opportunity (status opp-matched
     // only — not pending/active/past links). PII masking runs before this DTO,
     // so masked names pass through. Needs the
@@ -146,6 +151,10 @@ export function dtoOpportunityGet(
       ? opportunityComments.onetimer?.date
       : undefined;
 
+  const { appointmentDate, appointmentTime } = formatAppointmentDateTime(
+    opportunityComments.onetimer?.date,
+  );
+
   return {
     id: opportunityComments.id,
     title: opportunityComments.title,
@@ -160,6 +169,8 @@ export function dtoOpportunityGet(
     numberOfVolunteers: opportunityComments.numberVolunteers,
     agentTitle: opportunityComments.agent?.title ?? "",
     agentId: opportunityComments.agentId,
+    appointmentDate,
+    appointmentTime,
     languages: opportunityComments.deal.dealLanguage
       .filter(Boolean)
       .map((pl) => ({

--- a/src/services/utils/index.ts
+++ b/src/services/utils/index.ts
@@ -158,3 +158,13 @@ export const formatDate = (date: Date): string => {
 export const formatTime = (date: Date): string => {
   return `${String(date.getUTCHours()).padStart(2, "0")}:${String(date.getUTCMinutes()).padStart(2, "0")}`;
 };
+
+// Single source of truth for deriving an appointmentDate/appointmentTime pair
+// from a onetimer date — used both for ApiOpportunityGetList's top-level
+// fields and ApiOpportunityAccompanyingDetails', so the two can't drift.
+export const formatAppointmentDateTime = (
+  date?: Date,
+): { appointmentDate: string | null; appointmentTime: string | null } => ({
+  appointmentDate: date ? formatDate(date) : null,
+  appointmentTime: date ? formatTime(date) : null,
+});

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -25,6 +25,7 @@ import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
 import { DealType } from "../../../data/types";
 import { hashPassword } from "../../../data/utils";
 import { createServer } from "../../../server";
+import { formatDate, formatTime } from "../../../services/utils";
 
 const PASSWORD = "test_password";
 
@@ -1166,5 +1167,30 @@ describe("GET /opportunity sortBy=start-date", () => {
     expect(
       relativeOrder(data, [oppSoon.id, oppLater.id, oppNoDate.id]),
     ).toEqual([oppLater.id, oppSoon.id, oppNoDate.id]);
+  });
+
+  it("exposes appointmentDate/appointmentTime derived from onetimer, null when absent", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity?sortBy=start-date&sortOrder=old-new&limit=120",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const { data } = res.json();
+    const byId = (id: number) => data.find((o: { id: number }) => o.id === id);
+
+    expect(byId(oppSoon.id)).toMatchObject({
+      appointmentDate: formatDate(onetimerSoon.date),
+      appointmentTime: formatTime(onetimerSoon.date),
+    });
+    expect(byId(oppLater.id)).toMatchObject({
+      appointmentDate: formatDate(onetimerLater.date),
+      appointmentTime: formatTime(onetimerLater.date),
+    });
+    expect(byId(oppNoDate.id)).toMatchObject({
+      appointmentDate: null,
+      appointmentTime: null,
+    });
   });
 });

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -1013,6 +1013,117 @@ describe("PATCH /opportunity/:id onetimer resolution", () => {
   });
 });
 
+// be#890: dtoOpportunityGet backs this route and must set every field
+// ApiOpportunityGet's response schema now requires (inherited from the
+// widened ApiOpportunityGetList) — a missing required field makes
+// fast-json-stringify throw, not silently strip, so this exercises that path.
+describe("GET /opportunity/:id", () => {
+  let fastify: FastifyInstance;
+  let agent: Agent;
+  let deal: Deal;
+  let onetimer: Onetimer;
+  let opportunity: Opportunity;
+  let opportunityNoDate: Opportunity;
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (get-by-id) ${suffix}` }),
+    );
+    deal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    onetimer = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: new Date("2026-06-15T09:30:00Z") }),
+    );
+    opportunity = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity (get-by-id) ${suffix}`,
+        type: OpportunityType.EVENTS,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: deal.id,
+        onetimerId: onetimer.id,
+      }),
+    );
+    opportunityNoDate = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Opportunity No Date (get-by-id) ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: deal.id,
+      }),
+    );
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "GetByIdCoordinator" }),
+    );
+    const pwHash = await hashPassword(PASSWORD);
+    const coordinatorUser = await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-get-by-id-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const login = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: coordinatorUser.email, password: PASSWORD },
+    });
+    coordinatorCookie = getCookie(login.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.opportunityRepository.delete({ id: opportunity.id });
+    await fastify.db.opportunityRepository.delete({ id: opportunityNoDate.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimer.id });
+    await fastify.db.dealRepository.delete({ id: deal.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.close();
+  });
+
+  it("returns appointmentDate/appointmentTime derived from onetimer", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/opportunity/${opportunity.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+    expect(data.appointmentDate).toBe("2026-06-15");
+    expect(data.appointmentTime).toBe("09:30");
+  });
+
+  it("returns null appointmentDate/appointmentTime when there is no onetimer", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/opportunity/${opportunityNoDate.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { data } = res.json();
+    expect(data.appointmentDate).toBeNull();
+    expect(data.appointmentTime).toBeNull();
+  });
+});
+
 // be#746: server-side sort by start date, replacing the old client-side
 // per-page sort — this is what actually fixes opportunities falling through
 // the cracks across pages. Verifies both the ordering and that opportunities

--- a/src/test/services/dto/dto-opportunity.test.ts
+++ b/src/test/services/dto/dto-opportunity.test.ts
@@ -197,6 +197,25 @@ describe("dtoOpportunityGetList", () => {
       [],
     );
   });
+
+  it("derives appointmentDate/appointmentTime from the opportunity's onetimer", () => {
+    const opportunity = {
+      ...baseOpportunity,
+      onetimer: { id: 10, date: new Date("2026-06-15T09:30:00Z") },
+    };
+
+    const result = dtoOpportunityGetList(opportunity as any);
+    expect(result.appointmentDate).toBe("2026-06-15");
+    expect(result.appointmentTime).toBe("09:30");
+  });
+
+  it("returns null appointmentDate/appointmentTime when there is no onetimer", () => {
+    const opportunity = { ...baseOpportunity, onetimer: undefined };
+
+    const result = dtoOpportunityGetList(opportunity as any);
+    expect(result.appointmentDate).toBeNull();
+    expect(result.appointmentTime).toBeNull();
+  });
 });
 
 describe("dtoOpportunityGet", () => {

--- a/src/test/services/dto/dto-opportunity.test.ts
+++ b/src/test/services/dto/dto-opportunity.test.ts
@@ -293,4 +293,26 @@ describe("dtoOpportunityGet", () => {
 
     expect(result.event).toBeUndefined();
   });
+
+  it("populates appointmentDate/appointmentTime from onetimer regardless of type", () => {
+    const opportunity = {
+      ...baseDetail,
+      type: "accompanying",
+      onetimer: { id: 13, date: eventDate },
+    };
+
+    const result = dtoOpportunityGet(opportunity as any);
+
+    expect(result.appointmentDate).toBe("2026-06-15");
+    expect(result.appointmentTime).toBe("09:30");
+  });
+
+  it("returns null appointmentDate/appointmentTime when there is no onetimer", () => {
+    const opportunity = { ...baseDetail, onetimer: undefined };
+
+    const result = dtoOpportunityGet(opportunity as any);
+
+    expect(result.appointmentDate).toBeNull();
+    expect(result.appointmentTime).toBeNull();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.142:
-  version "0.0.142"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.142.tgz#f5e2a24d63149f0d8a98c8aee1319eb59016c9b0"
-  integrity sha512-BiSwsXu5mwc/lB/+0hZaYZADEP5hbSnuzxRQCAdi9vE4CBh/DHtEMq2tXwZu8mUEqMQvd65q8O/VUnA5yO+Q1g==
+need4deed-sdk@0.0.143:
+  version "0.0.143"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.143.tgz#d7d43922ef645bc64acff9d43671beb715c205dc"
+  integrity sha512-KoyL7ivHBgdb22HOC/Qxlt4hwar+6ZTqOLVbyluI5NSJ2RCxPtXAnEiBPCv0n1g+yNNHpULWRFuTjxkYPYuX8A==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
- Bumps `need4deed-sdk` to `0.0.143` (sdk#199, published).
- `dtoOpportunityGetList` now derives `appointmentDate`/`appointmentTime` from `Opportunity.onetimer.date` via the existing `formatDate`/`formatTime` helpers (same pattern already used for `ApiOpportunityGet.event`); `null` when there's no `onetimer`. No query change needed — the list route already loads the `onetimer` relation.
- Registers both fields on the `ApiOpportunityGetList` entry in `src/server/schema/sdk-types.json` — `fast-json-stringify` silently strips fields missing from that hand-maintained schema mirror, the same class of bug fixed in #575.

Closes #890. Part of #681 (need4deed-org/fe#646).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (pre-existing errors/warnings unrelated to this change)
- [x] `yarn test:run` — 79 files / 666 tests pass
- [x] New unit tests in `dto-opportunity.test.ts` (with/without `onetimer`)
- [x] New live-server test in `opportunity.routes.test.ts` asserting the fields round-trip through `fastify.inject` (catches schema-stripping, not just DTO output)