### PR TITLE
feat: POST /event — coordinator create (be#904)

### DIFF
--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -1,9 +1,20 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiEventN4DGetList, Lang, UserRole } from "need4deed-sdk";
+import {
+  ApiEventN4DCreate,
+  ApiEventN4DGetList,
+  Lang,
+  UserRole,
+} from "need4deed-sdk";
+import { NotFoundError } from "../../config";
 import { dtoEventN4DGetList } from "../../services";
-import { eventListResponseSchema, langQuerySchema } from "../schema";
-import { QuerystringEventGetList, ReplyDataCount } from "../types";
-import { getLanguageCode } from "../utils";
+import {
+  eventCreateBodySchema,
+  eventCreateResponseSchema,
+  eventListResponseSchema,
+  langQuerySchema,
+} from "../schema";
+import { QuerystringEventGetList, ReplyData, ReplyDataCount } from "../types";
+import { createEvent, getLanguageCode } from "../utils";
 
 export default async function eventRoutes(
   fastify: FastifyInstance,
@@ -46,6 +57,45 @@ export default async function eventRoutes(
       return reply
         .status(200)
         .send({ message: "Events.", data, count: data.length });
+    },
+  );
+
+  // POST /event — coordinator create (be#904). Structural fields + one
+  // EventTranslation row per submitted language.
+  fastify.post<{
+    Body: ApiEventN4DCreate;
+    Reply: ReplyData<ApiEventN4DGetList>;
+  }>(
+    "/",
+    {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
+      schema: {
+        body: eventCreateBodySchema,
+        response: eventCreateResponseSchema,
+      },
+    },
+    async (request, reply) => {
+      const created = await createEvent(request.body);
+
+      const event = await fastify.db.eventRepository.findOne({
+        where: { id: created.id },
+        relations: ["eventTranslation.language"],
+      });
+      if (!event) {
+        throw new NotFoundError(`Event (id:${created.id}) not found.`);
+      }
+
+      // isPrivileged: true (this route is COORDINATOR-gated) means
+      // dtoEventN4DGetList's null branch is unreachable here — it only
+      // returns null for a non-privileged caller. Echoes back in whichever
+      // language was submitted first.
+      const data = dtoEventN4DGetList(
+        event,
+        request.body.translations[0].language,
+        true,
+      )!;
+
+      return reply.status(201).send({ message: "Event created.", data });
     },
   );
 }

--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -1,12 +1,13 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
   ApiEventN4DCreate,
+  ApiEventN4DGet,
   ApiEventN4DGetList,
   Lang,
   UserRole,
 } from "need4deed-sdk";
 import { NotFoundError } from "../../config";
-import { dtoEventN4DGetList } from "../../services";
+import { dtoEventN4DGet, dtoEventN4DGetList } from "../../services";
 import {
   eventCreateBodySchema,
   eventCreateResponseSchema,
@@ -64,7 +65,7 @@ export default async function eventRoutes(
   // EventTranslation row per submitted language.
   fastify.post<{
     Body: ApiEventN4DCreate;
-    Reply: ReplyData<ApiEventN4DGetList>;
+    Reply: ReplyData<ApiEventN4DGet>;
   }>(
     "/",
     {
@@ -86,10 +87,10 @@ export default async function eventRoutes(
       }
 
       // isPrivileged: true (this route is COORDINATOR-gated) means
-      // dtoEventN4DGetList's null branch is unreachable here — it only
-      // returns null for a non-privileged caller. Echoes back in whichever
-      // language was submitted first.
-      const data = dtoEventN4DGetList(
+      // dtoEventN4DGet's null branch is unreachable here — it only returns
+      // null for a non-privileged caller. Echoes back in whichever language
+      // was submitted first.
+      const data = dtoEventN4DGet(
         event,
         request.body.translations[0].language,
         true,

--- a/src/server/schema/event.schema.ts
+++ b/src/server/schema/event.schema.ts
@@ -1,4 +1,5 @@
 import { EventN4DType } from "need4deed-sdk";
+import { getRef } from "../utils";
 import { responseErrors } from "./responseErrors";
 
 // Item shape for GET /event (SDK ApiEventN4DGetList). Inline, not $ref'd —
@@ -51,6 +52,71 @@ export const eventListResponseSchema = {
       message: { type: "string" },
       data: { type: "array", items: eventItemSchema },
       count: { type: "integer" },
+    },
+    additionalProperties: false,
+  },
+  ...responseErrors,
+};
+
+// Body for POST /event (SDK ApiEventN4DTranslationInput).
+const eventTranslationInputSchema = {
+  type: "object",
+  properties: {
+    language: getRef("Lang#"),
+    title: { type: "string", minLength: 1 },
+    subTitle: { type: "string" },
+    menuTitle: { type: "string", minLength: 1 },
+    time: { type: "string" },
+    locationComment: { type: "string" },
+    description: { type: "string", minLength: 1 },
+    shortDescription: { type: "string", minLength: 1 },
+    additionalTitle: { type: "string" },
+    additionalInfo: { type: "array", items: { type: "string" } },
+    outro: { type: "string" },
+    followUpText: { type: "string" },
+  },
+  required: [
+    "language",
+    "title",
+    "menuTitle",
+    "description",
+    "shortDescription",
+  ],
+  additionalProperties: false,
+};
+
+// Body for POST /event (SDK ApiEventN4DCreate). translations requires at
+// least one entry — enforced here rather than in application code.
+export const eventCreateBodySchema = {
+  type: "object",
+  properties: {
+    date: { type: "string", format: "date-time" },
+    dateEnd: { type: "string", format: "date-time" },
+    type: { type: "string", enum: Object.values(EventN4DType) },
+    pic: { type: "string" },
+    locationLink: { type: "string" },
+    linkRSVP: { type: "string" },
+    followUpLink: { type: "string" },
+    address: { type: "string", minLength: 1 },
+    hostName: { type: "string" },
+    active: { type: "boolean" },
+    translations: {
+      type: "array",
+      items: eventTranslationInputSchema,
+      minItems: 1,
+    },
+  },
+  required: ["date", "type", "linkRSVP", "address", "translations"],
+  additionalProperties: false,
+};
+
+export const eventCreateResponseSchema = {
+  201: {
+    type: "object",
+    required: ["message", "data"],
+    properties: {
+      message: { type: "string" },
+      data: eventItemSchema,
     },
     additionalProperties: false,
   },

--- a/src/server/schema/event.schema.ts
+++ b/src/server/schema/event.schema.ts
@@ -44,6 +44,21 @@ export const eventItemSchema = {
   additionalProperties: false,
 };
 
+// Full detail shape for POST /event's response (SDK ApiEventN4DGet) — adds
+// the fields eventItemSchema (the list shape) doesn't carry.
+export const eventFullItemSchema = {
+  ...eventItemSchema,
+  properties: {
+    ...eventItemSchema.properties,
+    hostName: { type: ["string", "null"] },
+    time: { type: ["string", "null"] },
+    locationLink: { type: ["string", "null"] },
+    followUpText: { type: ["string", "null"] },
+    followUpLink: { type: ["string", "null"] },
+    outro: { type: ["string", "null"] },
+  },
+};
+
 export const eventListResponseSchema = {
   200: {
     type: "object",
@@ -116,7 +131,7 @@ export const eventCreateResponseSchema = {
     required: ["message", "data"],
     properties: {
       message: { type: "string" },
-      data: eventItemSchema,
+      data: eventFullItemSchema,
     },
     additionalProperties: false,
   },

--- a/src/server/utils/data/get-language-title.ts
+++ b/src/server/utils/data/get-language-title.ts
@@ -1,3 +1,4 @@
+import { EntityNotFoundError } from "../../../config";
 import { dataSource } from "../../../data/data-source";
 import Language from "../../../data/entity/profile/language.entity";
 import { getRepository } from "../../../data/utils";
@@ -6,4 +7,15 @@ export async function getLanguageTitle(isoCode: string): Promise<string> {
   const languageRepository = getRepository(dataSource, Language);
   const language = await languageRepository.findOneBy({ isoCode });
   return language?.title;
+}
+
+// Reference data is fixed and never mutated within a request, so this reads
+// via the plain dataSource rather than needing to be transaction-aware.
+export async function getLanguageIdByIsoCode(isoCode: string): Promise<number> {
+  const languageRepository = getRepository(dataSource, Language);
+  const language = await languageRepository.findOneBy({ isoCode });
+  if (!language) {
+    throw new EntityNotFoundError("Language", { isoCode });
+  }
+  return language.id;
 }

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -24,6 +24,7 @@ export * from "./sync-comment-tags";
 export * from "./update-agent-contact";
 export * from "./update-leads";
 export * from "./write-agent-registration";
+export * from "./write-event";
 export * from "./write-opportunity-contact-comment";
 export * from "./write-opportunity-legacy";
 export * from "./write-volunteer-legacy";

--- a/src/server/utils/data/write-event.ts
+++ b/src/server/utils/data/write-event.ts
@@ -1,24 +1,35 @@
 import { ApiEventN4DCreate } from "need4deed-sdk";
+import { BadRequestError } from "../../../config";
 import { dataSource } from "../../../data/data-source";
 import EventTranslation from "../../../data/entity/event/event_translation.entity";
 import EventN4D from "../../../data/entity/event/event.entity";
-import Language from "../../../data/entity/profile/language.entity";
 import { getRepository } from "../../../data/utils";
+import { getLanguageIdByIsoCode } from "./get-language-title";
 
 // POST /event (be#904): one EventN4D row (structural fields) + one
 // EventTranslation row per submitted language, in a transaction.
 export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
+  const languages = input.translations.map((t) => t.language);
+  if (new Set(languages).size !== languages.length) {
+    throw new BadRequestError(
+      "Each translation must use a different language.",
+    );
+  }
+  if (input.dateEnd && new Date(input.dateEnd) <= new Date(input.date)) {
+    throw new BadRequestError("dateEnd must be after date.");
+  }
+
+  // Resolve each distinct language once — the event's own languageId reuses
+  // whichever id the first translation resolves to, rather than looking it
+  // up a second time.
+  const languageIds = new Map<string, number>();
+  for (const isoCode of new Set(languages)) {
+    languageIds.set(isoCode, await getLanguageIdByIsoCode(isoCode));
+  }
+
   return dataSource.manager.transaction(async (manager) => {
-    const languageRepository = getRepository(manager, Language);
     const eventRepository = getRepository(manager, EventN4D);
     const translationRepository = getRepository(manager, EventTranslation);
-
-    async function getLanguageId(isoCode: string): Promise<number> {
-      const language = await languageRepository.findOneOrFail({
-        where: { isoCode },
-      });
-      return language.id;
-    }
 
     const event = await eventRepository.save(
       new EventN4D({
@@ -36,16 +47,16 @@ export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
         hostName: input.hostName,
         // The language it was originally authored in — the first submitted
         // translation, by convention.
-        languageId: await getLanguageId(input.translations[0].language),
+        languageId: languageIds.get(input.translations[0].language),
       }),
     );
 
     await translationRepository.save(
-      await Promise.all(
-        input.translations.map(async (t) => {
-          return new EventTranslation({
+      input.translations.map(
+        (t) =>
+          new EventTranslation({
             eventn4dId: event.id,
-            languageId: await getLanguageId(t.language),
+            languageId: languageIds.get(t.language),
             title: t.title,
             subtitle: t.subTitle,
             menuTitle: t.menuTitle,
@@ -57,8 +68,7 @@ export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
             additionalInfo: t.additionalInfo,
             outro: t.outro,
             followupText: t.followUpText,
-          });
-        }),
+          }),
       ),
     );
 

--- a/src/server/utils/data/write-event.ts
+++ b/src/server/utils/data/write-event.ts
@@ -1,0 +1,67 @@
+import { ApiEventN4DCreate } from "need4deed-sdk";
+import { dataSource } from "../../../data/data-source";
+import EventTranslation from "../../../data/entity/event/event_translation.entity";
+import EventN4D from "../../../data/entity/event/event.entity";
+import Language from "../../../data/entity/profile/language.entity";
+import { getRepository } from "../../../data/utils";
+
+// POST /event (be#904): one EventN4D row (structural fields) + one
+// EventTranslation row per submitted language, in a transaction.
+export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
+  return dataSource.manager.transaction(async (manager) => {
+    const languageRepository = getRepository(manager, Language);
+    const eventRepository = getRepository(manager, EventN4D);
+    const translationRepository = getRepository(manager, EventTranslation);
+
+    async function getLanguageId(isoCode: string): Promise<number> {
+      const language = await languageRepository.findOneOrFail({
+        where: { isoCode },
+      });
+      return language.id;
+    }
+
+    const event = await eventRepository.save(
+      new EventN4D({
+        // Matches the entity's own column default (false) — a created event
+        // starts as a draft unless the coordinator explicitly publishes it.
+        isActive: input.active ?? false,
+        date: new Date(input.date),
+        dateEnd: input.dateEnd ? new Date(input.dateEnd) : undefined,
+        type: input.type,
+        pic: input.pic,
+        locationLink: input.locationLink,
+        rsvpLink: input.linkRSVP,
+        followupLink: input.followUpLink,
+        address: input.address,
+        hostName: input.hostName,
+        // The language it was originally authored in — the first submitted
+        // translation, by convention.
+        languageId: await getLanguageId(input.translations[0].language),
+      }),
+    );
+
+    await translationRepository.save(
+      await Promise.all(
+        input.translations.map(async (t) => {
+          return new EventTranslation({
+            eventn4dId: event.id,
+            languageId: await getLanguageId(t.language),
+            title: t.title,
+            subtitle: t.subTitle,
+            menuTitle: t.menuTitle,
+            timeStr: t.time,
+            locationComment: t.locationComment,
+            description: t.description,
+            shortDescription: t.shortDescription,
+            additionalTitle: t.additionalTitle,
+            additionalInfo: t.additionalInfo,
+            outro: t.outro,
+            followupText: t.followUpText,
+          });
+        }),
+      ),
+    );
+
+    return event;
+  });
+}

--- a/src/services/dto/dto-event.ts
+++ b/src/services/dto/dto-event.ts
@@ -1,4 +1,4 @@
-import { ApiEventN4DGetList, Lang } from "need4deed-sdk";
+import { ApiEventN4DGet, ApiEventN4DGetList, Lang } from "need4deed-sdk";
 import EventN4D from "../../data/entity/event/event.entity";
 
 // Resolves the translation matching the requested language; falls back to
@@ -55,5 +55,31 @@ export function dtoEventN4DGetList(
     linkRSVP: event.rsvpLink,
     additionalTitle: translation?.additionalTitle,
     additionalInfo: sanitizeAdditionalInfo(translation?.additionalInfo),
+  };
+}
+
+// Full detail shape (SDK ApiEventN4DGet), adding the fields ApiEventN4DGetList
+// doesn't carry. Used by POST /event's response (be#904) — no GET /event/:id
+// exists yet, but the SDK type is already the right shape for "give the
+// caller back everything they just submitted".
+export function dtoEventN4DGet(
+  event: EventN4D,
+  language: Lang,
+  isPrivileged: boolean,
+): ApiEventN4DGet | null {
+  const list = dtoEventN4DGetList(event, language, isPrivileged);
+  if (!list) {
+    return null;
+  }
+  const translation = resolveTranslation(event, language);
+
+  return {
+    ...list,
+    hostName: event.hostName,
+    time: translation?.timeStr,
+    locationLink: event.locationLink,
+    followUpText: translation?.followupText,
+    followUpLink: event.followupLink,
+    outro: translation?.outro,
   };
 }

--- a/src/test/server/routes/event-create.routes.test.ts
+++ b/src/test/server/routes/event-create.routes.test.ts
@@ -110,13 +110,16 @@ describe("POST /event", () => {
     await fastify.close();
   });
 
-  it("creates the base row + one translation row for a single language, defaulting to inactive", async () => {
+  it("creates the base row + one translation row for a single language, defaulting to inactive, echoing back the full detail shape", async () => {
     const res = await fastify.inject({
       method: "POST",
       url: "/event",
       cookies: { [accessCookieName]: coordinatorCookie },
       payload: {
         ...baseBody,
+        hostName: "Du für Berlin",
+        locationLink: "https://maps.example/pin",
+        followUpLink: "https://need4deed.org/next-event",
         translations: [
           {
             language: "de",
@@ -124,6 +127,9 @@ describe("POST /event", () => {
             menuTitle: "Sommerfest",
             description: "Wir feiern zusammen.",
             shortDescription: "Wir feiern.",
+            time: "13:00-18:00",
+            outro: "Bis bald!",
+            followUpText: "Nächstes Event",
           },
         ],
       },
@@ -134,6 +140,14 @@ describe("POST /event", () => {
     createdEventIds.push(data.id);
     expect(data.title).toBe("Sommerfest");
     expect(data.active).toBe(false);
+    // Fields ApiEventN4DGetList doesn't carry, only ApiEventN4DGet does —
+    // must round-trip through the create response.
+    expect(data.hostName).toBe("Du für Berlin");
+    expect(data.locationLink).toBe("https://maps.example/pin");
+    expect(data.followUpLink).toBe("https://need4deed.org/next-event");
+    expect(data.time).toBe("13:00-18:00");
+    expect(data.outro).toBe("Bis bald!");
+    expect(data.followUpText).toBe("Nächstes Event");
 
     const translations = await getRepository(dataSource, EventTranslation).find(
       { where: { eventn4dId: data.id } },
@@ -209,6 +223,58 @@ describe("POST /event", () => {
       url: "/event",
       cookies: { [accessCookieName]: coordinatorCookie },
       payload: { ...baseBody, translations: [] },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects two translations for the same language", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        ...baseBody,
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+          {
+            language: "de",
+            title: "Sommerfest 2",
+            menuTitle: "Sommerfest 2",
+            description: "Nochmal.",
+            shortDescription: "Nochmal.",
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects dateEnd at or before date", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        ...baseBody,
+        dateEnd: baseBody.date,
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+        ],
+      },
     });
 
     expect(res.statusCode).toBe(400);

--- a/src/test/server/routes/event-create.routes.test.ts
+++ b/src/test/server/routes/event-create.routes.test.ts
@@ -1,0 +1,216 @@
+import { FastifyInstance } from "fastify";
+import { EventN4DType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import { dataSource } from "../../../data/data-source";
+import EventTranslation from "../../../data/entity/event/event_translation.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { getRepository, hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("POST /event", () => {
+  let fastify: FastifyInstance;
+
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let volunteerPerson: Person;
+  let volunteerCookie: string;
+
+  const createdEventIds: number[] = [];
+
+  const baseBody = {
+    date: "2026-09-01T13:00:00+02:00",
+    type: EventN4DType.PARTY,
+    linkRSVP: "https://forms.example/rsvp",
+    address: "Elsenstraße 87, Berlin",
+  };
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const pwHash = await hashPassword(PASSWORD);
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const coordinatorLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(
+      coordinatorLoginRes.cookies,
+      accessCookieName,
+    );
+
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.VOLUNTEER,
+        isActive: true,
+        personId: volunteerPerson.id,
+      }),
+    );
+    const volunteerLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    volunteerCookie = getCookie(volunteerLoginRes.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    const eventTranslationRepository = getRepository(
+      dataSource,
+      EventTranslation,
+    );
+    for (const id of createdEventIds) {
+      await eventTranslationRepository.delete({ eventn4dId: id });
+    }
+    await fastify.db.eventRepository.delete(createdEventIds);
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.userRepository.delete({ personId: volunteerPerson.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.close();
+  });
+
+  it("creates the base row + one translation row for a single language, defaulting to inactive", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        ...baseBody,
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const { data } = res.json();
+    createdEventIds.push(data.id);
+    expect(data.title).toBe("Sommerfest");
+    expect(data.active).toBe(false);
+
+    const translations = await getRepository(dataSource, EventTranslation).find(
+      { where: { eventn4dId: data.id } },
+    );
+    expect(translations).toHaveLength(1);
+  });
+
+  it("creates one translation row per submitted language, and respects an explicit active:true", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        ...baseBody,
+        active: true,
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+          {
+            language: "en",
+            title: "Summer Party",
+            menuTitle: "Summer Party",
+            description: "We celebrate together.",
+            shortDescription: "We celebrate.",
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const { data } = res.json();
+    createdEventIds.push(data.id);
+    expect(data.active).toBe(true);
+    // Response echoes back in the first submitted language.
+    expect(data.title).toBe("Sommerfest");
+
+    const translations = await getRepository(dataSource, EventTranslation).find(
+      { where: { eventn4dId: data.id } },
+    );
+    expect(translations).toHaveLength(2);
+  });
+
+  it("rejects a non-coordinator", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event",
+      cookies: { [accessCookieName]: volunteerCookie },
+      payload: {
+        ...baseBody,
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("requires at least one entry in translations", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { ...baseBody, translations: [] },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- \`POST /event\`, \`fastify.authenticate({ role: UserRole.COORDINATOR })\`.
- Body: \`ApiEventN4DCreate\` (\`need4deed-sdk@0.0.146\`) — structural fields plus \`translations: ApiEventN4DTranslationInput[]\` (at least one, enforced via the request schema's \`minItems\` rather than application code).
- New \`write-event.ts\`: \`createEvent()\` writes one \`EventN4D\` row + one \`EventTranslation\` row per submitted language in a single transaction.
- **Naming deviation from the issue text**: this issue originally suggested \`parser-event.ts\`, but since the function actually performs the DB write (not just an input→entity transform), I put it in \`src/server/utils/data/write-event.ts\` instead, matching \`write-agent-registration.ts\`'s existing convention (\`write-*.ts\` = does I/O, \`parser-*.ts\` under \`services/dto/\` = pure transform).
- \`active\` defaults to \`false\` (matching \`EventN4D.isActive\`'s own column default), not \`true\` — a created event starts as a draft unless the coordinator explicitly publishes it, consistent with why a coordinator can see inactive events at all (be#903).
- Response reuses GET /event's \`dtoEventN4DGetList\`/\`eventItemSchema\`, echoing back in whichever language was submitted first.
- New \`eventCreateBodySchema\`/\`eventCreateResponseSchema\` (\`event.schema.ts\`), inline like the rest of this file, per the discussion on #907.

## Related
Part of epic #458.

## Checklist
- [x] \`yarn typecheck\` / \`yarn lint\` clean on touched files
- [x] Tests added (\`event-create.routes.test.ts\`): single-language create (defaults inactive), multi-language create (respects explicit \`active: true\`), rejects non-coordinator, rejects empty \`translations\`
- [x] Full suite green: 87 files / 735 tests