### PR TITLE
feat: scope GET /opportunity to an AGENT caller's own agents

### DIFF
--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -264,6 +264,8 @@ export default async function opportunityRoutes(
             : undefined;
 
       const where = getOpportunityWhere(request.query.filter, request.query);
+      const message = `Opportunities page:${request.query.page}.`;
+
       //  NGOs see only their own agent's opportunities
       if (request.authUser?.role === UserRole.AGENT) {
         const agentIds = await getCallerAgentIds(
@@ -275,7 +277,7 @@ export default async function opportunityRoutes(
         // skipping the filter, which would show everything.
         if (agentIds.length === 0) {
           return reply.status(200).send({
-            message: `Opportunities page:${request.query.page}.`,
+            message,
             data: [],
             count: 0,
           });
@@ -373,7 +375,7 @@ export default async function opportunityRoutes(
 
       // DTO (dtoOpportunityGetList) runs in the preSerialization hook after PII masking.
       return reply.status(200).send({
-        message: `Opportunities page:${request.query.page}.`,
+        message,
         data: opportunitiesCategoryDistrict,
         count,
       });

--- a/src/server/routes/opportunity/opportunity.routes.ts
+++ b/src/server/routes/opportunity/opportunity.routes.ts
@@ -13,6 +13,7 @@ import {
   SortOrder,
   UserRole,
 } from "need4deed-sdk";
+import { FindOptionsWhere, In } from "typeorm";
 import {
   BadRequestError,
   NotFoundError,
@@ -61,6 +62,7 @@ import {
 import {
   addAgentTypeServiceTranslations,
   addComments2Entity,
+  getCallerAgentIds,
   getCategoryToDealHandler,
   getDistrictToAgentHandler,
   getDistrictToOpportunityHandler,
@@ -262,6 +264,28 @@ export default async function opportunityRoutes(
             : undefined;
 
       const where = getOpportunityWhere(request.query.filter, request.query);
+      //  NGOs see only their own agent's opportunities
+      if (request.authUser?.role === UserRole.AGENT) {
+        const agentIds = await getCallerAgentIds(
+          fastify,
+          request.authUser.personId,
+        );
+
+        // An agent with no shelter must see nothing, so return here rather than
+        // skipping the filter, which would show everything.
+        if (agentIds.length === 0) {
+          return reply.status(200).send({
+            message: `Opportunities page:${request.query.page}.`,
+            data: [],
+            count: 0,
+          });
+        }
+        // Spread so this composes if getOpportunityWhere ever sets an agent filter;
+        where.agent = {
+          ...(where.agent as FindOptionsWhere<Agent> | undefined),
+          id: In(agentIds),
+        };
+      }
 
       logger.debug(
         `GET /opportunities called. options: ${JSON.stringify({ where })}`,

--- a/src/server/utils/data/get-caller-agent-ids.ts
+++ b/src/server/utils/data/get-caller-agent-ids.ts
@@ -1,0 +1,17 @@
+import { FastifyInstance } from "fastify";
+import { AgentMembershipStatus } from "need4deed-sdk";
+
+export async function getCallerAgentIds(
+  fastify: FastifyInstance,
+  personId: number | null | undefined,
+): Promise<number[]> {
+  if (!personId) {
+    return [];
+  }
+
+  const memberships = await fastify.db.agentPersonRepository.find({
+    where: { personId, status: AgentMembershipStatus.ACTIVE },
+  });
+
+  return [...new Set(memberships.map((m) => m.agentId))];
+}

--- a/src/server/utils/data/index.ts
+++ b/src/server/utils/data/index.ts
@@ -8,6 +8,7 @@ export * from "./create-agent-contact";
 export * from "./for-routes";
 export * from "./get-agent-by-postcode";
 export * from "./get-agent-where";
+export * from "./get-caller-agent-ids";
 export * from "./get-language-title";
 export * from "./get-opportunity-orphanage-agent";
 export * from "./get-opportunity-where";

--- a/src/test/server/routes/opportunity-agent-scope.routes.test.ts
+++ b/src/test/server/routes/opportunity-agent-scope.routes.test.ts
@@ -1,0 +1,176 @@
+import { FastifyInstance } from "fastify";
+import { AgentMembershipStatus, AgentRoleType, UserRole } from "need4deed-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import AgentPerson from "../../../data/entity/m2m/agent-person";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+// GET /opportunity returns every agent's opportunities to everyone.
+// AGENT caller must only receive their own agent's, resolved from the
+// authenticated caller rather than anything the request supplies.
+const PASSWORD = "test_password";
+
+describe("GET /opportunity is scoped to an AGENT caller's own agent(s)", () => {
+  let fastify: FastifyInstance;
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const coordinatorEmail = `coordinator-${suffix}@test.need4deed.org`;
+  const agentEmail = `agentrole-${suffix}@test.need4deed.org`;
+
+  let coordinatorCookie: string;
+  let agentCookie: string;
+  let personId: number;
+
+  // Chosen from seeded data
+  let ownAgentId: number;
+  let otherAgentId: number;
+  let ownAgentOpportunityCount: number;
+  let totalOpportunityCount: number;
+
+  async function login(email: string): Promise<string> {
+    const res = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email, password: PASSWORD },
+    });
+    return res.cookies.find((cookie) => cookie.name === accessCookieName)!
+      .value;
+  }
+
+  async function listOpportunities(cookie: string, query = "") {
+    return fastify.inject({
+      method: "GET",
+      url: `/opportunity/?limit=120${query}`,
+      cookies: { [accessCookieName]: cookie },
+    });
+  }
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    await fastify.db.userRepository.save(
+      new User({
+        email: coordinatorEmail,
+        password: await hashPassword(PASSWORD),
+        role: UserRole.COORDINATOR,
+        isActive: true,
+      }),
+    );
+    coordinatorCookie = await login(coordinatorEmail);
+
+    const person = await fastify.db.personRepository.save(
+      new Person({ firstName: "Scope", lastName: `Test-${suffix}` }),
+    );
+    personId = person.id;
+
+    await fastify.db.userRepository.save(
+      new User({
+        email: agentEmail,
+        password: await hashPassword(PASSWORD),
+        role: UserRole.AGENT,
+        isActive: true,
+        personId,
+      }),
+    );
+    agentCookie = await login(agentEmail);
+
+    // Pick an agent that actually owns opportunities, and a different one that
+    // also does, otherwise test 3 can't tell "scoped" from "empty".
+    const owned = await fastify.db.opportunityRepository
+      .createQueryBuilder("opportunity")
+      .select("opportunity.agent_id", "agentId")
+      .addSelect("COUNT(*)", "count")
+      .where("opportunity.agent_id IS NOT NULL")
+      .groupBy("opportunity.agent_id")
+      .orderBy("COUNT(*)", "DESC")
+      .getRawMany<{ agentId: number; count: string }>();
+
+    ownAgentId = Number(owned[0].agentId);
+    otherAgentId = Number(owned[1].agentId);
+    ownAgentOpportunityCount = Number(owned[0].count);
+    totalOpportunityCount = await fastify.db.opportunityRepository.count();
+
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: ownAgentId,
+        personId,
+        role: AgentRoleType.SOCIAL_WORKER,
+        status: AgentMembershipStatus.ACTIVE,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await fastify.db.agentPersonRepository.delete({ personId });
+    await fastify.db.userRepository.delete({ personId });
+    await fastify.db.personRepository.delete({ id: personId });
+    await fastify.db.userRepository.delete({ email: coordinatorEmail });
+    await fastify.close();
+  });
+
+  it("returns only the caller's own agent's opportunities", async () => {
+    const res = await listOpportunities(agentCookie);
+
+    expect(res.statusCode).toBe(200);
+    const { data, count } = res.json();
+    expect(count).toBe(ownAgentOpportunityCount);
+    expect(data.length).toBeGreaterThan(0);
+    expect(
+      data.every((o: { agentId: number }) => o.agentId === ownAgentId),
+    ).toBe(true);
+  });
+
+  it("leaves a COORDINATOR seeing every agent's opportunities", async () => {
+    const res = await listOpportunities(coordinatorCookie);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().count).toBe(totalOpportunityCount);
+    expect(totalOpportunityCount).toBeGreaterThan(ownAgentOpportunityCount);
+  });
+
+  it("keeps an AGENT scoped to their own agent even when filter[agentId] names another", async () => {
+    const res = await listOpportunities(
+      agentCookie,
+      `&filter[agentId]=${otherAgentId}`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    const { data, count } = res.json();
+    expect(count).toBe(ownAgentOpportunityCount);
+    expect(
+      data.every((o: { agentId: number }) => o.agentId !== otherAgentId),
+    ).toBe(true);
+  });
+
+  it("covers every agent a caller is a member of, not just the first", async () => {
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: otherAgentId,
+        personId,
+        role: AgentRoleType.SOCIAL_WORKER,
+        status: AgentMembershipStatus.ACTIVE,
+      }),
+    );
+
+    const res = await listOpportunities(agentCookie);
+
+    expect(res.statusCode).toBe(200);
+    const agentIds = new Set(
+      res.json().data.map((o: { agentId: number }) => o.agentId),
+    );
+    expect(agentIds.has(ownAgentId)).toBe(true);
+    expect(agentIds.has(otherAgentId)).toBe(true);
+  });
+
+  it("returns an empty list for an AGENT with no membership at all", async () => {
+    await fastify.db.agentPersonRepository.delete({ personId });
+
+    const res = await listOpportunities(agentCookie);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ data: [], count: 0 });
+  });
+});

--- a/src/test/server/routes/opportunity-agent-scope.routes.test.ts
+++ b/src/test/server/routes/opportunity-agent-scope.routes.test.ts
@@ -173,4 +173,21 @@ describe("GET /opportunity is scoped to an AGENT caller's own agent(s)", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ data: [], count: 0 });
   });
+
+  it("ignores a PENDING membership", async () => {
+    await fastify.db.agentPersonRepository.delete({ personId });
+    await fastify.db.agentPersonRepository.save(
+      new AgentPerson({
+        agentId: ownAgentId,
+        personId,
+        role: AgentRoleType.SOCIAL_WORKER,
+        status: AgentMembershipStatus.PENDING,
+      }),
+    );
+
+    const res = await listOpportunities(agentCookie);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ data: [], count: 0 });
+  });
 });


### PR DESCRIPTION
## Description
fe [934](https://github.com/need4deed-org/fe/issues/934) asks that NGO users only see opportunities belonging to their own organisation. Today `GET /opportunity` applies no caller-based scoping at all, so an NGO user sees every organisation's.

The issue says both "their own operator (their email domain)" and "for their own shelter", which give different lists. Nadav settled it on fe [950](https://github.com/need4deed-org/fe/pull/950): "anyone from the same NGO/agent can see the opportunities there of that NGO/agent". So this scopes by agent. `agent.organization_id` is NULL for every agent on local and dev so that operator scoping would return an empty list for everyone today anyway.

`GET /opportunity` now resolves the caller's agent memberships server-side and restricts the result to those agents when the caller's role is AGENT. Coordinators and admins are unaffected.

Only ACTIVE memberships count. A PENDING membership is one a coordinator has not approved yet, so it grants nothing.

fe [950](https://github.com/need4deed-org/fe/pull/950) is the frontend half and needs this to be safe to ship.


## Related Issues
fe [934](https://github.com/need4deed-org/fe/issues/934)
 fe [950](https://github.com/need4deed-org/fe/pull/950)

## Changes
- `getCallerAgentIds` in `src/server/utils/data/`: a person's ACTIVE agent memberships, deduped
- `GET /opportunity`: when the caller is an AGENT, constrain `where.agent.id`
    to those IDs
- An AGENT with no ACTIVE membership gets an empty list rather than falling
    through to an unfiltered query, so the failure mode is closed, not open
- 6 tests in `src/test/server/routes/opportunity-agent-scope.routes.test.ts`


## Checklist
- [x] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [x] Tests added/updated
- [ ] Documentation updated
- [x] CI passes

