### PR TITLE
Fix build-bootstrap's checkout for cross-repo workflow_call

### DIFF
--- a/.github/workflows/build-bootstrap.yaml
+++ b/.github/workflows/build-bootstrap.yaml
@@ -21,7 +21,14 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
+      # Explicit repository+ref: a reusable workflow called cross-repo
+      # (infra's release-prod.yaml does) checks out the CALLER's repo by
+      # default, not this one - without this, docker/build-push-action
+      # can't find data-bootstrap/ at all.
       - uses: actions/checkout@v4
+        with:
+          repository: need4deed-org/be
+          ref: develop
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
The first live test of `infra`'s new `release-prod.yaml` orchestrator failed here too: calling this workflow cross-repo via `uses: need4deed-org/be/.github/workflows/build-bootstrap.yaml@develop` checked out **infra's** repository by default (a documented `actions/checkout` gotcha for cross-repo `workflow_call`), not be's — `data-bootstrap/Dockerfile` didn't exist in what got checked out, so the build failed immediately with `lstat data-bootstrap: no such file or directory`.

Pins `actions/checkout@v4` to `repository: need4deed-org/be, ref: develop` explicitly. No behavior change for standalone `push`/`workflow_dispatch` runs.

Companion fix: fe#948 (same root cause).