### PR TITLE
feat: PATCH /event/:id — coordinator update (be#905)

### DIFF
--- a/src/data/entity/event/event_translation.entity.ts
+++ b/src/data/entity/event/event_translation.entity.ts
@@ -4,11 +4,16 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Unique,
 } from "typeorm";
 import Language from "../profile/language.entity";
 import EventN4D from "./event.entity";
 
+// One translation per (event, language) — be#905 review found the upsert in
+// write-event.ts was a find-then-insert with no DB-level guard, so a
+// concurrent PATCH race could silently create duplicates.
 @Entity()
+@Unique(["eventn4dId", "languageId"])
 export default class EventTranslation {
   constructor(event?: Partial<EventTranslation>) {
     if (event) {

--- a/src/data/migrations/1787521051623-add-unique-event-translation-language.ts
+++ b/src/data/migrations/1787521051623-add-unique-event-translation-language.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUniqueEventTranslationLanguage1787521051623
+  implements MigrationInterface
+{
+  name = "AddUniqueEventTranslationLanguage1787521051623";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Defensively drop any duplicate (eventn4d_id, language_id) rows a
+    // concurrent-PATCH race (be#905) may have already produced before
+    // enforcing uniqueness, keeping the lowest id.
+    await queryRunner.query(
+      `DELETE FROM "event_translation" a USING "event_translation" b WHERE a.id > b.id AND a.eventn4d_id = b.eventn4d_id AND a.language_id = b.language_id`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "event_translation" ADD CONSTRAINT "UQ_592ae4cbcb9092c02edd1a04106" UNIQUE ("eventn4d_id", "language_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "event_translation" DROP CONSTRAINT "UQ_592ae4cbcb9092c02edd1a04106"`,
+    );
+  }
+}

--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -3,6 +3,7 @@ import {
   ApiEventN4DCreate,
   ApiEventN4DGet,
   ApiEventN4DGetList,
+  ApiEventN4DPatch,
   Lang,
   UserRole,
 } from "need4deed-sdk";
@@ -12,10 +13,18 @@ import {
   eventCreateBodySchema,
   eventCreateResponseSchema,
   eventListResponseSchema,
+  eventPatchBodySchema,
+  idParamSchema,
   langQuerySchema,
+  responseSchema,
 } from "../schema";
-import { QuerystringEventGetList, ReplyData, ReplyDataCount } from "../types";
-import { createEvent, getLanguageCode } from "../utils";
+import {
+  ParamsId,
+  QuerystringEventGetList,
+  ReplyData,
+  ReplyDataCount,
+} from "../types";
+import { createEvent, getLanguageCode, updateEvent } from "../utils";
 
 export default async function eventRoutes(
   fastify: FastifyInstance,
@@ -97,6 +106,29 @@ export default async function eventRoutes(
       )!;
 
       return reply.status(201).send({ message: "Event created.", data });
+    },
+  );
+
+  // PATCH /event/:id — coordinator update (be#905). Structural fields are a
+  // plain partial update; translations is an upsert per (event, language) —
+  // see write-event.ts's updateEvent for the exact semantics.
+  fastify.patch<{
+    Params: ParamsId;
+    Body: ApiEventN4DPatch;
+    Reply: null;
+  }>(
+    "/:id",
+    {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
+      schema: {
+        params: idParamSchema,
+        body: eventPatchBodySchema,
+        response: responseSchema({ statusCode: 204 }),
+      },
+    },
+    async (request, reply) => {
+      await updateEvent(request.params.id, request.body);
+      return reply.status(204).send();
     },
   );
 }

--- a/src/server/schema/event.schema.ts
+++ b/src/server/schema/event.schema.ts
@@ -137,3 +137,34 @@ export const eventCreateResponseSchema = {
   },
   ...responseErrors,
 };
+
+// Body for PATCH /event/:id (SDK ApiEventN4DPatch). Everything's optional —
+// omitted = unchanged. Only the fields that are actually nullable columns
+// (dateEnd, pic, locationLink, followUpLink, hostName) accept null-to-clear;
+// date/type/linkRSVP/address/active reject null here even though the SDK's
+// VoidableProps type technically allows it, since those columns are
+// required and "clear this required field" isn't a meaningful request.
+// translations is a full-content upsert per language (see write-event.ts),
+// not a field-by-field patch — reuses the same item shape as create, so an
+// included entry still needs title/menuTitle/description/shortDescription.
+export const eventPatchBodySchema = {
+  type: "object",
+  properties: {
+    date: { type: "string", format: "date-time" },
+    dateEnd: { type: ["string", "null"], format: "date-time" },
+    type: { type: "string", enum: Object.values(EventN4DType) },
+    pic: { type: ["string", "null"] },
+    locationLink: { type: ["string", "null"] },
+    linkRSVP: { type: "string" },
+    followUpLink: { type: ["string", "null"] },
+    address: { type: "string", minLength: 1 },
+    hostName: { type: ["string", "null"] },
+    active: { type: "boolean" },
+    translations: {
+      type: "array",
+      items: eventTranslationInputSchema,
+      minItems: 1,
+    },
+  },
+  additionalProperties: false,
+};

--- a/src/server/utils/data/write-event.ts
+++ b/src/server/utils/data/write-event.ts
@@ -10,10 +10,7 @@ import EventN4D from "../../../data/entity/event/event.entity";
 import { getRepository } from "../../../data/utils";
 import { getLanguageIdByIsoCode } from "./get-language-title";
 
-function assertDistinctLanguages(
-  translations: ApiEventN4DTranslationInput[],
-): void {
-  const languages = translations.map((t) => t.language);
+function assertDistinctLanguages(languages: string[]): void {
   if (new Set(languages).size !== languages.length) {
     throw new BadRequestError(
       "Each translation must use a different language.",
@@ -21,42 +18,55 @@ function assertDistinctLanguages(
   }
 }
 
-// Shared between create and update — an entry in `translations` is always a
-// full representation of that language's content, not a field-by-field
-// patch, so both paths map it the same way.
+// Resolves each distinct submitted language once, up front — shared by
+// create and update so neither issues a separate lookup per translation
+// (or a duplicate one for whichever language is reused elsewhere).
+async function resolveLanguageIds(
+  languages: string[],
+): Promise<Map<string, number>> {
+  const languageIds = new Map<string, number>();
+  for (const isoCode of new Set(languages)) {
+    languageIds.set(isoCode, await getLanguageIdByIsoCode(isoCode));
+  }
+  return languageIds;
+}
+
+// An entry in `translations` is always a full representation of that
+// language's content, never a field-by-field patch — so replacing an
+// existing row must explicitly clear any optional field the caller omitted.
+// `?? null` (not left as undefined) matters here: TypeORM's save() skips
+// undefined properties, so leaving these as undefined on an update would
+// silently keep the old value instead of clearing it (be#905 review).
 function translationFields(
   t: ApiEventN4DTranslationInput,
 ): Partial<EventTranslation> {
   return {
     title: t.title,
-    subtitle: t.subTitle,
+    subtitle: t.subTitle ?? null,
     menuTitle: t.menuTitle,
-    timeStr: t.time,
-    locationComment: t.locationComment,
+    timeStr: t.time ?? null,
+    locationComment: t.locationComment ?? null,
     description: t.description,
     shortDescription: t.shortDescription,
-    additionalTitle: t.additionalTitle,
-    additionalInfo: t.additionalInfo,
-    outro: t.outro,
-    followupText: t.followUpText,
+    additionalTitle: t.additionalTitle ?? null,
+    additionalInfo: t.additionalInfo ?? null,
+    outro: t.outro ?? null,
+    followupText: t.followUpText ?? null,
   };
 }
 
 // POST /event (be#904): one EventN4D row (structural fields) + one
 // EventTranslation row per submitted language, in a transaction.
 export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
-  assertDistinctLanguages(input.translations);
+  const languages = input.translations.map((t) => t.language);
+  assertDistinctLanguages(languages);
   if (input.dateEnd && new Date(input.dateEnd) <= new Date(input.date)) {
     throw new BadRequestError("dateEnd must be after date.");
   }
 
-  // Resolve each distinct language once — the event's own languageId reuses
-  // whichever id the first translation resolves to, rather than looking it
-  // up a second time.
-  const languageIds = new Map<string, number>();
-  for (const isoCode of new Set(input.translations.map((t) => t.language))) {
-    languageIds.set(isoCode, await getLanguageIdByIsoCode(isoCode));
-  }
+  // The event's own languageId reuses whichever id the first translation
+  // resolves to, rather than looking it up a second time.
+  const languageIds = await resolveLanguageIds(languages);
 
   return dataSource.manager.transaction(async (manager) => {
     const eventRepository = getRepository(manager, EventN4D);
@@ -103,13 +113,16 @@ export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
 // required columns). translations is an upsert per (event, language): an
 // included entry replaces that language's row entirely if one exists,
 // otherwise inserts a new one; languages not mentioned are left untouched.
+// A unique (eventn4dId, languageId) DB constraint backs this — a concurrent
+// PATCH race on the same event+language surfaces as a conflict rather than
+// silently duplicating the row.
 export async function updateEvent(
   id: number,
   input: ApiEventN4DPatch,
 ): Promise<EventN4D> {
-  if (input.translations) {
-    assertDistinctLanguages(input.translations);
-  }
+  const languages = input.translations?.map((t) => t.language) ?? [];
+  assertDistinctLanguages(languages);
+  const languageIds = await resolveLanguageIds(languages);
 
   return dataSource.manager.transaction(async (manager) => {
     const eventRepository = getRepository(manager, EventN4D);
@@ -134,7 +147,11 @@ export async function updateEvent(
     Object.assign(event, {
       isActive: input.active,
       date: input.date ? new Date(input.date) : undefined,
-      dateEnd: effectiveDateEnd,
+      // Only rewritten when the caller actually touched it — effectiveDateEnd
+      // falls back to the existing value otherwise, and assigning that
+      // unchanged value would defeat TypeORM's undefined-skips-the-column
+      // behavior on save(), issuing a needless UPDATE of this column.
+      dateEnd: input.dateEnd !== undefined ? effectiveDateEnd : undefined,
       type: input.type,
       pic: input.pic,
       locationLink: input.locationLink,
@@ -146,7 +163,7 @@ export async function updateEvent(
     await eventRepository.save(event);
 
     for (const t of input.translations ?? []) {
-      const languageId = await getLanguageIdByIsoCode(t.language);
+      const languageId = languageIds.get(t.language);
       const existing = await translationRepository.findOneBy({
         eventn4dId: id,
         languageId,

--- a/src/server/utils/data/write-event.ts
+++ b/src/server/utils/data/write-event.ts
@@ -1,20 +1,51 @@
-import { ApiEventN4DCreate } from "need4deed-sdk";
-import { BadRequestError } from "../../../config";
+import {
+  ApiEventN4DCreate,
+  ApiEventN4DPatch,
+  ApiEventN4DTranslationInput,
+} from "need4deed-sdk";
+import { BadRequestError, NotFoundError } from "../../../config";
 import { dataSource } from "../../../data/data-source";
 import EventTranslation from "../../../data/entity/event/event_translation.entity";
 import EventN4D from "../../../data/entity/event/event.entity";
 import { getRepository } from "../../../data/utils";
 import { getLanguageIdByIsoCode } from "./get-language-title";
 
-// POST /event (be#904): one EventN4D row (structural fields) + one
-// EventTranslation row per submitted language, in a transaction.
-export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
-  const languages = input.translations.map((t) => t.language);
+function assertDistinctLanguages(
+  translations: ApiEventN4DTranslationInput[],
+): void {
+  const languages = translations.map((t) => t.language);
   if (new Set(languages).size !== languages.length) {
     throw new BadRequestError(
       "Each translation must use a different language.",
     );
   }
+}
+
+// Shared between create and update — an entry in `translations` is always a
+// full representation of that language's content, not a field-by-field
+// patch, so both paths map it the same way.
+function translationFields(
+  t: ApiEventN4DTranslationInput,
+): Partial<EventTranslation> {
+  return {
+    title: t.title,
+    subtitle: t.subTitle,
+    menuTitle: t.menuTitle,
+    timeStr: t.time,
+    locationComment: t.locationComment,
+    description: t.description,
+    shortDescription: t.shortDescription,
+    additionalTitle: t.additionalTitle,
+    additionalInfo: t.additionalInfo,
+    outro: t.outro,
+    followupText: t.followUpText,
+  };
+}
+
+// POST /event (be#904): one EventN4D row (structural fields) + one
+// EventTranslation row per submitted language, in a transaction.
+export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
+  assertDistinctLanguages(input.translations);
   if (input.dateEnd && new Date(input.dateEnd) <= new Date(input.date)) {
     throw new BadRequestError("dateEnd must be after date.");
   }
@@ -23,7 +54,7 @@ export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
   // whichever id the first translation resolves to, rather than looking it
   // up a second time.
   const languageIds = new Map<string, number>();
-  for (const isoCode of new Set(languages)) {
+  for (const isoCode of new Set(input.translations.map((t) => t.language))) {
     languageIds.set(isoCode, await getLanguageIdByIsoCode(isoCode));
   }
 
@@ -57,20 +88,80 @@ export async function createEvent(input: ApiEventN4DCreate): Promise<EventN4D> {
           new EventTranslation({
             eventn4dId: event.id,
             languageId: languageIds.get(t.language),
-            title: t.title,
-            subtitle: t.subTitle,
-            menuTitle: t.menuTitle,
-            timeStr: t.time,
-            locationComment: t.locationComment,
-            description: t.description,
-            shortDescription: t.shortDescription,
-            additionalTitle: t.additionalTitle,
-            additionalInfo: t.additionalInfo,
-            outro: t.outro,
-            followupText: t.followUpText,
+            ...translationFields(t),
           }),
       ),
     );
+
+    return event;
+  });
+}
+
+// PATCH /event/:id (be#905): structural fields are a plain partial update
+// (omitted = unchanged; explicit null clears a nullable one — date/type/
+// linkRSVP/address/active reject null at the schema level since they're
+// required columns). translations is an upsert per (event, language): an
+// included entry replaces that language's row entirely if one exists,
+// otherwise inserts a new one; languages not mentioned are left untouched.
+export async function updateEvent(
+  id: number,
+  input: ApiEventN4DPatch,
+): Promise<EventN4D> {
+  if (input.translations) {
+    assertDistinctLanguages(input.translations);
+  }
+
+  return dataSource.manager.transaction(async (manager) => {
+    const eventRepository = getRepository(manager, EventN4D);
+    const translationRepository = getRepository(manager, EventTranslation);
+
+    const event = await eventRepository.findOneBy({ id });
+    if (!event) {
+      throw new NotFoundError(`Event (id:${id}) not found.`);
+    }
+
+    const effectiveDate = input.date ? new Date(input.date) : event.date;
+    const effectiveDateEnd =
+      input.dateEnd === null
+        ? null
+        : input.dateEnd !== undefined
+          ? new Date(input.dateEnd)
+          : event.dateEnd;
+    if (effectiveDateEnd && effectiveDateEnd <= effectiveDate) {
+      throw new BadRequestError("dateEnd must be after date.");
+    }
+
+    Object.assign(event, {
+      isActive: input.active,
+      date: input.date ? new Date(input.date) : undefined,
+      dateEnd: effectiveDateEnd,
+      type: input.type,
+      pic: input.pic,
+      locationLink: input.locationLink,
+      rsvpLink: input.linkRSVP,
+      followupLink: input.followUpLink,
+      address: input.address,
+      hostName: input.hostName,
+    });
+    await eventRepository.save(event);
+
+    for (const t of input.translations ?? []) {
+      const languageId = await getLanguageIdByIsoCode(t.language);
+      const existing = await translationRepository.findOneBy({
+        eventn4dId: id,
+        languageId,
+      });
+
+      await translationRepository.save(
+        existing
+          ? Object.assign(existing, translationFields(t))
+          : new EventTranslation({
+              eventn4dId: id,
+              languageId,
+              ...translationFields(t),
+            }),
+      );
+    }
 
     return event;
   });

--- a/src/test/server/routes/event-patch.routes.test.ts
+++ b/src/test/server/routes/event-patch.routes.test.ts
@@ -1,0 +1,306 @@
+import { FastifyInstance } from "fastify";
+import { EventN4DType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import { dataSource } from "../../../data/data-source";
+import EventTranslation from "../../../data/entity/event/event_translation.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { getRepository, hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("PATCH /event/:id", () => {
+  let fastify: FastifyInstance;
+
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let volunteerPerson: Person;
+  let volunteerCookie: string;
+
+  const createdEventIds: number[] = [];
+
+  const baseBody = {
+    date: "2026-09-01T13:00:00+02:00",
+    type: EventN4DType.PARTY,
+    linkRSVP: "https://forms.example/rsvp",
+    address: "Elsenstraße 87, Berlin",
+  };
+
+  async function createTestEvent(): Promise<number> {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        ...baseBody,
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+        ],
+      },
+    });
+    const id = res.json().data.id;
+    createdEventIds.push(id);
+    return id;
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const pwHash = await hashPassword(PASSWORD);
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const coordinatorLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(
+      coordinatorLoginRes.cookies,
+      accessCookieName,
+    );
+
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.VOLUNTEER,
+        isActive: true,
+        personId: volunteerPerson.id,
+      }),
+    );
+    const volunteerLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    volunteerCookie = getCookie(volunteerLoginRes.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    const eventTranslationRepository = getRepository(
+      dataSource,
+      EventTranslation,
+    );
+    for (const id of createdEventIds) {
+      await eventTranslationRepository.delete({ eventn4dId: id });
+    }
+    await fastify.db.eventRepository.delete(createdEventIds);
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.userRepository.delete({ personId: volunteerPerson.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.close();
+  });
+
+  it("updates structural fields only, leaving existing translations untouched", async () => {
+    const id = await createTestEvent();
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { active: true },
+    });
+
+    expect(res.statusCode).toBe(204);
+
+    const event = await fastify.db.eventRepository.findOneByOrFail({ id });
+    expect(event.isActive).toBe(true);
+
+    const translations = await getRepository(dataSource, EventTranslation).find(
+      { where: { eventn4dId: id } },
+    );
+    expect(translations).toHaveLength(1);
+    expect(translations[0].title).toBe("Sommerfest");
+  });
+
+  it("updates an existing language's translation in place", async () => {
+    const id = await createTestEvent();
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest (aktualisiert)",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(204);
+
+    const translations = await getRepository(dataSource, EventTranslation).find(
+      { where: { eventn4dId: id } },
+    );
+    expect(translations).toHaveLength(1);
+    expect(translations[0].title).toBe("Sommerfest (aktualisiert)");
+  });
+
+  it("adds a new language's translation without touching the existing one", async () => {
+    const id = await createTestEvent();
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        translations: [
+          {
+            language: "en",
+            title: "Summer Party",
+            menuTitle: "Summer Party",
+            description: "We celebrate together.",
+            shortDescription: "We celebrate.",
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(204);
+
+    const translations = await getRepository(dataSource, EventTranslation).find(
+      { where: { eventn4dId: id } },
+    );
+    expect(translations).toHaveLength(2);
+    const de = translations.find((t) => t.title === "Sommerfest");
+    const en = translations.find((t) => t.title === "Summer Party");
+    expect(de).toBeDefined();
+    expect(en).toBeDefined();
+  });
+
+  it("clears a nullable field via explicit null", async () => {
+    const id = await createTestEvent();
+    await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { pic: "event.webp" },
+    });
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { pic: null },
+    });
+
+    expect(res.statusCode).toBe(204);
+    const event = await fastify.db.eventRepository.findOneByOrFail({ id });
+    expect(event.pic).toBeNull();
+  });
+
+  it("rejects a non-coordinator", async () => {
+    const id = await createTestEvent();
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: volunteerCookie },
+      payload: { active: true },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("404s a nonexistent id", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: "/event/999999999",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { active: true },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects two translations for the same language", async () => {
+    const id = await createTestEvent();
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        translations: [
+          {
+            language: "en",
+            title: "One",
+            menuTitle: "One",
+            description: "One.",
+            shortDescription: "One.",
+          },
+          {
+            language: "en",
+            title: "Two",
+            menuTitle: "Two",
+            description: "Two.",
+            shortDescription: "Two.",
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a dateEnd that isn't after the (possibly unchanged) date", async () => {
+    const id = await createTestEvent();
+
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { dateEnd: baseBody.date },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/src/test/server/routes/event-patch.routes.test.ts
+++ b/src/test/server/routes/event-patch.routes.test.ts
@@ -184,6 +184,54 @@ describe("PATCH /event/:id", () => {
     expect(translations[0].title).toBe("Sommerfest (aktualisiert)");
   });
 
+  it("clears an omitted optional translation field instead of leaving it stale", async () => {
+    const id = await createTestEvent();
+
+    await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+            outro: "Bis bald!",
+          },
+        ],
+      },
+    });
+
+    // Same language, same required fields, but outro omitted this time —
+    // the entry replaces the row entirely, so outro must clear, not survive.
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(204);
+    const translations = await getRepository(dataSource, EventTranslation).find(
+      { where: { eventn4dId: id } },
+    );
+    expect(translations).toHaveLength(1);
+    expect(translations[0].outro).toBeNull();
+  });
+
   it("adds a new language's translation without touching the existing one", async () => {
     const id = await createTestEvent();
 
@@ -302,5 +350,31 @@ describe("PATCH /event/:id", () => {
     });
 
     expect(res.statusCode).toBe(400);
+  });
+
+  // be#905 review: the upsert is a find-then-insert with no locking, so a
+  // concurrent race could otherwise create two rows for one (event,
+  // language) pair. This proves the DB-level backstop (not the app-level
+  // duplicate-language check above, which only catches it within one
+  // request) actually rejects that at the database.
+  it("has a DB-level unique constraint on (event, language) backing the upsert", async () => {
+    const id = await createTestEvent();
+    const translationRepository = getRepository(dataSource, EventTranslation);
+    const de = await translationRepository.findOneByOrFail({
+      eventn4dId: id,
+    });
+
+    await expect(
+      translationRepository.save(
+        new EventTranslation({
+          eventn4dId: id,
+          languageId: de.languageId,
+          title: "Duplicate",
+          menuTitle: "Duplicate",
+          description: "Duplicate.",
+          shortDescription: "Duplicate.",
+        }),
+      ),
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- \`PATCH /event/:id\`, \`fastify.authenticate({ role: UserRole.COORDINATOR })\`, \`204 No Content\` on success — matches this repo's dominant PATCH convention (agent, opportunity, organization all do the same).
- Body: \`ApiEventN4DPatch\` (\`need4deed-sdk@0.0.146\`). Structural fields are a plain partial update: omitted = unchanged, explicit \`null\` clears a nullable column. \`date\`/\`type\`/\`linkRSVP\`/\`address\`/\`active\` reject \`null\` in the schema even though the SDK's \`VoidableProps\` type technically allows it — those are required columns, and "clear this required field" isn't a meaningful request.
- \`translations\` is an upsert per \`(event, language)\`: an included entry replaces that language's \`EventTranslation\` row entirely if one exists, otherwise inserts a new one; languages not mentioned are left untouched — per the issue's stated design.
- Extracted \`translationFields\`/\`assertDistinctLanguages\` in \`write-event.ts\`, shared with \`createEvent\` (be#904) rather than duplicated.
- \`dateEnd\`/\`date\` cross-validation accounts for partial updates — compares the *effective* date/dateEnd (patch value if given, otherwise the existing row's), since either one may be omitted from the request.

## Related
Part of epic #458.

## Checklist
- [x] \`yarn typecheck\` / \`yarn lint\` clean on touched files
- [x] Tests added (\`event-patch.routes.test.ts\`): structural-only patch leaves translations untouched, updates an existing language in place, adds a new language without touching others, clears a nullable field via explicit null, rejects non-coordinator, 404s a nonexistent id, rejects duplicate languages, rejects an invalid date range
- [x] Full suite green: 88 files / 745 tests