### PR TITLE
Publish BE_DEVELOP_DIGEST as a repo variable on infra

### DIFF
--- a/.github/workflows/deploy-aits.yaml
+++ b/.github/workflows/deploy-aits.yaml
@@ -30,14 +30,15 @@ jobs:
           tags: ghcr.io/need4deed-org/be:develop
 
       - name: Publish develop digest for prod release pipeline
-        # infra's release-prod.yaml reads this as ${{ vars.BE_DEVELOP_DIGEST }}
-        # instead of scraping GHCR — be's own image isn't rebuilt for prod,
-        # it just promotes whatever's currently on :develop.
+        # A repository variable ON infra (not an org variable) - infra's
+        # release-prod.yaml reads this for free as ${{ vars.BE_DEVELOP_DIGEST }}
+        # since it's the same repo the variable lives on. be's own image
+        # isn't rebuilt for prod, it just promotes whatever's on :develop.
         # continue-on-error: the dev rollout below must still run even before
         # the PAT secret this needs exists, or once it's created but expires -
         # this step failing must never take down deploy-aits's actual job.
         continue-on-error: true
-        run: gh variable set BE_DEVELOP_DIGEST --org need4deed-org --repos infra --body "${{ steps.build.outputs.digest }}"
+        run: gh variable set BE_DEVELOP_DIGEST --repo need4deed-org/infra --body "${{ steps.build.outputs.digest }}"
         env:
           GH_TOKEN: ${{ secrets.PAT }}
 


### PR DESCRIPTION
## Summary
Follow-up to be#896. Switches the digest-publish step from an org-level variable to a plain repository variable on `need4deed-org/infra` — simpler PAT scope (just "Variables: read and write" on the `infra` repo, no organization-level permissions or org-owner approval needed). `infra`'s `release-prod.yaml` still reads it for free as `${{ vars.BE_DEVELOP_DIGEST }}` since Actions resolves `vars.*` from the current repo's own variables.

The `PAT` secret has now been added to this repo (fine-grained, scoped to `need4deed-org` as resource owner, `infra` repo selected, Variables: read and write).

## Test plan
- [ ] Merge, then `gh workflow run deploy-aits.yaml -R need4deed-org/be` (or push to develop)
- [ ] Confirm the "Publish develop digest" step succeeds (not just continue-on-error masking a failure)
- [ ] `gh variable get BE_DEVELOP_DIGEST -R need4deed-org/infra` shows a real digest