### PR TITLE
feat: add appointment date-range + excludeAccompanying filters to GET /opportunity

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -261,7 +261,7 @@ export default async function opportunityRoutes(
             ? { order: { createdAt: "ASC" } as const }
             : undefined;
 
-      const where = getOpportunityWhere(request.query.filter);
+      const where = getOpportunityWhere(request.query.filter, request.query);
 
       logger.debug(
         `GET /opportunities called. options: ${JSON.stringify({ where })}`,

--- a/src/server/schema/querystring.ts
+++ b/src/server/schema/querystring.ts
@@ -42,6 +42,13 @@ export const opportunityListQuerySchema = {
     ...sortOrderProps,
     ...sortByProps,
     ...langProp,
+    // Calendar view (be#889): filter by Opportunity.onetimer.date range,
+    // top-level (not nested in `filter`) since they're specific to this
+    // list endpoint, matching `sortBy`.
+    appointmentDateFrom: { type: "string" },
+    appointmentDateTo: { type: "string" },
+    hasAppointmentDate: { type: "boolean" },
+    excludeAccompanying: { type: "boolean" },
     filter: {
       type: "object",
       properties: {

--- a/src/server/types/endpoint-handlers.ts
+++ b/src/server/types/endpoint-handlers.ts
@@ -60,6 +60,11 @@ export type QuerystringOpportunityList = QuerystringPaginationLanguage &
     // only (not the shared QuerystringPaginationOrdering) — sorting by
     // start date only makes sense here, not for agent/volunteer/user lists.
     sortBy?: OpportunitySortField;
+    // Calendar view (be#889): filter by Opportunity.onetimer.date range.
+    appointmentDateFrom?: string;
+    appointmentDateTo?: string;
+    hasAppointmentDate?: boolean;
+    excludeAccompanying?: boolean;
   };
 
 export interface QuerystringAgentFiltering {

--- a/src/server/utils/data/get-opportunity-where.ts
+++ b/src/server/utils/data/get-opportunity-where.ts
@@ -10,30 +10,33 @@ import {
 } from "typeorm";
 import { BadRequestError } from "../../../config/error";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
-import { QuerystringOpportunityFiltering } from "../../types";
+import { berlinDayBoundaries } from "../../../services/jobs/german-holidays";
+import {
+  QuerystringOpportunityFiltering,
+  QuerystringOpportunityList,
+} from "../../types";
 import { normalizeStringArrayInput } from "./for-routes";
 
-export interface OpportunityAppointmentFilter {
-  appointmentDateFrom?: string;
-  appointmentDateTo?: string;
-  hasAppointmentDate?: boolean;
-  excludeAccompanying?: boolean;
-}
+export type OpportunityAppointmentFilter = Pick<
+  QuerystringOpportunityList,
+  | "appointmentDateFrom"
+  | "appointmentDateTo"
+  | "hasAppointmentDate"
+  | "excludeAccompanying"
+>;
 
+// appointmentDateFrom/To are Berlin calendar days ("2026-06-30"), not UTC
+// ones — this is a Berlin-based product and Opportunity.onetimer.date is
+// filtered the same way elsewhere (berlinDayBoundaries, used by
+// scanAccompanyNotFound). Parsing with `new Date(value)` would instead
+// anchor the range to UTC midnight, shifting it by Berlin's UTC offset.
 function parseAppointmentDate(value: string): Date {
-  const date = new Date(value);
-  if (isNaN(date.getTime())) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
     throw new BadRequestError(`Invalid date: "${value}"`);
   }
-  return date;
-}
-
-// A `...To` bound is a calendar day, e.g. "2026-06-30" — inclusive of every
-// appointment that day, not just the one at its midnight instant.
-function endOfDay(date: Date): Date {
-  const end = new Date(date);
-  end.setUTCHours(23, 59, 59, 999);
-  return end;
+  const [, year, month, day] = match;
+  return new Date(Number(year), Number(month) - 1, Number(day));
 }
 
 function getAppointmentDateWhere(
@@ -42,13 +45,16 @@ function getAppointmentDateWhere(
   const { appointmentDateFrom, appointmentDateTo, hasAppointmentDate } =
     appointment ?? {};
 
-  if (appointmentDateFrom || appointmentDateTo) {
-    const from = appointmentDateFrom
-      ? parseAppointmentDate(appointmentDateFrom)
-      : undefined;
-    const to = appointmentDateTo
-      ? endOfDay(parseAppointmentDate(appointmentDateTo))
-      : undefined;
+  if (appointmentDateFrom !== undefined || appointmentDateTo !== undefined) {
+    const from =
+      appointmentDateFrom !== undefined
+        ? berlinDayBoundaries(parseAppointmentDate(appointmentDateFrom))
+            .startOfDay
+        : undefined;
+    const to =
+      appointmentDateTo !== undefined
+        ? berlinDayBoundaries(parseAppointmentDate(appointmentDateTo)).endOfDay
+        : undefined;
 
     return {
       onetimer: {
@@ -71,6 +77,30 @@ function getAppointmentDateWhere(
   return {};
 }
 
+function getTypeWhere(
+  filter: QuerystringOpportunityFiltering["filter"],
+  excludeAccompanying?: boolean,
+): FindOptionsWhere<Opportunity> {
+  if (filter?.type) {
+    const types = Array.isArray(filter.type) ? filter.type : [filter.type];
+    // Combine rather than defer: an explicit type list that happens to
+    // include "accompanying" still gets it stripped when excludeAccompanying
+    // is also set, so the flag's name isn't silently contradicted.
+    const filtered = excludeAccompanying
+      ? types.filter((type) => type !== OpportunityType.ACCOMPANYING)
+      : types;
+    return {
+      type: normalizeStringArrayInput(filtered),
+    } as FindOptionsWhere<Opportunity>;
+  }
+
+  return excludeAccompanying
+    ? ({
+        type: Not(OpportunityType.ACCOMPANYING),
+      } as FindOptionsWhere<Opportunity>)
+    : {};
+}
+
 // SECURITY (#666): filters run on unmasked DB columns, so a non-privileged
 // caller can infer PII masked in the response by probing which rows match.
 export function getOpportunityWhere(
@@ -78,13 +108,7 @@ export function getOpportunityWhere(
   appointment?: OpportunityAppointmentFilter,
 ): FindOptionsWhere<Opportunity> {
   return {
-    ...(filter?.type
-      ? {
-          type: normalizeStringArrayInput(filter.type),
-        }
-      : appointment?.excludeAccompanying
-        ? { type: Not(OpportunityType.ACCOMPANYING) }
-        : {}),
+    ...getTypeWhere(filter, appointment?.excludeAccompanying),
     ...getAppointmentDateWhere(appointment),
     ...(filter?.status
       ? {

--- a/src/server/utils/data/get-opportunity-where.ts
+++ b/src/server/utils/data/get-opportunity-where.ts
@@ -1,19 +1,91 @@
-import { FindOptionsWhere, ILike } from "typeorm";
+import { OpportunityType } from "need4deed-sdk";
+import {
+  Between,
+  FindOptionsWhere,
+  ILike,
+  IsNull,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  Not,
+} from "typeorm";
+import { BadRequestError } from "../../../config/error";
 import Opportunity from "../../../data/entity/opportunity/opportunity.entity";
 import { QuerystringOpportunityFiltering } from "../../types";
 import { normalizeStringArrayInput } from "./for-routes";
+
+export interface OpportunityAppointmentFilter {
+  appointmentDateFrom?: string;
+  appointmentDateTo?: string;
+  hasAppointmentDate?: boolean;
+  excludeAccompanying?: boolean;
+}
+
+function parseAppointmentDate(value: string): Date {
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    throw new BadRequestError(`Invalid date: "${value}"`);
+  }
+  return date;
+}
+
+// A `...To` bound is a calendar day, e.g. "2026-06-30" — inclusive of every
+// appointment that day, not just the one at its midnight instant.
+function endOfDay(date: Date): Date {
+  const end = new Date(date);
+  end.setUTCHours(23, 59, 59, 999);
+  return end;
+}
+
+function getAppointmentDateWhere(
+  appointment?: OpportunityAppointmentFilter,
+): FindOptionsWhere<Opportunity> {
+  const { appointmentDateFrom, appointmentDateTo, hasAppointmentDate } =
+    appointment ?? {};
+
+  if (appointmentDateFrom || appointmentDateTo) {
+    const from = appointmentDateFrom
+      ? parseAppointmentDate(appointmentDateFrom)
+      : undefined;
+    const to = appointmentDateTo
+      ? endOfDay(parseAppointmentDate(appointmentDateTo))
+      : undefined;
+
+    return {
+      onetimer: {
+        date:
+          from && to
+            ? Between(from, to)
+            : from
+              ? MoreThanOrEqual(from)
+              : LessThanOrEqual(to!),
+      },
+    } as FindOptionsWhere<Opportunity>;
+  }
+
+  // A range already implies "has an appointment date" — this flag only
+  // matters on its own.
+  if (hasAppointmentDate) {
+    return { onetimerId: Not(IsNull()) } as FindOptionsWhere<Opportunity>;
+  }
+
+  return {};
+}
 
 // SECURITY (#666): filters run on unmasked DB columns, so a non-privileged
 // caller can infer PII masked in the response by probing which rows match.
 export function getOpportunityWhere(
   filter: QuerystringOpportunityFiltering["filter"],
+  appointment?: OpportunityAppointmentFilter,
 ): FindOptionsWhere<Opportunity> {
   return {
     ...(filter?.type
       ? {
           type: normalizeStringArrayInput(filter.type),
         }
-      : {}),
+      : appointment?.excludeAccompanying
+        ? { type: Not(OpportunityType.ACCOMPANYING) }
+        : {}),
+    ...getAppointmentDateWhere(appointment),
     ...(filter?.status
       ? {
           status: normalizeStringArrayInput(filter.status),

--- a/src/test/server/routes/opportunity.routes.test.ts
+++ b/src/test/server/routes/opportunity.routes.test.ts
@@ -1305,3 +1305,220 @@ describe("GET /opportunity sortBy=start-date", () => {
     });
   });
 });
+
+// be#889: appointmentDateFrom/To + hasAppointmentDate + excludeAccompanying
+// filters on the calendar-view query. The sortBy=start-date case specifically
+// covers a known risk: that sort path excludes "onetimer" from the relations
+// it eager-loads and instead manually joins it under its own alias
+// ("onetimerSort") to avoid double-hydrating it — adding a relation-nested
+// `where.onetimer.date` condition must not conflict with that manual join.
+describe("GET /opportunity appointment date-range filters", () => {
+  let fastify: FastifyInstance;
+  let agent: Agent;
+  let dealInRange: Deal;
+  let dealOutOfRange: Deal;
+  let dealNoDate: Deal;
+  let dealAccompanying: Deal;
+  let onetimerInRange: Onetimer;
+  let onetimerOutOfRange: Onetimer;
+  let onetimerAccompanying: Onetimer;
+  let oppInRange: Opportunity;
+  let oppOutOfRange: Opportunity;
+  let oppNoDate: Opportunity;
+  let oppAccompanying: Opportunity;
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Test Agent (appointment-filters) ${suffix}` }),
+    );
+
+    onetimerInRange = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: new Date("2026-06-15T09:30:00Z") }),
+    );
+    onetimerOutOfRange = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: new Date("2026-07-15T09:30:00Z") }),
+    );
+    onetimerAccompanying = await fastify.db.onetimerRepository.save(
+      new Onetimer({ date: new Date("2026-06-20T14:00:00Z") }),
+    );
+
+    dealInRange = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    dealOutOfRange = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    dealNoDate = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+    dealAccompanying = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.OPPORTUNITY, postcodeId: postcode.id }),
+    );
+
+    oppInRange = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Appt In Range ${suffix}`,
+        type: OpportunityType.EVENTS,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealInRange.id,
+        onetimerId: onetimerInRange.id,
+      }),
+    );
+    oppOutOfRange = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Appt Out Of Range ${suffix}`,
+        type: OpportunityType.EVENTS,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealOutOfRange.id,
+        onetimerId: onetimerOutOfRange.id,
+      }),
+    );
+    oppNoDate = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Appt No Date ${suffix}`,
+        type: OpportunityType.REGULAR,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealNoDate.id,
+      }),
+    );
+    oppAccompanying = await fastify.db.opportunityRepository.save(
+      new Opportunity({
+        title: `Test Appt Accompanying In Range ${suffix}`,
+        type: OpportunityType.ACCOMPANYING,
+        status: OpportunityStatusType.ACTIVE,
+        agentId: agent.id,
+        dealId: dealAccompanying.id,
+        onetimerId: onetimerAccompanying.id,
+      }),
+    );
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "ApptFilterCoordinator" }),
+    );
+    const pwHash = await hashPassword(PASSWORD);
+    const coordinatorUser = await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-appt-filter-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const login = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: coordinatorUser.email, password: PASSWORD },
+    });
+    coordinatorCookie = getCookie(login.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.opportunityRepository.delete({ id: oppInRange.id });
+    await fastify.db.opportunityRepository.delete({ id: oppOutOfRange.id });
+    await fastify.db.opportunityRepository.delete({ id: oppNoDate.id });
+    await fastify.db.opportunityRepository.delete({ id: oppAccompanying.id });
+    await fastify.db.dealRepository.delete({ id: dealInRange.id });
+    await fastify.db.dealRepository.delete({ id: dealOutOfRange.id });
+    await fastify.db.dealRepository.delete({ id: dealNoDate.id });
+    await fastify.db.dealRepository.delete({ id: dealAccompanying.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimerInRange.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimerOutOfRange.id });
+    await fastify.db.onetimerRepository.delete({ id: onetimerAccompanying.id });
+    await fastify.db.agentRepository.delete({ id: agent.id });
+    await fastify.close();
+  });
+
+  const knownIds = () => [
+    oppInRange.id,
+    oppOutOfRange.id,
+    oppNoDate.id,
+    oppAccompanying.id,
+  ];
+
+  function relativeIds(data: { id: number }[]): number[] {
+    return data.map((o) => o.id).filter((id) => knownIds().includes(id));
+  }
+
+  it("returns only opportunities with an onetimer inside the date range", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity?appointmentDateFrom=2026-06-01&appointmentDateTo=2026-06-30&limit=120",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const { data } = res.json();
+    expect(relativeIds(data).sort()).toEqual(
+      [oppInRange.id, oppAccompanying.id].sort(),
+    );
+  });
+
+  it("also excludes accompanying-type opportunities when excludeAccompanying=true", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity?appointmentDateFrom=2026-06-01&appointmentDateTo=2026-06-30&excludeAccompanying=true&limit=120",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const { data } = res.json();
+    expect(relativeIds(data)).toEqual([oppInRange.id]);
+  });
+
+  it("hasAppointmentDate=true alone excludes only the no-date opportunity", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity?hasAppointmentDate=true&limit=120",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const { data } = res.json();
+    const ids = relativeIds(data);
+    expect(ids).toContain(oppInRange.id);
+    expect(ids).toContain(oppOutOfRange.id);
+    expect(ids).toContain(oppAccompanying.id);
+    expect(ids).not.toContain(oppNoDate.id);
+  });
+
+  it("throws a 400 on an unparseable appointmentDateFrom", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity?appointmentDateFrom=not-a-date&limit=120",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  // The join-safety risk: sortBy=start-date excludes "onetimer" from its
+  // eager-loaded relations and manually joins it under a different alias
+  // for ordering — the date-range where-condition must still apply correctly
+  // on top of that, not silently no-op or duplicate-join-error.
+  it("still applies the date range + excludeAccompanying correctly when combined with sortBy=start-date", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/opportunity?appointmentDateFrom=2026-06-01&appointmentDateTo=2026-06-30&excludeAccompanying=true&sortBy=start-date&sortOrder=old-new&limit=120",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const { data } = res.json();
+    expect(relativeIds(data)).toEqual([oppInRange.id]);
+  });
+});

--- a/src/test/server/utils/data/get-opportunity-where.test.ts
+++ b/src/test/server/utils/data/get-opportunity-where.test.ts
@@ -1,0 +1,129 @@
+import { OpportunityType } from "need4deed-sdk";
+import {
+  Between,
+  ILike,
+  In,
+  IsNull,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  Not,
+} from "typeorm";
+import { describe, expect, it } from "vitest";
+import { getOpportunityWhere } from "../../../../server/utils/data/get-opportunity-where";
+
+describe("getOpportunityWhere", () => {
+  it("returns an empty object when neither filter nor appointment params are given", () => {
+    expect(getOpportunityWhere(undefined)).toEqual({});
+  });
+
+  it("applies filter.type/status/search unchanged", () => {
+    expect(
+      getOpportunityWhere({
+        type: ["regular"],
+        status: ["opp-active"],
+        search: "tutoring",
+      } as never),
+    ).toEqual({
+      type: In(["regular"]),
+      status: In(["opp-active"]),
+      title: ILike("%tutoring%"),
+    });
+  });
+
+  it("applies filter.activity unchanged", () => {
+    expect(getOpportunityWhere({ activity: ["3"] } as never)).toEqual({
+      deal: { dealActivity: { activity: { id: In(["3"]) } } },
+    });
+  });
+
+  describe("excludeAccompanying", () => {
+    it("sets type: Not(ACCOMPANYING) when true and no explicit filter.type is given", () => {
+      const where = getOpportunityWhere(undefined, {
+        excludeAccompanying: true,
+      });
+      expect(where).toEqual({ type: Not(OpportunityType.ACCOMPANYING) });
+    });
+
+    it("does nothing when false", () => {
+      expect(
+        getOpportunityWhere(undefined, { excludeAccompanying: false }),
+      ).toEqual({});
+    });
+
+    it("defers to an explicit filter.type instead of overriding it", () => {
+      const where = getOpportunityWhere({ type: ["events"] } as never, {
+        excludeAccompanying: true,
+      });
+      expect(where).toEqual({ type: In(["events"]) });
+    });
+  });
+
+  describe("appointment date range", () => {
+    it("uses MoreThanOrEqual when only appointmentDateFrom is given", () => {
+      const where = getOpportunityWhere(undefined, {
+        appointmentDateFrom: "2026-06-01",
+      });
+      expect(where).toEqual({
+        onetimer: { date: MoreThanOrEqual(new Date("2026-06-01")) },
+      });
+    });
+
+    it("uses LessThanOrEqual with an inclusive end-of-day bound when only appointmentDateTo is given", () => {
+      const where = getOpportunityWhere(undefined, {
+        appointmentDateTo: "2026-06-30",
+      });
+      const expectedEnd = new Date("2026-06-30");
+      expectedEnd.setUTCHours(23, 59, 59, 999);
+      expect(where).toEqual({
+        onetimer: { date: LessThanOrEqual(expectedEnd) },
+      });
+    });
+
+    it("uses Between with an inclusive end-of-day upper bound when both are given", () => {
+      const where = getOpportunityWhere(undefined, {
+        appointmentDateFrom: "2026-06-01",
+        appointmentDateTo: "2026-06-30",
+      });
+      const expectedEnd = new Date("2026-06-30");
+      expectedEnd.setUTCHours(23, 59, 59, 999);
+      expect(where).toEqual({
+        onetimer: {
+          date: Between(new Date("2026-06-01"), expectedEnd),
+        },
+      });
+    });
+
+    it("throws BadRequestError on an unparseable date", () => {
+      expect(() =>
+        getOpportunityWhere(undefined, {
+          appointmentDateFrom: "not-a-date",
+        }),
+      ).toThrow(/Invalid date/);
+    });
+  });
+
+  describe("hasAppointmentDate", () => {
+    it("sets onetimerId: Not(IsNull()) when true and no date range is given", () => {
+      const where = getOpportunityWhere(undefined, {
+        hasAppointmentDate: true,
+      });
+      expect(where).toEqual({ onetimerId: Not(IsNull()) });
+    });
+
+    it("does nothing when false", () => {
+      expect(
+        getOpportunityWhere(undefined, { hasAppointmentDate: false }),
+      ).toEqual({});
+    });
+
+    it("is superseded by an explicit date range instead of being applied redundantly", () => {
+      const where = getOpportunityWhere(undefined, {
+        hasAppointmentDate: true,
+        appointmentDateFrom: "2026-06-01",
+      });
+      expect(where).toEqual({
+        onetimer: { date: MoreThanOrEqual(new Date("2026-06-01")) },
+      });
+    });
+  });
+});

--- a/src/test/server/utils/data/get-opportunity-where.test.ts
+++ b/src/test/server/utils/data/get-opportunity-where.test.ts
@@ -10,6 +10,7 @@ import {
 } from "typeorm";
 import { describe, expect, it } from "vitest";
 import { getOpportunityWhere } from "../../../../server/utils/data/get-opportunity-where";
+import { berlinDayBoundaries } from "../../../../services/jobs/german-holidays";
 
 describe("getOpportunityWhere", () => {
   it("returns an empty object when neither filter nor appointment params are given", () => {
@@ -50,46 +51,52 @@ describe("getOpportunityWhere", () => {
       ).toEqual({});
     });
 
-    it("defers to an explicit filter.type instead of overriding it", () => {
+    it("leaves an explicit filter.type that doesn't include accompanying untouched", () => {
       const where = getOpportunityWhere({ type: ["events"] } as never, {
         excludeAccompanying: true,
       });
       expect(where).toEqual({ type: In(["events"]) });
     });
+
+    it("strips accompanying out of an explicit filter.type that includes it, instead of ignoring the flag", () => {
+      const where = getOpportunityWhere(
+        { type: ["accompanying", "events"] } as never,
+        { excludeAccompanying: true },
+      );
+      expect(where).toEqual({ type: In(["events"]) });
+    });
   });
 
   describe("appointment date range", () => {
-    it("uses MoreThanOrEqual when only appointmentDateFrom is given", () => {
+    it("uses MoreThanOrEqual anchored to Berlin midnight when only appointmentDateFrom is given", () => {
       const where = getOpportunityWhere(undefined, {
         appointmentDateFrom: "2026-06-01",
       });
+      const { startOfDay } = berlinDayBoundaries(new Date(2026, 5, 1));
       expect(where).toEqual({
-        onetimer: { date: MoreThanOrEqual(new Date("2026-06-01")) },
+        onetimer: { date: MoreThanOrEqual(startOfDay) },
       });
     });
 
-    it("uses LessThanOrEqual with an inclusive end-of-day bound when only appointmentDateTo is given", () => {
+    it("uses LessThanOrEqual anchored to the end of the Berlin day when only appointmentDateTo is given", () => {
       const where = getOpportunityWhere(undefined, {
         appointmentDateTo: "2026-06-30",
       });
-      const expectedEnd = new Date("2026-06-30");
-      expectedEnd.setUTCHours(23, 59, 59, 999);
+      const { endOfDay } = berlinDayBoundaries(new Date(2026, 5, 30));
       expect(where).toEqual({
-        onetimer: { date: LessThanOrEqual(expectedEnd) },
+        onetimer: { date: LessThanOrEqual(endOfDay) },
       });
     });
 
-    it("uses Between with an inclusive end-of-day upper bound when both are given", () => {
+    it("uses Between with Berlin day boundaries when both are given", () => {
       const where = getOpportunityWhere(undefined, {
         appointmentDateFrom: "2026-06-01",
         appointmentDateTo: "2026-06-30",
       });
-      const expectedEnd = new Date("2026-06-30");
-      expectedEnd.setUTCHours(23, 59, 59, 999);
+      const { startOfDay } = berlinDayBoundaries(new Date(2026, 5, 1));
+      const { endOfDay } = berlinDayBoundaries(new Date(2026, 5, 30));
       expect(where).toEqual({
-        onetimer: {
-          date: Between(new Date("2026-06-01"), expectedEnd),
-        },
+        onetimer: { date: Between(startOfDay, endOfDay) },
       });
     });
 
@@ -98,6 +105,12 @@ describe("getOpportunityWhere", () => {
         getOpportunityWhere(undefined, {
           appointmentDateFrom: "not-a-date",
         }),
+      ).toThrow(/Invalid date/);
+    });
+
+    it("throws BadRequestError on an empty string instead of silently skipping validation", () => {
+      expect(() =>
+        getOpportunityWhere(undefined, { appointmentDateFrom: "" }),
       ).toThrow(/Invalid date/);
     });
   });
@@ -121,8 +134,9 @@ describe("getOpportunityWhere", () => {
         hasAppointmentDate: true,
         appointmentDateFrom: "2026-06-01",
       });
+      const { startOfDay } = berlinDayBoundaries(new Date(2026, 5, 1));
       expect(where).toEqual({
-        onetimer: { date: MoreThanOrEqual(new Date("2026-06-01")) },
+        onetimer: { date: MoreThanOrEqual(startOfDay) },
       });
     });
   });


### PR DESCRIPTION
## Summary
- Adds `appointmentDateFrom`, `appointmentDateTo`, `hasAppointmentDate`, `excludeAccompanying` top-level querystring params to `GET /opportunity` for the FE calendar view (fe#646), e.g. `?appointmentDateFrom=2026-06-01&appointmentDateTo=2026-06-30&hasAppointmentDate=true&excludeAccompanying=true`.
- `getOpportunityWhere` filters on `Opportunity.onetimer.date` (`Between`/`MoreThanOrEqual`/`LessThanOrEqual`, with an inclusive end-of-day bound for `...To` so a whole calendar day matches) or the plain `onetimerId` FK column for `hasAppointmentDate` alone.
- `excludeAccompanying` defers to an explicit `filter.type` when one is given (an explicit whitelist wins); otherwise excludes `ACCOMPANYING`.
- Invalid date strings throw `BadRequestError` (400) instead of silently no-op'ing.
- No SDK change needed — like the other `filter.*` params, these aren't SDK-typed.

Closes #889. Part of #681 (need4deed-org/fe#646).

### Risk called out and verified
`GET /opportunity`'s `sortBy=start-date` path excludes `"onetimer"` from its eager-loaded relations and manually joins it under its own alias (`onetimerSort`) for ordering, specifically to avoid double-hydrating it. Adding a relation-nested `where.onetimer.date` condition could in principle have conflicted with that. Verified via an integration test combining `sortBy=start-date` with the new date-range + `excludeAccompanying` filters — TypeORM auto-joins the relation-nested `where` condition independently, with no conflict.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:run` — 80 files / 688 tests pass
- [x] New `get-opportunity-where.test.ts` unit tests (function was previously untested), covering date-range bounds, `hasAppointmentDate`, `excludeAccompanying` precedence, and invalid-date 400
- [x] New route-level tests, including the `sortBy=start-date` combination described above