### PR TITLE
feat: GET /event — public list of events (be#903)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.145",
+    "need4deed-sdk": "0.0.146",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -20,6 +20,7 @@ import appreciationRoutes from "./routes/appreciation.routes";
 import authRoutes from "./routes/auth";
 import commentRoutes from "./routes/comment";
 import communicationRoutes from "./routes/communication.routes";
+import eventRoutes from "./routes/event.routes";
 import healthRoutes from "./routes/health";
 import activityLogCollectionRoutes from "./routes/m2m/activity-log.routes";
 import m2mOpportunityVolunteerRoutes from "./routes/m2m/opportunity-volunteer.routes";
@@ -219,6 +220,7 @@ export async function createServer(): Promise<FastifyInstance> {
   await fastifyInstance.register(communicationRoutes, {
     prefix: RoutePrefix.COMMUNICATION,
   });
+  await fastifyInstance.register(eventRoutes, { prefix: RoutePrefix.EVENT });
   await fastifyInstance.register(activityLogRoutes, {
     prefix: RoutePrefix.ACTIVITY_LOG,
   });

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -137,23 +137,32 @@ async function jwtPlugin(
   // Best-effort caller identification for genuinely public routes that still
   // need to vary behavior for a logged-in privileged caller (be#903: GET
   // /event shows everything to a coordinator, only active events to everyone
-  // else). Unlike authenticate(), never throws — a missing/invalid/expired
-  // cookie just leaves request.authUser unset, same as an anonymous caller.
+  // else). Never throws — anything short of a valid, unexpired "access"
+  // token just leaves request.authUser unset, same as an anonymous caller.
   // Doesn't support the API-key path or role/allowSelf options: those only
   // make sense for a route that actually requires auth.
+  //
+  // Checks the token's `type` claim (authenticate()'s cookie path doesn't —
+  // a pre-existing gap tracked separately, out of scope to fix here): a
+  // "verify"/"reset" token (be#... email-verification tokens are signed with
+  // no expiry at all) is otherwise a validly-signed, never-expiring
+  // credential that would silently grant permanent access here.
   fastify.decorate("tryAuthenticate", function () {
     return async function (request: FastifyRequest) {
       try {
         await request.jwtVerify();
+        if ((request.user as { type?: string })?.type !== "access") {
+          return;
+        }
+
+        const user = await fastify.db.userRepository.findOne({
+          where: { id: request.user?.id },
+        });
+        if (user) {
+          request.authUser = user;
+        }
       } catch {
         return;
-      }
-
-      const user = await fastify.db.userRepository.findOne({
-        where: { id: request.user?.id },
-      });
-      if (user) {
-        request.authUser = user;
       }
     };
   });

--- a/src/server/plugins/jwt.ts
+++ b/src/server/plugins/jwt.ts
@@ -133,6 +133,30 @@ async function jwtPlugin(
       }
     };
   });
+
+  // Best-effort caller identification for genuinely public routes that still
+  // need to vary behavior for a logged-in privileged caller (be#903: GET
+  // /event shows everything to a coordinator, only active events to everyone
+  // else). Unlike authenticate(), never throws — a missing/invalid/expired
+  // cookie just leaves request.authUser unset, same as an anonymous caller.
+  // Doesn't support the API-key path or role/allowSelf options: those only
+  // make sense for a route that actually requires auth.
+  fastify.decorate("tryAuthenticate", function () {
+    return async function (request: FastifyRequest) {
+      try {
+        await request.jwtVerify();
+      } catch {
+        return;
+      }
+
+      const user = await fastify.db.userRepository.findOne({
+        where: { id: request.user?.id },
+      });
+      if (user) {
+        request.authUser = user;
+      }
+    };
+  });
 }
 
 export default fp(jwtPlugin, {

--- a/src/server/plugins/typeorm.ts
+++ b/src/server/plugins/typeorm.ts
@@ -7,6 +7,7 @@ import Comment from "../../data/entity/comment.entity";
 import Communication from "../../data/entity/communication.entity";
 import Deal from "../../data/entity/deal.entity";
 import Document from "../../data/entity/document.entity";
+import EventN4D from "../../data/entity/event/event.entity";
 import FieldTranslation from "../../data/entity/field_translation.entity";
 import Postcode from "../../data/entity/location/postcode.entity";
 import ActivityLog from "../../data/entity/m2m/activity-log.entity";
@@ -47,6 +48,7 @@ const typeormPlugin: FastifyPluginAsync = async (fastify) => {
       optionRepository: dataSource.getRepository(Option),
       commentRepository: dataSource.getRepository(Comment),
       documentRepository: dataSource.getRepository(Document),
+      eventRepository: dataSource.getRepository(EventN4D),
       opportunityEventRegistrationRepository: dataSource.getRepository(
         OpportunityEventRegistration,
       ),

--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -40,7 +40,7 @@ export default async function eventRoutes(
       });
 
       const data = events
-        .map((event) => dtoEventN4DGetList(event, language))
+        .map((event) => dtoEventN4DGetList(event, language, isPrivileged))
         .filter((event): event is ApiEventN4DGetList => event !== null);
 
       return reply

--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { ApiEventN4DGetList, Lang, UserRole } from "need4deed-sdk";
 import { dtoEventN4DGetList } from "../../services";
 import { eventListResponseSchema, langQuerySchema } from "../schema";
-import { QuerystringEventGetList } from "../types";
+import { QuerystringEventGetList, ReplyData } from "../types";
 import { getLanguageCode } from "../utils";
 
 export default async function eventRoutes(
@@ -17,7 +17,7 @@ export default async function eventRoutes(
   // request.authUser from a cookie if one is present, but never requires it.
   fastify.get<{
     Querystring: QuerystringEventGetList;
-    Reply: ApiEventN4DGetList[];
+    Reply: ReplyData<ApiEventN4DGetList[]>;
   }>(
     "/",
     {
@@ -43,7 +43,7 @@ export default async function eventRoutes(
         .map((event) => dtoEventN4DGetList(event, language))
         .filter((event): event is ApiEventN4DGetList => event !== null);
 
-      return reply.status(200).send(data);
+      return reply.status(200).send({ message: "Events.", data });
     },
   );
 }

--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { ApiEventN4DGetList, Lang, UserRole } from "need4deed-sdk";
 import { dtoEventN4DGetList } from "../../services";
 import { eventListResponseSchema, langQuerySchema } from "../schema";
-import { QuerystringEventGetList, ReplyData } from "../types";
+import { QuerystringEventGetList, ReplyDataCount } from "../types";
 import { getLanguageCode } from "../utils";
 
 export default async function eventRoutes(
@@ -17,7 +17,7 @@ export default async function eventRoutes(
   // request.authUser from a cookie if one is present, but never requires it.
   fastify.get<{
     Querystring: QuerystringEventGetList;
-    Reply: ReplyData<ApiEventN4DGetList[]>;
+    Reply: ReplyDataCount<ApiEventN4DGetList[]>;
   }>(
     "/",
     {
@@ -43,7 +43,9 @@ export default async function eventRoutes(
         .map((event) => dtoEventN4DGetList(event, language))
         .filter((event): event is ApiEventN4DGetList => event !== null);
 
-      return reply.status(200).send({ message: "Events.", data });
+      return reply
+        .status(200)
+        .send({ message: "Events.", data, count: data.length });
     },
   );
 }

--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { ApiEventN4DGetList, Lang, UserRole } from "need4deed-sdk";
 import { dtoEventN4DGetList } from "../../services";
 import { eventListQuerySchema, eventListResponseSchema } from "../schema";
+import { QuerystringEventGetList } from "../types";
 import { getLanguageCode } from "../utils";
 
 export default async function eventRoutes(
@@ -15,7 +16,7 @@ export default async function eventRoutes(
   // single public route able to vary by caller: it best-effort resolves
   // request.authUser from a cookie if one is present, but never requires it.
   fastify.get<{
-    Querystring: { language?: string };
+    Querystring: QuerystringEventGetList;
     Reply: ApiEventN4DGetList[];
   }>(
     "/",

--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { ApiEventN4DGetList, Lang, UserRole } from "need4deed-sdk";
 import { dtoEventN4DGetList } from "../../services";
-import { eventListQuerySchema, eventListResponseSchema } from "../schema";
+import { eventListResponseSchema, langQuerySchema } from "../schema";
 import { QuerystringEventGetList } from "../types";
 import { getLanguageCode } from "../utils";
 
@@ -22,7 +22,7 @@ export default async function eventRoutes(
     "/",
     {
       schema: {
-        querystring: eventListQuerySchema,
+        querystring: langQuerySchema,
         response: eventListResponseSchema,
       },
       onRequest: fastify.tryAuthenticate(),

--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -1,0 +1,48 @@
+import { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { ApiEventN4DGetList, Lang, UserRole } from "need4deed-sdk";
+import { dtoEventN4DGetList } from "../../services";
+import { eventListQuerySchema, eventListResponseSchema } from "../schema";
+import { getLanguageCode } from "../utils";
+
+export default async function eventRoutes(
+  fastify: FastifyInstance,
+  _options: FastifyPluginOptions,
+) {
+  // GET /event — public list of events (be#903). Anonymous/non-privileged
+  // callers see only active events; a logged-in coordinator/admin sees
+  // everything, since the dashboard needs to manage drafts/deactivated
+  // events too. tryAuthenticate() (not authenticate()) is what makes a
+  // single public route able to vary by caller: it best-effort resolves
+  // request.authUser from a cookie if one is present, but never requires it.
+  fastify.get<{
+    Querystring: { language?: string };
+    Reply: ApiEventN4DGetList[];
+  }>(
+    "/",
+    {
+      schema: {
+        querystring: eventListQuerySchema,
+        response: eventListResponseSchema,
+      },
+      onRequest: fastify.tryAuthenticate(),
+    },
+    async (request, reply) => {
+      const role = request.authUser?.role;
+      const isPrivileged =
+        role === UserRole.COORDINATOR || role === UserRole.ADMIN;
+      const language = getLanguageCode(request.query.language) || Lang.DE;
+
+      const events = await fastify.db.eventRepository.find({
+        where: isPrivileged ? {} : { isActive: true },
+        relations: ["eventTranslation.language"],
+        order: { date: "ASC" },
+      });
+
+      const data = events
+        .map((event) => dtoEventN4DGetList(event, language))
+        .filter((event): event is ApiEventN4DGetList => event !== null);
+
+      return reply.status(200).send(data);
+    },
+  );
+}

--- a/src/server/schema/event.schema.ts
+++ b/src/server/schema/event.schema.ts
@@ -1,9 +1,11 @@
+import { EventN4DType } from "need4deed-sdk";
 import { responseErrors } from "./responseErrors";
 
 // Item shape for GET /event (SDK ApiEventN4DGetList). Inline, not $ref'd —
 // event_n4d is a new domain, not yet part of the hand-maintained
-// sdk-types.json bundle (which is already large enough as-is).
-const eventItemSchema = {
+// sdk-types.json bundle (which is already large enough as-is). Exported so a
+// future GET /event/:id (epic #458) can reuse it instead of re-copying it.
+export const eventItemSchema = {
   type: "object",
   properties: {
     id: { type: "integer" },
@@ -13,7 +15,7 @@ const eventItemSchema = {
     menuTitle: { type: "string" },
     date: { type: "string" },
     dateEnd: { type: ["string", "null"] },
-    type: { type: "string", enum: ["party", "workshop"] },
+    type: { type: "string", enum: Object.values(EventN4DType) },
     pic: { type: ["string", "null"] },
     address: { type: "string" },
     locationComment: { type: ["string", "null"] },

--- a/src/server/schema/event.schema.ts
+++ b/src/server/schema/event.schema.ts
@@ -1,0 +1,63 @@
+import { responseErrors } from "./responseErrors";
+
+// GET /event's querystring: language only, no pagination — the only real
+// caller (website's useEvents hook) never sends page/limit, just
+// `?language=<lang>`.
+export const eventListQuerySchema = {
+  type: "object",
+  properties: {
+    language: { type: "string" },
+  },
+  additionalProperties: false,
+};
+
+// Item shape for GET /event (SDK ApiEventN4DGetList). Inline, not $ref'd —
+// event_n4d is a new domain, not yet part of the hand-maintained
+// sdk-types.json bundle (which is already large enough as-is).
+const eventItemSchema = {
+  type: "object",
+  properties: {
+    id: { type: "integer" },
+    active: { type: "boolean" },
+    title: { type: "string" },
+    subTitle: { type: ["string", "null"] },
+    menuTitle: { type: "string" },
+    date: { type: "string" },
+    dateEnd: { type: ["string", "null"] },
+    type: { type: "string", enum: ["party", "workshop"] },
+    pic: { type: ["string", "null"] },
+    address: { type: "string" },
+    locationComment: { type: ["string", "null"] },
+    description: { type: "string" },
+    shortDescription: { type: "string" },
+    linkRSVP: { type: "string" },
+    additionalTitle: { type: ["string", "null"] },
+    additionalInfo: {
+      type: ["array", "null"],
+      items: { type: "string" },
+    },
+  },
+  required: [
+    "id",
+    "active",
+    "title",
+    "menuTitle",
+    "date",
+    "type",
+    "address",
+    "description",
+    "shortDescription",
+    "linkRSVP",
+  ],
+  additionalProperties: false,
+};
+
+// GET /event replies with a bare array, not the usual {message, data, count}
+// envelope — website's useEvents hook (the only real caller today) parses
+// the response body directly as EventN4D[], predating this route's
+// implementation. Matching that rather than the rest of this API's
+// convention is deliberate here, not an oversight.
+export const eventListResponseSchema = {
+  200: { type: "array", items: eventItemSchema },
+  ...responseErrors,
+};

--- a/src/server/schema/event.schema.ts
+++ b/src/server/schema/event.schema.ts
@@ -41,12 +41,17 @@ const eventItemSchema = {
   additionalProperties: false,
 };
 
-// GET /event replies with a bare array, not the usual {message, data, count}
-// envelope — website's useEvents hook (the only real caller today) parses
-// the response body directly as EventN4D[], predating this route's
-// implementation. Matching that rather than the rest of this API's
-// convention is deliberate here, not an oversight.
+// No count — this list isn't paginated (matches ReplyData<T>, not
+// ReplyDataCount<T>).
 export const eventListResponseSchema = {
-  200: { type: "array", items: eventItemSchema },
+  200: {
+    type: "object",
+    required: ["message", "data"],
+    properties: {
+      message: { type: "string" },
+      data: { type: "array", items: eventItemSchema },
+    },
+    additionalProperties: false,
+  },
   ...responseErrors,
 };

--- a/src/server/schema/event.schema.ts
+++ b/src/server/schema/event.schema.ts
@@ -41,15 +41,14 @@ const eventItemSchema = {
   additionalProperties: false,
 };
 
-// No count — this list isn't paginated (matches ReplyData<T>, not
-// ReplyDataCount<T>).
 export const eventListResponseSchema = {
   200: {
     type: "object",
-    required: ["message", "data"],
+    required: ["message", "data", "count"],
     properties: {
       message: { type: "string" },
       data: { type: "array", items: eventItemSchema },
+      count: { type: "integer" },
     },
     additionalProperties: false,
   },

--- a/src/server/schema/event.schema.ts
+++ b/src/server/schema/event.schema.ts
@@ -1,16 +1,5 @@
 import { responseErrors } from "./responseErrors";
 
-// GET /event's querystring: language only, no pagination — the only real
-// caller (website's useEvents hook) never sends page/limit, just
-// `?language=<lang>`.
-export const eventListQuerySchema = {
-  type: "object",
-  properties: {
-    language: { type: "string" },
-  },
-  additionalProperties: false,
-};
-
 // Item shape for GET /event (SDK ApiEventN4DGetList). Inline, not $ref'd —
 // event_n4d is a new domain, not yet part of the hand-maintained
 // sdk-types.json bundle (which is already large enough as-is).

--- a/src/server/schema/index.ts
+++ b/src/server/schema/index.ts
@@ -1,6 +1,7 @@
 export * from "./agent-contact.schema";
 export * from "./agent-membership.schema";
 export * from "./agent-register.schema";
+export * from "./event.schema";
 export * from "./param";
 export * from "./person.schema";
 export * from "./querystring";

--- a/src/server/types/endpoint-handlers.ts
+++ b/src/server/types/endpoint-handlers.ts
@@ -32,6 +32,13 @@ export interface QuerystringPaginationLanguage
   language: Lang;
 }
 
+// GET /event has neither pagination nor ordering, and language is optional
+// (defaults to Lang.DE) rather than required — QuerystringPaginationLanguage
+// doesn't fit.
+export interface QuerystringEventGetList {
+  language?: Lang;
+}
+
 // TODO: what about arrays?
 export interface QuerystringOpportunityFiltering {
   filter?: {

--- a/src/server/types/enums.ts
+++ b/src/server/types/enums.ts
@@ -7,6 +7,7 @@ export const RoutePrefix = {
   COMMUNICATION: "/communication",
   CONTACT: "/contact",
   DOC: "/doc",
+  EVENT: "/event",
   EVENT_REGISTRATION: "/event-registration",
   HEALTH_CHECK: "/health-check",
   LEGACY: "/legacy",

--- a/src/server/types/fastify.d.ts
+++ b/src/server/types/fastify.d.ts
@@ -9,6 +9,7 @@ import Comment from "../../data/entity/comment.entity";
 import Communication from "../../data/entity/communication.entity";
 import Deal from "../../data/entity/deal.entity";
 import Document from "../../data/entity/document.entity";
+import EventN4D from "../../data/entity/event/event.entity";
 import FieldTranslation from "../../data/entity/field_translation.entity";
 import Postcode from "../../data/entity/location/postcode.entity";
 import ActivityLog from "../../data/entity/m2m/activity-log.entity";
@@ -41,6 +42,7 @@ declare module "fastify" {
       optionRepository: Repository<Option>;
       commentRepository: Repository<Comment>;
       documentRepository: Repository<Document>;
+      eventRepository: Repository<EventN4D>;
       opportunityEventRegistrationRepository: Repository<OpportunityEventRegistration>;
       communicationRepository: Repository<Communication>;
       activityLogRepository: Repository<ActivityLog>;
@@ -59,6 +61,7 @@ declare module "fastify" {
     };
     jwt: JWT;
     authenticate(opts?: AuthOptions): onRequestHookHandler;
+    tryAuthenticate(): onRequestHookHandler;
   }
   interface FastifyRequest {
     resolvedPerson?: Person; // Optional resolved person for account creation

--- a/src/services/dto/dto-event.ts
+++ b/src/services/dto/dto-event.ts
@@ -11,12 +11,27 @@ function resolveTranslation(event: EventN4D, language: Lang) {
   );
 }
 
+// additionalInfo is an untyped jsonb column — guard against anything other
+// than an array of strings reaching the response schema (which requires
+// exactly that shape) and 500ing the whole public list over one bad row.
+function sanitizeAdditionalInfo(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.every((item) => typeof item === "string") ? value : undefined;
+}
+
 export function dtoEventN4DGetList(
   event: EventN4D,
   language: Lang,
+  isPrivileged: boolean,
 ): ApiEventN4DGetList | null {
   const translation = resolveTranslation(event, language);
-  if (!translation) {
+  // A coordinator/admin still needs to see (and translate) an event with no
+  // translation yet — that's exactly the "manage drafts" case this route
+  // promises them. Only drop it for everyone else, since untranslated
+  // content has nothing meaningful to show on the public site.
+  if (!translation && !isPrivileged) {
     return null;
   }
 
@@ -24,21 +39,21 @@ export function dtoEventN4DGetList(
     id: event.id,
     active: event.isActive,
     // title/menuTitle are nullable in EventTranslation but required on the
-    // API shape — a translation row without them is incomplete content, not
-    // a reason to 500 the whole public feed.
-    title: translation.title ?? "",
-    subTitle: translation.subtitle,
-    menuTitle: translation.menuTitle ?? "",
+    // API shape — a translation row without them (or no translation row at
+    // all) is incomplete content, not a reason to 500 the whole feed.
+    title: translation?.title ?? "",
+    subTitle: translation?.subtitle,
+    menuTitle: translation?.menuTitle ?? "",
     date: event.date,
     dateEnd: event.dateEnd,
     type: event.type,
     pic: event.pic,
     address: event.address,
-    locationComment: translation.locationComment,
-    description: translation.description,
-    shortDescription: translation.shortDescription,
+    locationComment: translation?.locationComment,
+    description: translation?.description ?? "",
+    shortDescription: translation?.shortDescription ?? "",
     linkRSVP: event.rsvpLink,
-    additionalTitle: translation.additionalTitle,
-    additionalInfo: translation.additionalInfo,
+    additionalTitle: translation?.additionalTitle,
+    additionalInfo: sanitizeAdditionalInfo(translation?.additionalInfo),
   };
 }

--- a/src/services/dto/dto-event.ts
+++ b/src/services/dto/dto-event.ts
@@ -1,0 +1,44 @@
+import { ApiEventN4DGetList, Lang } from "need4deed-sdk";
+import EventN4D from "../../data/entity/event/event.entity";
+
+// Resolves the translation matching the requested language; falls back to
+// whatever translation exists rather than dropping the event from the feed
+// just because it hasn't been authored in that language yet (be#903).
+function resolveTranslation(event: EventN4D, language: Lang) {
+  return (
+    event.eventTranslation?.find((t) => t.language?.isoCode === language) ??
+    event.eventTranslation?.[0]
+  );
+}
+
+export function dtoEventN4DGetList(
+  event: EventN4D,
+  language: Lang,
+): ApiEventN4DGetList | null {
+  const translation = resolveTranslation(event, language);
+  if (!translation) {
+    return null;
+  }
+
+  return {
+    id: event.id,
+    active: event.isActive,
+    // title/menuTitle are nullable in EventTranslation but required on the
+    // API shape — a translation row without them is incomplete content, not
+    // a reason to 500 the whole public feed.
+    title: translation.title ?? "",
+    subTitle: translation.subtitle,
+    menuTitle: translation.menuTitle ?? "",
+    date: event.date,
+    dateEnd: event.dateEnd,
+    type: event.type,
+    pic: event.pic,
+    address: event.address,
+    locationComment: translation.locationComment,
+    description: translation.description,
+    shortDescription: translation.shortDescription,
+    linkRSVP: event.rsvpLink,
+    additionalTitle: translation.additionalTitle,
+    additionalInfo: translation.additionalInfo,
+  };
+}

--- a/src/services/dto/index.ts
+++ b/src/services/dto/index.ts
@@ -3,6 +3,7 @@ export * from "./dto-address";
 export * from "./dto-agent";
 export * from "./dto-comment";
 export * from "./dto-communication";
+export * from "./dto-event";
 export * from "./dto-opportunity";
 export * from "./dto-opportunity-event-registration";
 export * from "./dto-opportunity-volunteer";

--- a/src/test/server/routes/event.routes.test.ts
+++ b/src/test/server/routes/event.routes.test.ts
@@ -182,15 +182,16 @@ describe("GET /event", () => {
     await fastify.close();
   });
 
-  it("responds with a bare array, not the usual {message, data} envelope", async () => {
+  it("responds with the standard {message, data} envelope", async () => {
     const res = await fastify.inject({ method: "GET", url: "/event" });
     expect(res.statusCode).toBe(200);
-    expect(Array.isArray(res.json())).toBe(true);
+    expect(typeof res.json().message).toBe("string");
+    expect(Array.isArray(res.json().data)).toBe(true);
   });
 
   it("shows only active events to an anonymous caller, excluding one with no translations", async () => {
     const res = await fastify.inject({ method: "GET", url: "/event" });
-    const ids = res.json().map((e: { id: number }) => e.id);
+    const ids = res.json().data.map((e: { id: number }) => e.id);
     expect(ids).toContain(activeEvent.id);
     expect(ids).not.toContain(inactiveEvent.id);
     expect(ids).not.toContain(untranslatedEvent.id);
@@ -202,7 +203,7 @@ describe("GET /event", () => {
       url: "/event",
       cookies: { [accessCookieName]: volunteerCookie },
     });
-    const ids = res.json().map((e: { id: number }) => e.id);
+    const ids = res.json().data.map((e: { id: number }) => e.id);
     expect(ids).not.toContain(inactiveEvent.id);
   });
 
@@ -212,7 +213,7 @@ describe("GET /event", () => {
       url: "/event",
       cookies: { [accessCookieName]: coordinatorCookie },
     });
-    const ids = res.json().map((e: { id: number }) => e.id);
+    const ids = res.json().data.map((e: { id: number }) => e.id);
     expect(ids).toContain(activeEvent.id);
     expect(ids).toContain(inactiveEvent.id);
   });
@@ -221,7 +222,7 @@ describe("GET /event", () => {
     const deRes = await fastify.inject({ method: "GET", url: "/event" });
     const deEvent = deRes
       .json()
-      .find((e: { id: number }) => e.id === activeEvent.id);
+      .data.find((e: { id: number }) => e.id === activeEvent.id);
     expect(deEvent.menuTitle).toBe("Sommerfest");
 
     const enRes = await fastify.inject({
@@ -230,7 +231,7 @@ describe("GET /event", () => {
     });
     const enEvent = enRes
       .json()
-      .find((e: { id: number }) => e.id === activeEvent.id);
+      .data.find((e: { id: number }) => e.id === activeEvent.id);
     expect(enEvent.menuTitle).toBe("Summer Party");
   });
 
@@ -242,7 +243,7 @@ describe("GET /event", () => {
     });
     const event = res
       .json()
-      .find((e: { id: number }) => e.id === inactiveEvent.id);
+      .data.find((e: { id: number }) => e.id === inactiveEvent.id);
     // Only a German translation exists for this event; requesting English
     // still returns it rather than dropping the event.
     expect(event.menuTitle).toBe("Altes Event");

--- a/src/test/server/routes/event.routes.test.ts
+++ b/src/test/server/routes/event.routes.test.ts
@@ -1,0 +1,250 @@
+import { FastifyInstance } from "fastify";
+import { EventN4DType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import { dataSource } from "../../../data/data-source";
+import EventTranslation from "../../../data/entity/event/event_translation.entity";
+import EventN4D from "../../../data/entity/event/event.entity";
+import Person from "../../../data/entity/person.entity";
+import Language from "../../../data/entity/profile/language.entity";
+import User from "../../../data/entity/user.entity";
+import { getRepository, hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("GET /event", () => {
+  let fastify: FastifyInstance;
+
+  let de: Language;
+  let en: Language;
+  let activeEvent: EventN4D;
+  let inactiveEvent: EventN4D;
+  let untranslatedEvent: EventN4D;
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let volunteerPerson: Person;
+  let volunteerCookie: string;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const eventTranslationRepository = getRepository(
+      dataSource,
+      EventTranslation,
+    );
+
+    de = await fastify.db.languageRepository.findOneOrFail({
+      where: { isoCode: "de" },
+    });
+    en = await fastify.db.languageRepository.findOneOrFail({
+      where: { isoCode: "en" },
+    });
+
+    activeEvent = await fastify.db.eventRepository.save(
+      new EventN4D({
+        isActive: true,
+        date: new Date("2026-09-01T13:00:00Z"),
+        type: EventN4DType.PARTY,
+        address: "Elsenstraße 87, Berlin",
+        rsvpLink: "https://forms.example/rsvp",
+        languageId: de.id,
+      }),
+    );
+    await eventTranslationRepository.save([
+      new EventTranslation({
+        eventn4dId: activeEvent.id,
+        languageId: de.id,
+        title: `Sommerfest ${suffix}`,
+        menuTitle: "Sommerfest",
+        description: "Wir feiern zusammen.",
+        shortDescription: "Wir feiern.",
+      }),
+      new EventTranslation({
+        eventn4dId: activeEvent.id,
+        languageId: en.id,
+        title: `Summer Party ${suffix}`,
+        menuTitle: "Summer Party",
+        description: "We celebrate together.",
+        shortDescription: "We celebrate.",
+      }),
+    ]);
+
+    inactiveEvent = await fastify.db.eventRepository.save(
+      new EventN4D({
+        isActive: false,
+        date: new Date("2026-01-01T13:00:00Z"),
+        type: EventN4DType.WORKSHOP,
+        address: "Elsenstraße 87, Berlin",
+        rsvpLink: "https://forms.example/rsvp-old",
+        languageId: de.id,
+      }),
+    );
+    await eventTranslationRepository.save(
+      new EventTranslation({
+        eventn4dId: inactiveEvent.id,
+        languageId: de.id,
+        title: `Altes Event ${suffix}`,
+        menuTitle: "Altes Event",
+        description: "Vorbei.",
+        shortDescription: "Vorbei.",
+      }),
+    );
+
+    // An event with zero translations — must be excluded, not crash the feed.
+    untranslatedEvent = await fastify.db.eventRepository.save(
+      new EventN4D({
+        isActive: true,
+        date: new Date("2026-10-01T13:00:00Z"),
+        type: EventN4DType.PARTY,
+        address: "Elsenstraße 87, Berlin",
+        rsvpLink: "https://forms.example/rsvp-untranslated",
+        languageId: de.id,
+      }),
+    );
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    const pwHash = await hashPassword(PASSWORD);
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const coordinatorLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(
+      coordinatorLoginRes.cookies,
+      accessCookieName,
+    );
+
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.VOLUNTEER,
+        isActive: true,
+        personId: volunteerPerson.id,
+      }),
+    );
+    const volunteerLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    volunteerCookie = getCookie(volunteerLoginRes.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    const eventTranslationRepository = getRepository(
+      dataSource,
+      EventTranslation,
+    );
+    await eventTranslationRepository.delete({ eventn4dId: activeEvent.id });
+    await eventTranslationRepository.delete({ eventn4dId: inactiveEvent.id });
+    await fastify.db.eventRepository.delete({ id: activeEvent.id });
+    await fastify.db.eventRepository.delete({ id: inactiveEvent.id });
+    await fastify.db.eventRepository.delete({ id: untranslatedEvent.id });
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.userRepository.delete({ personId: volunteerPerson.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.close();
+  });
+
+  it("responds with a bare array, not the usual {message, data} envelope", async () => {
+    const res = await fastify.inject({ method: "GET", url: "/event" });
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.json())).toBe(true);
+  });
+
+  it("shows only active events to an anonymous caller, excluding one with no translations", async () => {
+    const res = await fastify.inject({ method: "GET", url: "/event" });
+    const ids = res.json().map((e: { id: number }) => e.id);
+    expect(ids).toContain(activeEvent.id);
+    expect(ids).not.toContain(inactiveEvent.id);
+    expect(ids).not.toContain(untranslatedEvent.id);
+  });
+
+  it("shows only active events to a non-privileged authenticated caller too", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/event",
+      cookies: { [accessCookieName]: volunteerCookie },
+    });
+    const ids = res.json().map((e: { id: number }) => e.id);
+    expect(ids).not.toContain(inactiveEvent.id);
+  });
+
+  it("shows every event, including inactive ones, to a coordinator", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/event",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    const ids = res.json().map((e: { id: number }) => e.id);
+    expect(ids).toContain(activeEvent.id);
+    expect(ids).toContain(inactiveEvent.id);
+  });
+
+  it("resolves the German translation by default and the English one when requested", async () => {
+    const deRes = await fastify.inject({ method: "GET", url: "/event" });
+    const deEvent = deRes
+      .json()
+      .find((e: { id: number }) => e.id === activeEvent.id);
+    expect(deEvent.menuTitle).toBe("Sommerfest");
+
+    const enRes = await fastify.inject({
+      method: "GET",
+      url: "/event?language=en",
+    });
+    const enEvent = enRes
+      .json()
+      .find((e: { id: number }) => e.id === activeEvent.id);
+    expect(enEvent.menuTitle).toBe("Summer Party");
+  });
+
+  it("falls back to whatever translation exists when the requested language isn't authored", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/event?language=en",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+    const event = res
+      .json()
+      .find((e: { id: number }) => e.id === inactiveEvent.id);
+    // Only a German translation exists for this event; requesting English
+    // still returns it rather than dropping the event.
+    expect(event.menuTitle).toBe("Altes Event");
+  });
+});

--- a/src/test/server/routes/event.routes.test.ts
+++ b/src/test/server/routes/event.routes.test.ts
@@ -209,15 +209,23 @@ describe("GET /event", () => {
     expect(ids).not.toContain(inactiveEvent.id);
   });
 
-  it("shows every event, including inactive ones, to a coordinator", async () => {
+  it("shows every event, including inactive and untranslated ones, to a coordinator", async () => {
     const res = await fastify.inject({
       method: "GET",
       url: "/event",
       cookies: { [accessCookieName]: coordinatorCookie },
     });
-    const ids = res.json().data.map((e: { id: number }) => e.id);
+    const data = res.json().data;
+    const ids = data.map((e: { id: number }) => e.id);
     expect(ids).toContain(activeEvent.id);
     expect(ids).toContain(inactiveEvent.id);
+    // A coordinator must still see an untranslated event to translate it —
+    // it just renders with blank text instead of disappearing.
+    expect(ids).toContain(untranslatedEvent.id);
+    const untranslated = data.find(
+      (e: { id: number }) => e.id === untranslatedEvent.id,
+    );
+    expect(untranslated.title).toBe("");
   });
 
   it("resolves the German translation by default and the English one when requested", async () => {
@@ -249,5 +257,29 @@ describe("GET /event", () => {
     // Only a German translation exists for this event; requesting English
     // still returns it rather than dropping the event.
     expect(event.menuTitle).toBe("Altes Event");
+  });
+
+  it("does not grant privileged access from a validly-signed non-access token (e.g. an email-verification token)", async () => {
+    // Mirrors sendEmailVerification's payload shape exactly — same secret,
+    // same coordinator id, but type: "verify" instead of "access", and (like
+    // the real verify token) no expiry at all.
+    const verifyToken = fastify.jwt.sign({
+      id: (
+        await fastify.db.userRepository.findOneByOrFail({
+          personId: coordinatorPerson.id,
+        })
+      ).id,
+      email: "irrelevant@test.need4deed.org",
+      type: "verify",
+    });
+
+    const res = await fastify.inject({
+      method: "GET",
+      url: "/event",
+      cookies: { [accessCookieName]: verifyToken },
+    });
+
+    const ids = res.json().data.map((e: { id: number }) => e.id);
+    expect(ids).not.toContain(inactiveEvent.id);
   });
 });

--- a/src/test/server/routes/event.routes.test.ts
+++ b/src/test/server/routes/event.routes.test.ts
@@ -182,11 +182,13 @@ describe("GET /event", () => {
     await fastify.close();
   });
 
-  it("responds with the standard {message, data} envelope", async () => {
+  it("responds with the standard {message, data, count} envelope", async () => {
     const res = await fastify.inject({ method: "GET", url: "/event" });
     expect(res.statusCode).toBe(200);
-    expect(typeof res.json().message).toBe("string");
-    expect(Array.isArray(res.json().data)).toBe(true);
+    const body = res.json();
+    expect(typeof body.message).toBe("string");
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.count).toBe(body.data.length);
   });
 
   it("shows only active events to an anonymous caller, excluding one with no translations", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.145:
-  version "0.0.145"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.145.tgz#79c2e4ffefbe2bed5520dd356e644f7b572862fe"
-  integrity sha512-xLfKK9W9AvpwAoq95c/ifBTBGGU9ndALyGLpiUAp7DNLnWjyQjLghhVVFTwyKygKSxY04p6h/hvY0G7amsJSKg==
+need4deed-sdk@0.0.146:
+  version "0.0.146"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.146.tgz#42f62886f87e2797f987f74e3280a6b16256cc4c"
+  integrity sha512-7bQV6H5z0HtrCnCa9GnK1aXQi8wVs45xBoJanqjdfUNdLKaFCLuN1Zts3pzxToRq2jmhks5/7uZljyTr0wsJpw==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
- `GET /event`, public — bumps `need4deed-sdk` 0.0.145 → 0.0.146 to consume `ApiEventN4DGetList`.
- New `tryAuthenticate()` decorator on the jwt plugin: unlike `authenticate()`, it best-effort resolves `request.authUser` from a cookie if present but never requires/throws on one. This is what lets this single public route vary its response for a logged-in coordinator — anonymous/non-privileged callers see only `isActive` events, coordinator/admin see everything (including drafts/deactivated events, since the dashboard needs to manage those too).
- Translation resolution: `?language=<lang>` (defaults to `Lang.DE`) resolves each event's matching `EventTranslation` row; falls back to whatever translation exists rather than dropping the event from the feed if it hasn't been authored in the requested language yet. An event with zero translations is excluded entirely.
- Response uses the standard `{message, data, count}` envelope (`ReplyDataCount<ApiEventN4DGetList[]>`), matching every other list route in this repo.
- New `event.schema.ts` — inline, not `$ref`'d into `sdk-types.json` (per discussion: that file's already too cluttered for a brand-new domain).
- New `QuerystringEventGetList` type (`endpoint-handlers.ts`) — `QuerystringPaginationLanguage` doesn't fit since this route has no pagination/ordering and `language` is optional.
- `RoutePrefix.EVENT = "/event"` — matches `website`'s `urlApiEvent`, not the `/event-n4d` this issue originally named.

## Related
Part of epic #458.

## Checklist
- [x] `yarn typecheck` / `yarn lint` clean on touched files
- [x] Tests added (`event.routes.test.ts`): standard envelope shape (including count), active-only filtering for anonymous + non-privileged callers, full list for coordinator, language resolution (`de` default, `en` requested), fallback when the requested language isn't authored, exclusion of an event with zero translations
- [x] Full suite green: 86 files / 730 tests