### PR TITLE
test: integration tests for agent registration and membership routes

### DIFF
--- a/src/test/server/routes/agent-membership.routes.test.ts
+++ b/src/test/server/routes/agent-membership.routes.test.ts
@@ -1,0 +1,272 @@
+import { FastifyInstance } from "fastify";
+import { AgentMembershipStatus, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+// be#652: GET/PATCH/DELETE /agent/membership had zero route-level coverage.
+describe("/agent/membership", () => {
+  let fastify: FastifyInstance;
+
+  const password = "test_password";
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let volunteerPerson: Person;
+  let volunteerCookie: string;
+
+  const createdPersonIds: number[] = [];
+  const createdAgentIds: number[] = [];
+  const createdMembershipIds: number[] = [];
+
+  async function makeMembership(
+    status: AgentMembershipStatus,
+  ): Promise<{ agent: Agent; person: Person; membership: AgentPerson }> {
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const agent = await fastify.db.agentRepository.save(
+      new Agent({ title: `Membership Test Agent ${suffix}` }),
+    );
+    createdAgentIds.push(agent.id);
+
+    const person = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Member" }),
+    );
+    createdPersonIds.push(person.id);
+
+    const membership = await fastify.db.agentPersonRepository.save(
+      new AgentPerson({ agentId: agent.id, personId: person.id, status }),
+    );
+    createdMembershipIds.push(membership.id);
+
+    return { agent, person, membership };
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const pwHash = await hashPassword(password);
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const coordinatorLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `coordinator-${suffix}@test.need4deed.org`,
+        password,
+      },
+    });
+    coordinatorCookie = getCookie(
+      coordinatorLoginRes.cookies,
+      accessCookieName,
+    );
+
+    volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    await fastify.db.userRepository.save(
+      new User({
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.VOLUNTEER,
+        isActive: true,
+        personId: volunteerPerson.id,
+      }),
+    );
+    const volunteerLoginRes = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: {
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password,
+      },
+    });
+    volunteerCookie = getCookie(volunteerLoginRes.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    for (const id of createdMembershipIds) {
+      await fastify.db.agentPersonRepository.delete({ id });
+    }
+    for (const agentId of createdAgentIds) {
+      await fastify.db.agentRepository.delete({ id: agentId });
+    }
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.userRepository.delete({ personId: volunteerPerson.id });
+    await fastify.db.personRepository.delete({ id: volunteerPerson.id });
+    for (const personId of createdPersonIds) {
+      await fastify.db.personRepository.delete({ id: personId });
+    }
+    await fastify.close();
+  });
+
+  describe("GET /", () => {
+    it("defaults to listing PENDING memberships", async () => {
+      const { membership } = await makeMembership(
+        AgentMembershipStatus.PENDING,
+      );
+
+      const res = await fastify.inject({
+        method: "GET",
+        url: "/agent/membership",
+        cookies: { [accessCookieName]: coordinatorCookie },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const ids = res.json().data.map((m: { id: number }) => m.id);
+      expect(ids).toContain(membership.id);
+    });
+
+    it("lists ACTIVE memberships when status=active is passed", async () => {
+      const { membership } = await makeMembership(AgentMembershipStatus.ACTIVE);
+
+      const res = await fastify.inject({
+        method: "GET",
+        url: "/agent/membership?status=active",
+        cookies: { [accessCookieName]: coordinatorCookie },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const ids = res.json().data.map((m: { id: number }) => m.id);
+      expect(ids).toContain(membership.id);
+    });
+
+    it("rejects a non-coordinator", async () => {
+      const res = await fastify.inject({
+        method: "GET",
+        url: "/agent/membership",
+        cookies: { [accessCookieName]: volunteerCookie },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("rejects an unauthenticated caller", async () => {
+      const res = await fastify.inject({
+        method: "GET",
+        url: "/agent/membership",
+      });
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe("PATCH /:id", () => {
+    it("updates a membership's status", async () => {
+      const { membership } = await makeMembership(
+        AgentMembershipStatus.PENDING,
+      );
+
+      const res = await fastify.inject({
+        method: "PATCH",
+        url: `/agent/membership/${membership.id}`,
+        cookies: { [accessCookieName]: coordinatorCookie },
+        payload: { status: AgentMembershipStatus.ACTIVE },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const updated = await fastify.db.agentPersonRepository.findOneByOrFail({
+        id: membership.id,
+      });
+      expect(updated.status).toBe(AgentMembershipStatus.ACTIVE);
+    });
+
+    it("404s a nonexistent membership id", async () => {
+      const res = await fastify.inject({
+        method: "PATCH",
+        url: "/agent/membership/999999999",
+        cookies: { [accessCookieName]: coordinatorCookie },
+        payload: { status: AgentMembershipStatus.ACTIVE },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("rejects a non-coordinator", async () => {
+      const { membership } = await makeMembership(
+        AgentMembershipStatus.PENDING,
+      );
+
+      const res = await fastify.inject({
+        method: "PATCH",
+        url: `/agent/membership/${membership.id}`,
+        cookies: { [accessCookieName]: volunteerCookie },
+        payload: { status: AgentMembershipStatus.ACTIVE },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe("DELETE /:id", () => {
+    it("removes the membership", async () => {
+      const { membership } = await makeMembership(
+        AgentMembershipStatus.PENDING,
+      );
+
+      const res = await fastify.inject({
+        method: "DELETE",
+        url: `/agent/membership/${membership.id}`,
+        cookies: { [accessCookieName]: coordinatorCookie },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const gone = await fastify.db.agentPersonRepository.findOneBy({
+        id: membership.id,
+      });
+      expect(gone).toBeNull();
+    });
+
+    it("404s a nonexistent membership id", async () => {
+      const res = await fastify.inject({
+        method: "DELETE",
+        url: "/agent/membership/999999999",
+        cookies: { [accessCookieName]: coordinatorCookie },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("rejects a non-coordinator", async () => {
+      const { membership } = await makeMembership(
+        AgentMembershipStatus.PENDING,
+      );
+
+      const res = await fastify.inject({
+        method: "DELETE",
+        url: `/agent/membership/${membership.id}`,
+        cookies: { [accessCookieName]: volunteerCookie },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+});

--- a/src/test/server/routes/agent-register-search.routes.test.ts
+++ b/src/test/server/routes/agent-register-search.routes.test.ts
@@ -17,6 +17,7 @@ describe("GET /agent/register/search", () => {
   let token: string;
   let activeAgent: Agent;
   let inactiveAgent: Agent;
+  let unclaimedAgent: Agent;
 
   beforeAll(async () => {
     fastify = await createServer();
@@ -54,14 +55,57 @@ describe("GET /agent/register/search", () => {
         engagementStatus: AgentEngagementStatusType.INACTIVE,
       }),
     );
+    unclaimedAgent = await fastify.db.agentRepository.save(
+      new Agent({
+        title: `Findable Unclaimed NGO ${suffix}`,
+        unclaimed: true,
+      }),
+    );
   });
 
   afterAll(async () => {
     await fastify.db.agentRepository.delete({ id: activeAgent.id });
     await fastify.db.agentRepository.delete({ id: inactiveAgent.id });
+    await fastify.db.agentRepository.delete({ id: unclaimedAgent.id });
     await fastify.db.userRepository.delete({ id: registrantUser.id });
     await fastify.db.personRepository.delete({ id: registrantPerson.id });
     await fastify.close();
+  });
+
+  it("400s with no token", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/agent/register/search?street=${encodeURIComponent("Findable")}`,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("401s with an invalid token", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/agent/register/search?token=not-a-real-token&street=${encodeURIComponent("Findable")}`,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns an empty match list without querying when street is under 3 characters", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/agent/register/search?token=${token}&street=ab`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toEqual([]);
+  });
+
+  it("excludes an unclaimed agent from the candidates", async () => {
+    const res = await fastify.inject({
+      method: "GET",
+      url: `/agent/register/search?token=${token}&street=${encodeURIComponent("Findable")}`,
+    });
+
+    const ids = res.json().data.map((a: { id: number }) => a.id);
+    expect(ids).not.toContain(unclaimedAgent.id);
   });
 
   it("excludes an INACTIVE agent from the candidates but keeps an ACTIVE one", async () => {

--- a/src/test/server/routes/agent-register.routes.test.ts
+++ b/src/test/server/routes/agent-register.routes.test.ts
@@ -1,0 +1,305 @@
+import { FastifyInstance } from "fastify";
+import {
+  AgentEngagementStatusType,
+  AgentMembershipStatus,
+  UserRole,
+} from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Agent from "../../../data/entity/opportunity/agent.entity";
+import Person from "../../../data/entity/person.entity";
+import TrustedDomain from "../../../data/entity/trusted-domain.entity";
+import User from "../../../data/entity/user.entity";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+// be#652: POST /agent/register had zero route-level coverage — only the
+// write-helper unit tests and the /search picker's INACTIVE-exclusion case
+// (be#885) existed. This exercises the route itself: auth via the verify
+// token, the JOIN vs CREATE branches, and the conflict/error paths.
+describe("POST /agent/register", () => {
+  let fastify: FastifyInstance;
+
+  const password = "test_password";
+  const createdUserIds: number[] = [];
+  const createdPersonIds: number[] = [];
+  const createdAgentIds: number[] = [];
+
+  async function makeRegistrant(domain: string): Promise<{
+    person: Person;
+    user: User;
+    token: string;
+  }> {
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const person = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Registrant" }),
+    );
+    createdPersonIds.push(person.id);
+    const user = await fastify.db.userRepository.save(
+      new User({
+        email: `registrant-${suffix}@${domain}`,
+        password: await hashPassword(password),
+        role: UserRole.AGENT,
+        isActive: true,
+        personId: person.id,
+      }),
+    );
+    createdUserIds.push(user.id);
+    const token = fastify.jwt.sign({
+      id: user.id,
+      email: user.email,
+      type: "verify",
+    });
+    return { person, user, token };
+  }
+
+  async function makeAgent(overrides: Partial<Agent> = {}): Promise<Agent> {
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const agent = await fastify.db.agentRepository.save(
+      new Agent({
+        title: `Test Agent ${suffix}`,
+        engagementStatus: AgentEngagementStatusType.ACTIVE,
+        ...overrides,
+      }),
+    );
+    createdAgentIds.push(agent.id);
+    return agent;
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    for (const personId of createdPersonIds) {
+      await fastify.db.agentPersonRepository.delete({ personId });
+    }
+    for (const agentId of createdAgentIds) {
+      await fastify.db.agentRepository.delete({ id: agentId });
+    }
+    for (const userId of createdUserIds) {
+      await fastify.db.userRepository.delete({ id: userId });
+    }
+    for (const personId of createdPersonIds) {
+      await fastify.db.personRepository.delete({ id: personId });
+    }
+    await fastify.close();
+  });
+
+  it("401s with no token", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/agent/register",
+      payload: { agentId: 1 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("401s with an invalid token", async () => {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/agent/register?token=not-a-real-token",
+      payload: { agentId: 1 },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("401s a token whose type isn't 'verify' (e.g. an access token)", async () => {
+    const { user } = await makeRegistrant("test.need4deed.org");
+    const accessToken = fastify.jwt.sign({
+      id: user.id,
+      email: user.email,
+      type: "access",
+    });
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${accessToken}`,
+      payload: { agentId: 1 },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("403s a verify token for a non-AGENT/ADMIN role", async () => {
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const person = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    createdPersonIds.push(person.id);
+    const user = await fastify.db.userRepository.save(
+      new User({
+        email: `volunteer-${suffix}@test.need4deed.org`,
+        password: await hashPassword(password),
+        role: UserRole.VOLUNTEER,
+        isActive: true,
+        personId: person.id,
+      }),
+    );
+    createdUserIds.push(user.id);
+    const token = fastify.jwt.sign({
+      id: user.id,
+      email: user.email,
+      type: "verify",
+    });
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${token}`,
+      payload: { agentId: 1 },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("creates a new agent for the registrant (CREATE branch)", async () => {
+    const { token } = await makeRegistrant("test.need4deed.org");
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${token}`,
+      payload: { agent: { title: `Brand New NGO ${suffix}` } },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.data.membershipStatus).toBe(AgentMembershipStatus.ACTIVE);
+    createdAgentIds.push(body.data.agentId);
+
+    const membership = await fastify.db.agentPersonRepository.findOneBy({
+      agentId: body.data.agentId,
+    });
+    expect(membership).not.toBeNull();
+    expect(membership?.status).toBe(AgentMembershipStatus.ACTIVE);
+  });
+
+  it("joins an existing agent as ACTIVE when the registrant's email domain matches an existing member", async () => {
+    const domain = `matching-${Date.now()}.example.org`;
+    const agent = await makeAgent();
+
+    const existingMemberPerson = await fastify.db.personRepository.save(
+      new Person({
+        firstName: "Existing",
+        lastName: "Member",
+        email: `existing@${domain}`,
+      }),
+    );
+    createdPersonIds.push(existingMemberPerson.id);
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: agent.id,
+        personId: existingMemberPerson.id,
+        status: AgentMembershipStatus.ACTIVE,
+      }),
+    );
+
+    const { token } = await makeRegistrant(domain);
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${token}`,
+      payload: { agentId: agent.id },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.data.agentId).toBe(agent.id);
+    expect(body.data.membershipStatus).toBe(AgentMembershipStatus.ACTIVE);
+  });
+
+  it("joins an existing agent as PENDING when there's no domain match or trust", async () => {
+    const agent = await makeAgent();
+    const { token } = await makeRegistrant(
+      `untrusted-${Date.now()}.example.org`,
+    );
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${token}`,
+      payload: { agentId: agent.id },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.data.membershipStatus).toBe(AgentMembershipStatus.PENDING);
+  });
+
+  it("auto-approves ACTIVE when the registrant's domain is on the trusted allowlist", async () => {
+    const domain = `trusted-${Date.now()}.example.org`;
+    const trusted = await fastify.db.trustedDomainRepository.save(
+      new TrustedDomain({ domain }),
+    );
+
+    try {
+      const agent = await makeAgent();
+      const { token } = await makeRegistrant(domain);
+
+      const res = await fastify.inject({
+        method: "POST",
+        url: `/agent/register?token=${token}`,
+        payload: { agentId: agent.id },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().data.membershipStatus).toBe(
+        AgentMembershipStatus.ACTIVE,
+      );
+    } finally {
+      await fastify.db.trustedDomainRepository.delete({ id: trusted.id });
+    }
+  });
+
+  it("409s creating an agent whose title is already taken", async () => {
+    const existing = await makeAgent();
+    const { token } = await makeRegistrant("test.need4deed.org");
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${token}`,
+      payload: { agent: { title: existing.title } },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().conflict).toBe("title");
+  });
+
+  it("404s joining a nonexistent agent", async () => {
+    const { token } = await makeRegistrant("test.need4deed.org");
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${token}`,
+      payload: { agentId: 999999999 },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects joining an unclaimed agent directly", async () => {
+    const agent = await makeAgent({ unclaimed: true });
+    const { token } = await makeRegistrant("test.need4deed.org");
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${token}`,
+      payload: { agentId: agent.id },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects joining an INACTIVE agent directly", async () => {
+    const agent = await makeAgent({
+      engagementStatus: AgentEngagementStatusType.INACTIVE,
+    });
+    const { token } = await makeRegistrant("test.need4deed.org");
+
+    const res = await fastify.inject({
+      method: "POST",
+      url: `/agent/register?token=${token}`,
+      payload: { agentId: agent.id },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+});


### PR DESCRIPTION
Closes #652.

## Summary
- Adds route-level (real DB, `fastify.inject`) coverage for `POST /agent/register` — both the JOIN and CREATE branches, verify-token auth (missing/invalid/wrong-type/wrong-role), the 409 title conflict, the 404 nonexistent-agent case, and the unclaimed/INACTIVE-agent join rejections.
- Adds full coverage for `/agent/membership` — GET (default/explicit status filter, non-coordinator/unauthenticated rejection), PATCH (status update, 404, non-coordinator), DELETE (removal, 404, non-coordinator).
- Extends the existing `GET /agent/register/search` test file with the auth-failure cases (missing/invalid token), the `street.length < 3` short-circuit, and unclaimed-agent exclusion — it previously only covered the INACTIVE-agent case (be#885).

Only touches `src/test/`; no route/schema/entity changes.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] New/extended test files pass in isolation (28 tests)
- [x] Full `yarn test:run` passes (91 files, 776 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)