### PR TITLE
feat: DELETE /event/:id — coordinator delete (be#906)

### DIFF
--- a/src/server/routes/event.routes.ts
+++ b/src/server/routes/event.routes.ts
@@ -23,6 +23,7 @@ import {
   QuerystringEventGetList,
   ReplyData,
   ReplyDataCount,
+  ReplyMessage,
 } from "../types";
 import { createEvent, getLanguageCode, updateEvent } from "../utils";
 
@@ -129,6 +130,39 @@ export default async function eventRoutes(
     async (request, reply) => {
       await updateEvent(request.params.id, request.body);
       return reply.status(204).send();
+    },
+  );
+
+  // DELETE /event/:id — coordinator delete (be#906). A real row delete
+  // (cascades to EventTranslation via the entity's onDelete: "CASCADE"),
+  // not a soft-deactivate — PATCH /event/:id { active: false } already
+  // covers "hide without losing data", so DELETE stays a distinct,
+  // standard-REST "remove it" rather than a second way to do the same
+  // thing. Matches the DELETE /agent/:id convention (200 + message, not
+  // 204 — this repo's PATCH/DELETE conventions differ).
+  fastify.delete<{ Params: ParamsId; Reply: ReplyMessage }>(
+    "/:id",
+    {
+      onRequest: fastify.authenticate({ role: UserRole.COORDINATOR }),
+      schema: {
+        params: idParamSchema,
+        response: responseSchema(""),
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const eventRepository = fastify.db.eventRepository;
+      const event = await eventRepository.findOneBy({ id });
+
+      if (!event) {
+        throw new NotFoundError(`Event (id:${id}) not found.`);
+      }
+
+      await eventRepository.delete({ id });
+
+      return reply.status(200).send({
+        message: `Event (id:${id}) deleted successfully`,
+      });
     },
   );
 }

--- a/src/test/server/routes/event-delete.routes.test.ts
+++ b/src/test/server/routes/event-delete.routes.test.ts
@@ -57,6 +57,11 @@ describe("DELETE /event/:id", () => {
         ],
       },
     });
+    if (res.statusCode !== 201) {
+      throw new Error(
+        `createTestEvent fixture setup failed: ${res.statusCode} ${res.body}`,
+      );
+    }
     const id = res.json().data.id;
     createdEventIds.push(id);
     return id;
@@ -118,15 +123,9 @@ describe("DELETE /event/:id", () => {
   });
 
   afterAll(async () => {
-    // Only cleans up events NOT already deleted by the tests themselves —
-    // delete() on an already-gone id is a harmless no-op.
-    const eventTranslationRepository = getRepository(
-      dataSource,
-      EventTranslation,
-    );
-    for (const id of createdEventIds) {
-      await eventTranslationRepository.delete({ eventn4dId: id });
-    }
+    // No separate EventTranslation cleanup needed — the FK's ON DELETE
+    // CASCADE handles it, and delete() on an already-gone id (events the
+    // tests themselves deleted) is a harmless no-op.
     await fastify.db.eventRepository.delete(createdEventIds);
     await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
     await fastify.db.personRepository.delete({ id: coordinatorPerson.id });

--- a/src/test/server/routes/event-delete.routes.test.ts
+++ b/src/test/server/routes/event-delete.routes.test.ts
@@ -1,0 +1,182 @@
+import { FastifyInstance } from "fastify";
+import { EventN4DType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import { dataSource } from "../../../data/data-source";
+import EventTranslation from "../../../data/entity/event/event_translation.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { getRepository, hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+describe("DELETE /event/:id", () => {
+  let fastify: FastifyInstance;
+
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let volunteerPerson: Person;
+  let volunteerCookie: string;
+
+  const createdEventIds: number[] = [];
+
+  const baseBody = {
+    date: "2026-09-01T13:00:00+02:00",
+    type: EventN4DType.PARTY,
+    linkRSVP: "https://forms.example/rsvp",
+    address: "Elsenstraße 87, Berlin",
+  };
+
+  async function createTestEvent(): Promise<number> {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/event",
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: {
+        ...baseBody,
+        translations: [
+          {
+            language: "de",
+            title: "Sommerfest",
+            menuTitle: "Sommerfest",
+            description: "Wir feiern zusammen.",
+            shortDescription: "Wir feiern.",
+          },
+        ],
+      },
+    });
+    const id = res.json().data.id;
+    createdEventIds.push(id);
+    return id;
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const pwHash = await hashPassword(PASSWORD);
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const coordinatorLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    coordinatorCookie = getCookie(
+      coordinatorLoginRes.cookies,
+      accessCookieName,
+    );
+
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.VOLUNTEER,
+        isActive: true,
+        personId: volunteerPerson.id,
+      }),
+    );
+    const volunteerLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: PASSWORD,
+      },
+    });
+    volunteerCookie = getCookie(volunteerLoginRes.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    // Only cleans up events NOT already deleted by the tests themselves —
+    // delete() on an already-gone id is a harmless no-op.
+    const eventTranslationRepository = getRepository(
+      dataSource,
+      EventTranslation,
+    );
+    for (const id of createdEventIds) {
+      await eventTranslationRepository.delete({ eventn4dId: id });
+    }
+    await fastify.db.eventRepository.delete(createdEventIds);
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.userRepository.delete({ personId: volunteerPerson.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    await fastify.close();
+  });
+
+  it("deletes the event row and cascades to its translations", async () => {
+    const id = await createTestEvent();
+
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const event = await fastify.db.eventRepository.findOneBy({ id });
+    expect(event).toBeNull();
+
+    const translations = await getRepository(dataSource, EventTranslation).find(
+      { where: { eventn4dId: id } },
+    );
+    expect(translations).toHaveLength(0);
+  });
+
+  it("rejects a non-coordinator", async () => {
+    const id = await createTestEvent();
+
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: `/event/${id}`,
+      cookies: { [accessCookieName]: volunteerCookie },
+    });
+
+    expect(res.statusCode).toBe(403);
+
+    const event = await fastify.db.eventRepository.findOneBy({ id });
+    expect(event).not.toBeNull();
+  });
+
+  it("404s a nonexistent id", async () => {
+    const res = await fastify.inject({
+      method: "DELETE",
+      url: "/event/999999999",
+      cookies: { [accessCookieName]: coordinatorCookie },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- \`DELETE /event/:id\`, \`fastify.authenticate({ role: UserRole.COORDINATOR })\`.
- **Design decision (confirmed before implementing, per the issue's own flag): hard delete, not soft-deactivate.** \`PATCH /event/:id { active: false }\` (be#905) already covers "hide without losing data" — a soft-delete DELETE would just be a second way to do the same thing. This is a real row delete, cascading to \`EventTranslation\` via the entity's existing \`onDelete: "CASCADE"\`.
- Mirrors \`DELETE /agent/:id\`'s exact shape — inline in the route (no separate \`write-event.ts\` helper needed for a plain existence-check + delete) and its \`200 + { message }\` response convention (this repo's DELETE and PATCH conventions differ: 200/message vs 204/no-body — this follows DELETE's).

## Related
Closes epic #458 — this is the last of its 4 sub-issues.

## Checklist
- [x] \`yarn typecheck\` / \`yarn lint\` clean on touched files
- [x] Tests added (\`event-delete.routes.test.ts\`): deletes the row and cascades to translations, rejects non-coordinator, 404s a nonexistent id
- [x] Full suite green: 89 files / 750 tests