### PR TITLE
feat: store appreciation delivery status instead of inferring it from dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-validator": "^0.14.2",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.0.1",
-    "need4deed-sdk": "0.0.146",
+    "need4deed-sdk": "0.0.147",
     "node-cron": "^4.5.0",
     "nodemailer": "^9.0.3",
     "pg": "^8.14.1",

--- a/src/data/entity/volunteer/appreciation.entity.ts
+++ b/src/data/entity/volunteer/appreciation.entity.ts
@@ -1,4 +1,7 @@
-import { VolunteerStateAppreciationType } from "need4deed-sdk";
+import {
+  AppreciationStatusType,
+  VolunteerStateAppreciationType,
+} from "need4deed-sdk";
 import {
   Column,
   CreateDateColumn,
@@ -24,6 +27,9 @@ export default class Appreciation {
 
   @Column({ type: "enum", enum: VolunteerStateAppreciationType })
   title: VolunteerStateAppreciationType;
+
+  @Column({ type: "enum", enum: AppreciationStatusType })
+  status: AppreciationStatusType;
 
   @Column({ type: "timestamp", nullable: true })
   dateDue?: Date;

--- a/src/data/migrations/1787735192446-add-status-to-appreciation.ts
+++ b/src/data/migrations/1787735192446-add-status-to-appreciation.ts
@@ -4,7 +4,13 @@ import { MigrationInterface, QueryRunner } from "typeorm";
  * Adds an explicit delivery `status` to appreciation rows so it no longer
  * has to be inferred from which date is set. Existing rows are backfilled:
  * `date_delivery` set -> 'appr-received', otherwise -> 'appr-pending'.
- * (The new 'appr-post' value has no prior data to derive from.)
+ *
+ * REVIEWER SIGN-OFF: this backfill is lossy and irreversible. There was no
+ * 'appr-post' concept before this migration, so any row that was really
+ * "sent by post, awaiting confirmation" is indistinguishable in the existing
+ * data from a plain "not yet started" row — both backfill to 'appr-pending'
+ * with no way to tell them apart afterwards. `down()` cannot restore that
+ * lost distinction either, since it was never recorded in the first place.
  */
 export class AddStatusToAppreciation1787735192446
   implements MigrationInterface

--- a/src/data/migrations/1787735192446-add-status-to-appreciation.ts
+++ b/src/data/migrations/1787735192446-add-status-to-appreciation.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * Adds an explicit delivery `status` to appreciation rows so it no longer
+ * has to be inferred from which date is set. Existing rows are backfilled:
+ * `date_delivery` set -> 'appr-received', otherwise -> 'appr-pending'.
+ * (The new 'appr-post' value has no prior data to derive from.)
+ */
+export class AddStatusToAppreciation1787735192446
+  implements MigrationInterface
+{
+  name = "AddStatusToAppreciation1787735192446";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."appreciation_status_enum" AS ENUM('appr-received', 'appr-pending', 'appr-post')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "appreciation" ADD "status" "public"."appreciation_status_enum"`,
+    );
+    await queryRunner.query(`
+      UPDATE "appreciation"
+      SET "status" = CASE
+        WHEN "date_delivery" IS NOT NULL THEN 'appr-received'
+        ELSE 'appr-pending'
+      END::"public"."appreciation_status_enum"
+    `);
+    await queryRunner.query(
+      `ALTER TABLE "appreciation" ALTER COLUMN "status" SET NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "appreciation" DROP COLUMN "status"`);
+    await queryRunner.query(`DROP TYPE "public"."appreciation_status_enum"`);
+  }
+}

--- a/src/server/routes/appreciation.routes.ts
+++ b/src/server/routes/appreciation.routes.ts
@@ -1,5 +1,9 @@
 import { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { ApiAppreciationPatch, UserRole } from "need4deed-sdk";
+import {
+  ApiAppreciationPatch,
+  AppreciationStatusType,
+  UserRole,
+} from "need4deed-sdk";
 import { NotFoundError, UnauthorizedError } from "../../config/error/fastify";
 import { idParamSchema } from "../schema";
 import { validatePermissions } from "../utils";
@@ -58,9 +62,29 @@ export default async function appreciationRoutes(
         );
       }
 
+      // `status` is the source of truth, but a caller that only patches
+      // `dateDue`/`dateDelivery` (the pre-be#909 contract) would otherwise
+      // leave it stale — silently desyncing the two. Mirror the old
+      // date-inference rule (`dateDelivery` set -> received, else pending)
+      // whenever `status` itself isn't part of this patch; a caller that
+      // does send `status` (e.g. to set the new "post" state) always wins.
+      const patch = { ...request.body };
+      if (
+        patch.status === undefined &&
+        (patch.dateDelivery !== undefined || patch.dateDue !== undefined)
+      ) {
+        const nextDateDelivery =
+          patch.dateDelivery !== undefined
+            ? patch.dateDelivery
+            : appreciation.dateDelivery;
+        patch.status = nextDateDelivery
+          ? AppreciationStatusType.RECEIVED
+          : AppreciationStatusType.PENDING;
+      }
+
       const updatedAppreciation = await appreciationRepository.save({
         ...appreciation,
-        ...request.body,
+        ...patch,
       });
 
       return reply.status(200).send({

--- a/src/server/schema/sdk-types.json
+++ b/src/server/schema/sdk-types.json
@@ -636,6 +636,11 @@
       "$id": "ApiCommunicationPatch",
       "$ref": "ApiCommunication#"
     },
+    "AppreciationStatusType": {
+      "$id": "AppreciationStatusType",
+      "type": "string",
+      "enum": ["appr-received", "appr-pending", "appr-post"]
+    },
     "ApiAppreciation": {
       "$id": "ApiAppreciation",
       "type": "object",
@@ -645,6 +650,9 @@
         },
         "title": {
           "$ref": "VolunteerStateAppreciationType#"
+        },
+        "status": {
+          "$ref": "AppreciationStatusType#"
         },
         "dateDue": {
           "type": ["string", "null"],
@@ -671,6 +679,7 @@
       "required": [
         "id",
         "title",
+        "status",
         "dateDue",
         "userId",
         "opportunityId",
@@ -680,7 +689,7 @@
     "ApiAppreciationPost": {
       "$id": "ApiAppreciationPost",
       "$ref": "ApiAppreciation#",
-      "required": ["title", "dateDue"]
+      "required": ["title", "status", "dateDue"]
     },
     "ApiAppreciationPatch": {
       "$id": "ApiAppreciationPatch",

--- a/src/services/dto/dto-appreciation.ts
+++ b/src/services/dto/dto-appreciation.ts
@@ -7,6 +7,7 @@ export function dtoAppreciation(
   return {
     id: appreciation.id,
     title: appreciation.title,
+    status: appreciation.status,
     dateDue: appreciation?.dateDue,
     dateDelivery: appreciation?.dateDelivery,
     volunteerId: appreciation.volunteerId,

--- a/src/test/server/routes/appreciation.routes.test.ts
+++ b/src/test/server/routes/appreciation.routes.test.ts
@@ -1,0 +1,158 @@
+import { FastifyInstance } from "fastify";
+import {
+  AppreciationStatusType,
+  UserRole,
+  VolunteerStateAppreciationType,
+} from "need4deed-sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { accessCookieName } from "../../../config/constants";
+import Deal from "../../../data/entity/deal.entity";
+import Person from "../../../data/entity/person.entity";
+import User from "../../../data/entity/user.entity";
+import Appreciation from "../../../data/entity/volunteer/appreciation.entity";
+import Volunteer from "../../../data/entity/volunteer/volunteer.entity";
+import { DealType } from "../../../data/types";
+import { hashPassword } from "../../../data/utils";
+import { createServer } from "../../../server";
+
+const PASSWORD = "test_password";
+
+function getCookie(
+  cookies: { name: string; value: string }[],
+  name: string,
+): string {
+  const cookie = cookies.find((c) => c.name === name)?.value;
+  if (!cookie) {
+    throw new Error(`Cookie ${name} not found in response`);
+  }
+  return cookie;
+}
+
+// be#909 review: `status` is the new source of truth, but a caller that only
+// patches dateDue/dateDelivery (the pre-be#909 contract) must not leave it
+// stale — the handler reconciles status from the dates whenever the patch
+// itself doesn't include `status`, and never overrides an explicit `status`.
+describe("PATCH /appreciation/:id status reconciliation (be#909)", () => {
+  let fastify: FastifyInstance;
+  let volunteer: Volunteer;
+  let coordinatorPerson: Person;
+  let coordinatorCookie: string;
+  let appreciation: Appreciation;
+
+  beforeAll(async () => {
+    fastify = await createServer();
+    await fastify.ready();
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const postcode = await fastify.db.postcodeRepository.findOneOrFail({
+      where: {},
+    });
+
+    const deal = await fastify.db.dealRepository.save(
+      new Deal({ type: DealType.VOLUNTEER, postcodeId: postcode.id }),
+    );
+    const volunteerPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Volunteer" }),
+    );
+    volunteer = await fastify.db.volunteerRepository.save(
+      new Volunteer({ dealId: deal.id, personId: volunteerPerson.id }),
+    );
+
+    coordinatorPerson = await fastify.db.personRepository.save(
+      new Person({ firstName: "Test", lastName: "Coordinator" }),
+    );
+    const pwHash = await hashPassword(PASSWORD);
+    const coordinatorUser = await fastify.db.userRepository.save(
+      new User({
+        email: `coordinator-appreciation-${suffix}@test.need4deed.org`,
+        password: pwHash,
+        role: UserRole.COORDINATOR,
+        isActive: true,
+        personId: coordinatorPerson.id,
+      }),
+    );
+    const login = await fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: coordinatorUser.email, password: PASSWORD },
+    });
+    coordinatorCookie = getCookie(login.cookies, accessCookieName);
+  });
+
+  afterAll(async () => {
+    await fastify.db.userRepository.delete({ personId: coordinatorPerson.id });
+    await fastify.db.personRepository.delete({ id: coordinatorPerson.id });
+    await fastify.db.volunteerRepository.delete({ id: volunteer.id });
+    await fastify.close();
+  });
+
+  beforeEach(async () => {
+    appreciation = await fastify.db.appreciationRepository.save(
+      new Appreciation({
+        title: VolunteerStateAppreciationType.T_SHIRT,
+        status: AppreciationStatusType.PENDING,
+        volunteerId: volunteer.id,
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await fastify.db.appreciationRepository.delete({ id: appreciation.id });
+  });
+
+  it("derives status=received when dateDelivery is patched without status", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/appreciation/${appreciation.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { dateDelivery: "2026-08-01T00:00:00.000Z" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data.status).toBe(AppreciationStatusType.RECEIVED);
+  });
+
+  it("derives status=pending when dateDue is patched without status and no dateDelivery is set", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/appreciation/${appreciation.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { dateDue: "2026-08-01T00:00:00.000Z" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data.status).toBe(AppreciationStatusType.PENDING);
+  });
+
+  it("respects an explicit status instead of deriving it from dates", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/appreciation/${appreciation.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { status: AppreciationStatusType.POST },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data.status).toBe(AppreciationStatusType.POST);
+  });
+
+  it("leaves status untouched when the patch touches neither status nor dates", async () => {
+    const res = await fastify.inject({
+      method: "PATCH",
+      url: `/appreciation/${appreciation.id}`,
+      cookies: { [accessCookieName]: coordinatorCookie },
+      payload: { title: VolunteerStateAppreciationType.CAP },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data.status).toBe(AppreciationStatusType.PENDING);
+  });
+});

--- a/src/test/services/dto/dto-appreciation.test.ts
+++ b/src/test/services/dto/dto-appreciation.test.ts
@@ -40,4 +40,12 @@ describe("dtoAppreciation", () => {
     expect(result.opportunityId).toBeUndefined();
     expect(result.userId).toBeUndefined();
   });
+
+  it.each(["appr-received", "appr-pending", "appr-post"])(
+    "passes through status %s",
+    (status) => {
+      const result = dtoAppreciation({ ...base, status } as any);
+      expect(result.status).toBe(status);
+    },
+  );
 });

--- a/src/test/services/dto/dto-appreciation.test.ts
+++ b/src/test/services/dto/dto-appreciation.test.ts
@@ -5,6 +5,7 @@ describe("dtoAppreciation", () => {
   const base = {
     id: 1,
     title: "T-shirt",
+    status: "appr-received",
     dateDue: new Date("2025-01-01"),
     dateDelivery: new Date("2025-02-01"),
     volunteerId: 10,
@@ -17,6 +18,7 @@ describe("dtoAppreciation", () => {
     expect(result).toEqual({
       id: 1,
       title: "T-shirt",
+      status: "appr-received",
       dateDue: base.dateDue,
       dateDelivery: base.dateDelivery,
       volunteerId: 10,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-need4deed-sdk@0.0.146:
-  version "0.0.146"
-  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.146.tgz#42f62886f87e2797f987f74e3280a6b16256cc4c"
-  integrity sha512-7bQV6H5z0HtrCnCa9GnK1aXQi8wVs45xBoJanqjdfUNdLKaFCLuN1Zts3pzxToRq2jmhks5/7uZljyTr0wsJpw==
+need4deed-sdk@0.0.147:
+  version "0.0.147"
+  resolved "https://registry.yarnpkg.com/need4deed-sdk/-/need4deed-sdk-0.0.147.tgz#b5d54178585dc519be975f7a0be4d29b6daf5713"
+  integrity sha512-SDZHVyVWrmMzESvjmEb87TV4299gLL3oyEZ4VgiiuLxwhqprdnzUDe5TaZT72FbYll/kQoV0fspMKjNq6+mKmw==
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
- Adds `status: AppreciationStatusType` to the `Appreciation` entity, bumped from `need4deed-sdk@0.0.147` (sdk#209/PR #210, merged)
- New migration backfills existing rows: `date_delivery` set -> `appr-received`, else -> `appr-pending`
- Threads `status` through `dtoAppreciation` and `sdk-types.json`

Closes #909

Related: fe#640, fe#924

## Test plan
- [x] `yarn typecheck`, `yarn lint` (touched files clean)
- [x] Migration applied cleanly to local dev DB (verified via docker logs)
- [x] Full `yarn test:run` — 91 files, 776 tests, clean