### PR TITLE
Make build-bootstrap callable + publish be's develop digest

### DIFF
--- a/.github/workflows/build-bootstrap.yaml
+++ b/.github/workflows/build-bootstrap.yaml
@@ -6,6 +6,11 @@ on:
     paths:
       - data-bootstrap/**
   workflow_dispatch:
+  workflow_call:
+    outputs:
+      digest:
+        description: Digest of the pushed bootstrap image
+        value: ${{ jobs.build.outputs.digest }}
 
 jobs:
   build:
@@ -13,6 +18,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
 
@@ -24,6 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push bootstrap image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/deploy-aits.yaml
+++ b/.github/workflows/deploy-aits.yaml
@@ -22,11 +22,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ghcr.io/need4deed-org/be:develop
+
+      - name: Publish develop digest for prod release pipeline
+        # infra's release-prod.yaml reads this as ${{ vars.BE_DEVELOP_DIGEST }}
+        # instead of scraping GHCR — be's own image isn't rebuilt for prod,
+        # it just promotes whatever's currently on :develop.
+        run: gh variable set BE_DEVELOP_DIGEST --org need4deed-org --repos infra --body "${{ steps.build.outputs.digest }}"
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
 
       - name: Roll out new image on AITS
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-aits.yaml
+++ b/.github/workflows/deploy-aits.yaml
@@ -33,6 +33,10 @@ jobs:
         # infra's release-prod.yaml reads this as ${{ vars.BE_DEVELOP_DIGEST }}
         # instead of scraping GHCR — be's own image isn't rebuilt for prod,
         # it just promotes whatever's currently on :develop.
+        # continue-on-error: the dev rollout below must still run even before
+        # the PAT secret this needs exists, or once it's created but expires -
+        # this step failing must never take down deploy-aits's actual job.
+        continue-on-error: true
         run: gh variable set BE_DEVELOP_DIGEST --org need4deed-org --repos infra --body "${{ steps.build.outputs.digest }}"
         env:
           GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary
- `build-bootstrap.yaml` gains `workflow_call` (existing `push`/`workflow_dispatch` triggers untouched) plus a digest output, mirroring `n4d-infra/.github/workflows/build-push-docker-image.yml`'s existing `workflow_call`/`outputs` pattern.
- `deploy-aits.yaml` now publishes the just-pushed `be:develop` digest as an org-level `BE_DEVELOP_DIGEST` variable (visible to `infra`), so the prod-release pipeline can promote whatever's currently on `develop` without scraping GHCR — which turned out to be unreliable even for an org member's PAT during today's incident (403 on package read despite a successful `docker login`).

## Requires (before this is fully live)
A new `PAT` secret in this repo's settings: a fine-grained PAT with **only** "Organization variables: read and write" — narrowest scope that lets the new step in `deploy-aits.yaml` call `gh variable set`. Until that secret exists, that one step will fail (the rest of `deploy-aits.yaml` is unaffected).

## Context
Part of automating the manual prod-release process (build fe + bootstrap → resolve be's digest → PR the digest bump into `infra/overlays/prod/kustomization.yaml`), after today's prod outage caused by stale/placeholder digests nobody had a reliable way to check before applying.